### PR TITLE
[lsp] Depend on JSON >= 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ List of dependencies:
  - earley 2.0.0 (https://github.com/rlepigre/ocaml-earley),
  - timed 1.0 (https://github.com/rlepigre/ocaml-timed).
  - menhir
- - yojson
+ - yojson (>= 1.6.0)
  - cmdliner
  - ppx\_inline\_test
 

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -31,7 +31,7 @@ depends: [
   "ppx_inline_test" { with-test }
 
   # lp-lsp dependencies
-  "yojson"
+  "yojson"       { >= "1.6.0" }
   "cmdliner"
 ]
 


### PR DESCRIPTION
Change at #133 didn't fix the issue #131 properly, indeed
https://github.com/ocaml-community/yojson/pull/73 forces us to use
1.6.0.

Closes #131