### PR TITLE
[lsp] Enable goal display on hover.

### DIFF
--- a/lp-lsp/README.md
+++ b/lp-lsp/README.md
@@ -15,8 +15,13 @@ The resulting binary will be in `../_build/install/default/bin/lp-lsp`
 
 ## Using with VSCode
 
+There is an extension for VSCode derived from VSCoq. To install do:
+
+$ cd editors/vscode-lp/
 $ npm install
-$ ln -s `pwd`/vscode-lp/ ~/.vscode/extensions/
+$ ln -s `pwd` ~/.vscode/extensions/
+
+You need a recent enough VSCode (>= 1.31)
 
 ## Using with Emacs
 

--- a/lp-lsp/lp_doc.ml
+++ b/lp-lsp/lp_doc.ml
@@ -13,20 +13,22 @@
 open Core
 module LSP = Lsp_base
 
-type doc_node = {
-  ast  : Syntax.command;
-  exec : bool;
-}
+type doc_node =
+  { ast   : Pure.Command.t
+  ; exec  : bool
+  ; goals : Proof.Goal.t list
+  }
 
 (* Private. A doc is a list of nodes for now. The first element in
    the list is assumed to be the tip of the document. The initial
    document is the empty list.
 *)
-type doc = {
+type t = {
   uri : string;
   version: int;
   text : string;
-  root : Pure.command_state;
+  root  : Pure.command_state;
+  final : Pure.command_state;
   nodes : doc_node list;
 }
 
@@ -51,24 +53,25 @@ let process_proof pstate tacs =
   List.fold_left process_pstep (pstate,[]) tacs
 
 (* XXX: Imperative problem *)
-let process_cmd _file (st,dg) node =
+let process_cmd _file (nodes,st,dg) ast =
   let open Pure in
   (* let open Timed in *)
   (* XXX: Capture output *)
   (* Console.out_fmt := lp_fmt;
    * Console.err_fmt := lp_fmt; *)
-  let cmd_loc = Command.get_pos node in
-  match handle_command st node with
+  let cmd_loc = Command.get_pos ast in
+  match handle_command st ast with
   | Cmd_OK st ->
+    let nodes = { ast; exec = true; goals = [] } :: nodes in
     let ok_diag = cmd_loc, 4, "OK", None in
-    st, ok_diag :: dg
+    nodes, st, ok_diag :: dg
 
   | Cmd_Proof (pst, tlist, thm_loc, qed_loc) ->
     let pst, dg_proof = process_proof pst tlist in
-    let dg_proof =
-      let goals = Some (current_goals pst) in
-      (thm_loc, 4, "OK", goals) :: dg_proof
-    in
+    let goals = current_goals pst in
+    let dg_proof = (cmd_loc, 4, "OKK", Some goals) :: dg_proof in
+    let dg_proof = (thm_loc, 4, "OK", Some goals) :: dg_proof in
+    let nodes = { ast; exec = true; goals } :: nodes in
     let st, dg_proof =
       match end_proof pst with
       | Cmd_OK st          ->
@@ -81,17 +84,20 @@ let process_cmd _file (st,dg) node =
         Lsp_io.log_error "process_cmd" "closing proof is nested";
         assert false
     in
-    st, dg_proof @ dg
+    nodes, st, dg_proof @ dg
 
   | Cmd_Error(loc, msg) ->
-    let loc = option_default loc Command.(get_pos node) in
-    st, (loc, 1, msg, None) :: dg
+    let nodes = { ast; exec = false; goals = [] } :: nodes in
+    let loc = option_default loc Command.(get_pos ast) in
+    nodes, st, (loc, 1, msg, None) :: dg
 
 let new_doc ~uri ~version ~text =
+  let root = Pure.initial_state [uri] in
   { uri;
     text;
     version;
-    root = Pure.initial_state [uri];
+    root;
+    final = root;
     nodes = [];
   }
 
@@ -111,12 +117,16 @@ let check_text ~doc =
   let uri, version = doc.uri, doc.version in
   try
     let doc_spans = Pure.parse_text uri doc.text in
-    let st, diag = List.fold_left (process_cmd uri) (doc.root,[]) doc_spans in
-    st, LSP.mk_diagnostics ~uri ~version @@ List.fold_left (fun acc (pos,lvl,msg,goal) ->
+    (* let doc = { doc with nodes = List.map doc_spans } in *)
+    let nodes, final, diag = List.fold_left (process_cmd uri) ([],doc.root,[]) doc_spans in
+    let doc = { doc with nodes; final } in
+    doc,
+    LSP.mk_diagnostics ~uri ~version @@
+    List.fold_left (fun acc (pos,lvl,msg,goal) ->
         match pos with
         | None     -> acc
         | Some pos -> (pos,lvl,msg,goal) :: acc
       ) [] diag
   with
   | Pure.Parse_error(loc, msg) ->
-    doc.root, mk_error ~doc loc msg
+    doc, mk_error ~doc loc msg

--- a/lp-lsp/lp_lsp.ml
+++ b/lp-lsp/lp_lsp.ml
@@ -25,6 +25,12 @@ end
 module List = struct
   include List
   let assoc_opt n d = try Some List.(assoc n d) with | Not_found -> None
+  let find_opt f l = try Some List.(find f l) with | Not_found -> None
+end
+
+module Option = struct
+  let iter f x = match x with | None -> () | Some x -> f x
+  let map f x = match x with | None -> None | Some x -> Some (f x)
 end
 
 let    int_field name dict = U.to_int    List.(assoc name dict)
@@ -50,7 +56,7 @@ let do_initialize ofmt ~id _params =
        `Assoc [
           "textDocumentSync", `Int 1
         ; "documentSymbolProvider", `Bool true
-        ; "hoverProvider", `Bool false
+        ; "hoverProvider", `Bool true
         ; "codeActionProvider", `Bool false
         ]]) in
   LIO.send_json ofmt msg
@@ -60,12 +66,13 @@ let do_shutdown ofmt ~id =
   LIO.send_json ofmt msg
 
 let doc_table : (string, _) Hashtbl.t = Hashtbl.create 39
-let completed_table : (string, Pure.command_state) Hashtbl.t = Hashtbl.create 39
+let completed_table : (string, Lp_doc.t) Hashtbl.t = Hashtbl.create 39
 
 (* Notification handling; reply is optional / asynchronous *)
 let do_check_text ofmt ~doc =
-  let final_st, diags = Lp_doc.check_text ~doc in
-  Hashtbl.replace completed_table doc.uri final_st;
+  let doc, diags = Lp_doc.check_text ~doc in
+  Hashtbl.replace doc_table doc.uri doc;
+  Hashtbl.replace completed_table doc.uri doc;
   LIO.send_json ofmt @@ diags
 
 let do_change ofmt ~doc change =
@@ -132,8 +139,8 @@ let kind_of_type tm =
     12                         (* Function *)
 
 let do_symbols ofmt ~id params =
-  let file, _, final_st = grab_doc params in
-  let sym = Pure.get_symbols final_st in
+  let file, _, doc = grab_doc params in
+  let sym = Pure.get_symbols doc.final in
   let sym = Extra.StrMap.fold (fun _ (s,p) l ->
       let open Terms in
       (* LIO.log_error "sym" (s.sym_name ^ " | " ^ Format.asprintf "%a" pp_term !(s.sym_type)); *)
@@ -149,11 +156,35 @@ let get_docTextPosition params =
   let line, character = int_field "line" pos, int_field "character" pos in
   file, line, character
 
+let in_range ?loc (line, pos) =
+  match loc with
+  | None -> false
+  | Some loc ->
+    let { Pos.start_line ; start_col ; end_line ; end_col ; _ } = Lazy.force loc in
+    start_line - 1 < line && line < end_line - 1 ||
+    (start_line - 1 = line && start_col <= pos) ||
+    (end_line - 1 = line && pos <= end_col)
+
+let get_goals ~doc ~line ~pos =
+  let open Lp_doc in
+  let node =
+    List.find_opt (fun { ast; _ } ->
+        let loc = Pure.Command.get_pos ast in
+        let res = in_range ?loc (line,pos) in
+                let ls = Format.asprintf "%B l:%d p:%d / %a " res line pos Pos.print loc in
+        LIO.log_error "get_goals" ("call: "^ls);
+        res
+      ) doc.Lp_doc.nodes in
+  Option.map
+    (fun node -> Format.asprintf "%a" Proof.pp_goals node.goals) node
+
 let do_hover ofmt ~id params =
-  let _ = get_docTextPosition params in
-  let result = `Assoc [ "contents", `String "hover XXX"] in
-  let msg = LSP.mk_reply ~id ~result in
-  LIO.send_json ofmt msg
+  let uri, line, pos = get_docTextPosition params in
+  let doc = Hashtbl.find completed_table uri in
+  get_goals ~doc ~line ~pos |> Option.iter (fun goals ->
+      let result = `Assoc [ "contents", `String goals] in
+      let msg = LSP.mk_reply ~id ~result in
+      LIO.send_json ofmt msg)
 
 let protect_dispatch p f x =
   try f x

--- a/src/proof.ml
+++ b/src/proof.ml
@@ -80,33 +80,35 @@ let init : builtins -> Pos.strloc -> term -> t = fun proof_builtins name a ->
 (** [finished ps] tells whether the proof represented by [ps] is finished. *)
 let finished : t -> bool = fun ps -> ps.proof_goals = []
 
+(** [pp_goals oc gl] prints the goal list [gl] to channel [oc]. *)
+let pp_goals : _ pp = fun oc gl ->
+  let open Print in
+  match gl with
+  | []    -> Format.fprintf oc " No more goals...\n"
+  | g::gs ->
+    let (hyps, a) = Goal.get_type g in
+    let print_hyp (s,(_,t)) =
+      Format.fprintf oc "  %s : %a\n" s pp (Bindlib.unbox t)
+    in
+    List.iter print_hyp hyps;
+    Format.fprintf oc " ----------------------------------------\n";
+    Format.fprintf oc "  %a\n" pp a;
+    if gs <> [] then
+      begin
+        let g_meta = Goal.get_meta g in
+        let (_, g_type) = Goal.get_type g in
+        Format.fprintf oc "\n";
+        Format.fprintf oc " >0< %a : %a\n" pp_meta g_meta pp g_type;
+        let print_goal i g =
+          let m = Goal.get_meta g in
+          let (_, a) = Goal.get_type g in
+          Format.fprintf oc " (%i) %a : %a\n" (i+1) pp_meta m pp a
+        in
+        List.iteri print_goal gs
+      end
+
 (** [pp oc ps] prints the proof state [ps] to channel [oc]. *)
 let pp : t pp = fun oc ps ->
   Format.fprintf oc "== Current theorem ======================\n";
-  let open Print in
-  begin
-    match ps.proof_goals with
-    | []    -> Format.fprintf oc " No more goals...\n"
-    | g::gs ->
-        let (hyps, a) = Goal.get_type g in
-        let print_hyp (s,(_,t)) =
-          Format.fprintf oc "  %s : %a\n" s pp (Bindlib.unbox t)
-        in
-        List.iter print_hyp hyps;
-        Format.fprintf oc " ----------------------------------------\n";
-        Format.fprintf oc "  %a\n" pp a;
-        if gs <> [] then
-          begin
-            let g_meta = Goal.get_meta g in
-            let (_, g_type) = Goal.get_type g in
-            Format.fprintf oc "\n";
-            Format.fprintf oc " >0< %a : %a\n" pp_meta g_meta pp g_type;
-            let print_goal i g =
-              let m = Goal.get_meta g in
-              let (_, a) = Goal.get_type g in
-              Format.fprintf oc " (%i) %a : %a\n" (i+1) pp_meta m pp a
-            in
-            List.iteri print_goal gs
-          end
-  end;
+  pp_goals oc ps.proof_goals;
   Format.fprintf oc "==========================================\n"


### PR DESCRIPTION
This provides goal display on hover which while not perfect allows one
to complete a proof.

Note the VSCode interprets the goal display as markdown so we want to
add a different printing mode for improved readability.