### PR TITLE
Allow multiple variables in type annotations.

### DIFF
--- a/src/parser.ml
+++ b/src/parser.ml
@@ -334,11 +334,11 @@ and parser env = "[" t:(term PAppl) ts:{"," (term PAppl)}* "]" -> t::ts
 (** [arg] parses a single function argument. *)
 and parser arg =
   (* Explicit argument without type annotation. *)
-  | x:ident                               -> (x, None,    false)
+  | x:ident                                 -> ([x], None,    false)
   (* Explicit argument with type annotation. *)
-  | "(" x:ident    ":" a:(term PFunc) ")" -> (x, Some(a), false)
+  | "(" xs:ident+    ":" a:(term PFunc) ")" -> (xs , Some(a), false)
   (* Implicit argument (with possible type annotation). *)
-  | "{" x:ident a:{":" (term PFunc)}? "}" -> (x, a      , true )
+  | "{" xs:ident+ a:{":" (term PFunc)}? "}" -> (xs , a      , true )
 
 let term = term PFunc
 

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -72,12 +72,13 @@ let rec pp_p_term : p_term pp = fun oc t ->
   in
   pp_toplevel oc t
 
-and pp_p_arg : p_arg pp = fun oc (id,ao,b) ->
+and pp_p_arg : p_arg pp = fun oc (ids,ao,b) ->
+  let pp_ids = List.pp (fun oc id -> Format.pp_print_string oc id.elt) " " in
   match (ao,b) with
-  | (None   , false) -> Format.fprintf oc "%s" id.elt
-  | (None   , true ) -> Format.fprintf oc "{%s}" id.elt
-  | (Some(a), false) -> Format.fprintf oc "(%s : %a)" id.elt pp_p_term a
-  | (Some(a), true ) -> Format.fprintf oc "{%s : %a}" id.elt pp_p_term a
+  | (None   , false) -> Format.fprintf oc "%a" pp_ids ids
+  | (None   , true ) -> Format.fprintf oc "{%a}" pp_ids ids
+  | (Some(a), false) -> Format.fprintf oc "(%a : %a)" pp_ids ids pp_p_term a
+  | (Some(a), true ) -> Format.fprintf oc "{%a : %a}" pp_ids ids pp_p_term a
 
 and pp_p_args : p_arg list pp = fun oc ->
   List.iter (Format.fprintf oc " %a" pp_p_arg)

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -200,6 +200,19 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
        let vs = Env.vars_of_env env in
        let m = fresh_meta (prod_of_env env _Type) (Array.length vs) in
        _Meta m vs
+  (* Scoping of a binder (abstraction or product). *)
+  and scope_binder cons env xs t =
+    let rec aux env xs =
+      match xs with
+      | []             -> scope env t
+      | ([]  ,_,_)::xs -> aux env xs
+      | (x::l,d,i)::xs ->
+          let v = Bindlib.new_var mkfree x.elt in
+          let a = scope_domain x.pos env d in
+          let t = aux (Env.add x.elt v a env) ((l,d,i)::xs) in
+          cons a (Bindlib.bind_var v t)
+    in
+    aux env xs
   (* Scoping function for head terms. *)
   and scope_head : env -> p_term -> tbox = fun env t ->
     match (t.elt, md) with
@@ -269,34 +282,14 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
     | (P_Impl(_,_)     , M_Patt   ) -> fatal t.pos "Not allowed in a pattern."
     | (P_Impl(a,b)     , _        ) -> _Impl (scope env a) (scope env b)
     | (P_Abst(_,_)     , M_Patt   ) -> fatal t.pos "Not allowed in a pattern."
-    | (P_Abst(xs,t)    , _        ) ->
-        let rec scope_abst env xs =
-          match xs with
-          | []          -> scope env t
-          | (x,a,_)::xs ->
-              let v = Bindlib.new_var mkfree x.elt in
-              let a = scope_domain x.pos env a in
-              let t = scope_abst (Env.add x.elt v a env) xs in
-              _Abst a (Bindlib.bind_var v t)
-        in
-        assert (xs <> []); scope_abst env xs
+    | (P_Abst(xs,t)    , _        ) -> scope_binder _Abst env xs t
     | (P_Prod(_,_)     , M_LHS(_) ) -> fatal t.pos "Not allowed in a LHS."
     | (P_Prod(_,_)     , M_Patt   ) -> fatal t.pos "Not allowed in a pattern."
-    | (P_Prod(xs,b)    , _        ) ->
-        let rec scope_prod env xs =
-          match xs with
-          | []          -> scope env b
-          | (x,a,_)::xs ->
-              let v = Bindlib.new_var mkfree x.elt in
-              let a = scope_domain x.pos env a in
-              let b = scope_prod (Env.add x.elt v a env) xs in
-              _Prod a (Bindlib.bind_var v b)
-        in
-        assert (xs <> []); scope_prod env xs
+    | (P_Prod(xs,b)    , _        ) -> scope_binder _Prod env xs b
     | (P_LLet(x,xs,t,u), M_Term(_)) ->
         (* “let x = t in u” is desugared as “(λx.u) t” (for now). *)
         let t = scope env (if xs = [] then t else Pos.none (P_Abst(xs,t))) in
-        _Appl (scope env (Pos.none (P_Abst([(x,None,false)], u)))) t
+        _Appl (scope env (Pos.none (P_Abst([([x],None,false)], u)))) t
     | (P_LLet(_,_,_,_) , _        ) -> fatal t.pos "Only allowed in terms."
     | (P_NLit(n)       , _        ) ->
         let sym_z = get_builtin t.pos ss "0"  in

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -66,7 +66,7 @@ and p_patt = p_term
 
 (** Parser-level representation of a function argument. The boolean is true if
     the argument is marked as implicit (i.e., between curly braces). *)
-and p_arg = ident * p_type option * bool
+and p_arg = ident list * p_type option * bool
 
 (** Representation of a symbol tag. *)
 type symtag =
@@ -210,7 +210,8 @@ let rec eq_p_term : p_term eq = fun t1 t2 ->
       t1 = t2
 
 and eq_p_arg : p_arg eq = fun (x1,ao1,b1) (x2,ao2,b2) ->
-  x1.elt = x2.elt && Option.equal eq_p_term ao1 ao2 && b1 = b2
+  List.equal (fun x1 x2 -> x1.elt = x2.elt) x1 x2
+  && Option.equal eq_p_term ao1 ao2 && b1 = b2
 
 let eq_p_rule : p_rule eq = fun r1 r2 ->
   let {elt = (lhs1, rhs1); _} = r1 in

--- a/src/tactics.ml
+++ b/src/tactics.ml
@@ -76,8 +76,7 @@ let handle_tactic : sig_state -> Proof.t -> p_tactic -> Proof.t =
   | P_tac_intro(xs)     ->
       (* Scoping a sequence of abstractions in the goal's environment. *)
       let env, _ = Proof.Goal.get_type g in
-      let xs = List.map (fun x -> (x, None, false)) xs in
-      let t = Pos.none (P_Abst(xs, Pos.none P_Wild)) in
+      let t = Pos.none (P_Abst([(xs,None,false)], Pos.none P_Wild)) in
       let t = scope_basic ss env t in
       (* Refine using the built term. *)
       handle_refine t


### PR DESCRIPTION
Alternative to #190.

The main difference is that we actually reflect the syntax in the parser-level AST, which has several advantages. For instance, `--beautify` would keep the syntax the user used.

I also took this opportunity to factorize some scoping code.