### PR TITLE
Sanity check in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 
 script:
   - make $TEST_TARGETS
+  - if [[ `make sanity_check` != "" ]]; then echo "Sanity check failed"; exit 1; fi
 
 notifications:
   email:


### PR DESCRIPTION
This line in `.travis.yml` ensures that the `sanity_check` doesn't fail on the PR.
If we want to have an hope to keep following these "sanity" rules, I think it is critical to have a test performed automatically.