### PR TITLE
[lsp] Fix deprecated warnings for JSON.

### DIFF
--- a/lp-lsp/lp_lsp.ml
+++ b/lp-lsp/lp_lsp.ml
@@ -109,7 +109,7 @@ let grab_doc params =
   let start_doc, end_doc = Hashtbl.(find doc_table doc_file, find completed_table doc_file) in
   doc_file, start_doc, end_doc
 
-let mk_syminfo file (name, _path, kind, pos) : J.json =
+let mk_syminfo file (name, _path, kind, pos) : J.t =
   `Assoc [
     "name", `String name;
     "kind", `Int kind;            (* function *)
@@ -192,7 +192,7 @@ let dispatch_message ofmt dict =
   | msg ->
     LIO.log_error "no_handler" msg
 
-let process_input ofmt (com : J.json) =
+let process_input ofmt (com : J.t) =
   try dispatch_message ofmt (U.to_assoc com)
   with
   | U.Type_error (msg, obj) ->

--- a/lp-lsp/lsp_base.ml
+++ b/lp-lsp/lsp_base.ml
@@ -50,7 +50,7 @@ let json_of_thm thm =
     ]
 *)
 
-let mk_range (p : Pos.pos) : J.json =
+let mk_range (p : Pos.pos) : J.t =
   let open Pos in
   let {start_line=line1; start_col=col1; end_line=line2; end_col=col2; _} =
     Lazy.force p
@@ -59,7 +59,7 @@ let mk_range (p : Pos.pos) : J.json =
           "end",   `Assoc ["line", `Int (line2 - 1); "character", `Int col2]]
 
 (* let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (thm : Proofs.theorem option)) : J.json = *)
-let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (_thm : unit option)) : J.json =
+let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (_thm : unit option)) : J.t =
   (* let goal = json_of_thm thm in *)
   let range = mk_range p in
   `Assoc ((* mk_extra ["goal_info", goal] @ *)
@@ -68,7 +68,7 @@ let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (_thm : unit opti
            "message",  `String msg;
           ])
 
-let mk_diagnostics ~uri ~version ld : J.json =
+let mk_diagnostics ~uri ~version ld : J.t =
   let extra = mk_extra ["version", `Int version] in
   mk_event "textDocument/publishDiagnostics" @@
     extra @


### PR DESCRIPTION
This should be backward compatible. Closes #131