### PR TITLE
Better pretty-printing + boolean flags.

### DIFF
--- a/src/console.ml
+++ b/src/console.ml
@@ -1,6 +1,7 @@
 (** Output and debugging utilities. *)
 
 open Timed
+open Extra
 
 (** Short name for a standard formatter. *)
 type 'a outfmt = ('a, Format.formatter, unit) format
@@ -131,3 +132,20 @@ let out : int -> 'a outfmt -> 'a = fun lvl fmt ->
   let fmt = if !log_enabled then mag fmt else fmt ^^ "%!" in
   if lvl > !verbose then Format.ifprintf Pervasives.(!out_fmt) fmt
   else Format.fprintf Pervasives.(!out_fmt) fmt
+
+(** List of registered boolean flags. *)
+let boolean_flags : bool ref StrMap.t Pervasives.ref =
+  Pervasives.ref StrMap.empty
+
+(** [register_flag id d] registers a new boolean flag named [id], with default
+    value of [d]. Note the the name should not have been used previously. *)
+let register_flag : string -> bool -> bool ref = fun id default ->
+  if StrMap.mem id Pervasives.(!boolean_flags) then
+    invalid_arg "Console.register_flag: already registered";
+  let r = ref default in
+  Pervasives.(boolean_flags := StrMap.add id r !boolean_flags); r
+
+(** [set_flag id b] sets the value of the flag named [id] to be [b], or raises
+    [Not_found] if no flag with this name was registered. *)
+let set_flag : string -> bool -> unit = fun id b ->
+  StrMap.find id Pervasives.(!boolean_flags) := b

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -236,6 +236,12 @@ let handle_cmd_aux : sig_state -> command -> sig_state * proof_data option =
         | P_config_verbose(i)     ->
             (* Just update the option, state not modified. *)
             Console.verbose := i; ss
+        | P_config_flag(id,b)     ->
+            (* We set the value of the flag, if it exists. *)
+            begin
+              try Console.set_flag id b with Not_found ->
+                wrn cmd.pos "Unknown flag \"%s\"." id
+            end; ss
         | P_config_builtin(s,qid) ->
             (* Set the builtin symbol [s]. *)
             let sym = find_sym false ss qid in

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -393,6 +393,8 @@ let parser config =
       P_config_verbose(i)
   | "debug" b:{'+' -> true | '-' -> false} - s:alpha ->
       P_config_debug(b, s)
+  | "flag" s:string_lit b:{"on" -> true | "off" -> false} ->
+      P_config_flag(s, b)
   | "builtin" s:string_lit "≔" qid:qident ->
       P_config_builtin(s,qid)
   | "infix" a:assoc p:float_lit s:string_lit "≔" qid:qident ->

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -165,6 +165,8 @@ let pp_command : command pp = fun oc cmd ->
       out "set verbose %i" i
   | P_set(P_config_debug(true ,s))  ->
       out "set debug \"+%s\"" s
+  | P_set(P_config_flag(s, b))      ->
+      out "set flag \"%s\" %s" s (if b then "on" else "off")
   | P_set(P_config_debug(false,s))  ->
       out "set debug \"-%s\"" s
   | P_set(P_config_builtin(n,i)  )  ->

--- a/src/print.ml
+++ b/src/print.ml
@@ -5,8 +5,12 @@
     log messages, and feedback in case of success or error while type-checking
     terms or testing convertibility. *)
 
+open Timed
 open Extra
 open Terms
+
+(** Flag controling the printing of the domains of λ-abstractions. *)
+let print_domains : bool ref = Console.register_flag "print_domains" false
 
 (** [pp_symbol h oc s] prints the name of the symbol [s] to channel [oc] using
     the printing hint [h] to decide qualification. *)
@@ -27,43 +31,81 @@ let pp_meta : meta pp = fun oc m ->
 
 (** [pp_term oc t] prints the term [t] to the channel [oc]. *)
 let pp_term : term pp = fun oc t ->
-  let out oc fmt = Format.fprintf oc fmt in
-  (* NOTE we apply the conventions used in [Parser.expr] for priorities. *)
+  let out = Format.fprintf in
   let rec pp (p : [`Func | `Appl | `Atom]) oc t =
-    let pp_func = pp `Func in
-    let pp_appl = pp `Appl in
-    let pp_atom = pp `Atom in
+    match Basics.get_args t with
+    | (Symb(_,Binary(o)), [l;r]) ->
+        if p = `Atom then out oc "(";
+        (* Can be improved by looking at symbol priority. *)
+        out oc "%a %s %a" (pp `Atom) l o (pp `Atom) r;
+        if p = `Atom then out oc ")";
+    | (h                , []   ) ->
+        pp_head (p <> `Func) oc h
+    | (h                , args ) ->
+        if p = `Atom then out oc "(";
+        pp_head true oc h;
+        List.iter (out oc " %a" (pp `Atom)) args;
+        if p = `Atom then out oc ")"
+  and pp_head wrap oc t =
     let pp_env oc ar =
-      if Array.length ar <> 0 then out oc "[%a]" (Array.pp pp_appl ",") ar
+      if ar <> [||] then out oc "[%a]" (Array.pp (pp `Appl) ",") ar
     in
     let pp_term_env oc te =
       match te with
       | TE_Vari(m) -> out oc "%s" (Bindlib.name_of m)
       | _          -> assert false
     in
-    match (unfold t, p) with
+    match unfold t with
+    (* Application is handled separately, unreachable. *)
+    | Appl(_,_)   -> assert false
+    (* Forbidden cases. *)
+    | Wild        -> assert false
+    | TRef(_)     -> assert false
     (* Atoms are printed inconditonally. *)
-    | (Vari(x)    , _    ) -> pp_tvar oc x
-    | (Type       , _    ) -> out oc "TYPE"
-    | (Kind       , _    ) -> out oc "KIND"
-    | (Symb(s,h)  , _    ) -> pp_symbol h oc s
-    | (Meta(m,e)  , _    ) -> out oc "%a%a" pp_meta m pp_env e
-    | (Patt(_,n,e), _    ) -> out oc "&%s%a" n pp_env e
-    | (TEnv(t,e)  , _    ) -> out oc "&%a%a" pp_term_env t pp_env e
-    (* Applications are printed when priority is above [`Appl]. *)
-    | (Appl(t,u)  , `Appl)
-    | (Appl(t,u)  , `Func) -> out oc "%a %a" pp_appl t pp_atom u
-    (* Abstractions and products are only printed at priority [`Func]. *)
-    | (Abst(a,t)  , `Func) ->
+    | Vari(x)     -> pp_tvar oc x
+    | Type        -> out oc "TYPE"
+    | Kind        -> out oc "KIND"
+    | Symb(s,h)   -> pp_symbol h oc s
+    | Meta(m,e)   -> out oc "%a%a" pp_meta m pp_env e
+    | Patt(_,n,e) -> out oc "&%s%a" n pp_env e
+    | TEnv(t,e)   -> out oc "&%a%a" pp_term_env t pp_env e
+    (* Product and abstraction (only them can be wrapped). *)
+    | Abst(a,t)   ->
+        if wrap then out oc "(";
+        let pp_arg oc (x,a) =
+          if !print_domains then out oc "(%a:%a)" pp_tvar x (pp `Func) a
+          else pp_tvar oc x
+        in
         let (x,t) = Bindlib.unbind t in
-        out oc "λ(%a:%a), %a" pp_tvar x pp_func a pp_func t
-    | (Prod(a,b)  , `Func) ->
+        out oc "λ%a" pp_arg (x,a);
+        let rec pp_absts oc t =
+          match unfold t with
+          | Abst(a,t) -> let (x,t) = Bindlib.unbind t in
+                         out oc " %a%a" pp_arg (x,a) pp_absts t
+          | _         -> out oc ", %a" (pp `Func) t
+        in
+        pp_absts oc t;
+        if wrap then out oc ")"
+    | Prod(a,b)   ->
+        if wrap then out oc "(";
+        let pp_arg oc (x,a) = out oc "(%a:%a)" pp_tvar x (pp `Func) a in
         let (x,c) = Bindlib.unbind b in
         if Bindlib.binder_occur b then
-          out oc "∀(%a:%a), %a" pp_tvar x pp_appl a pp_func c
-        else out oc "%a ⇒ %a" pp_appl a pp_func c
-    (* Anything else needs parentheses. *)
-    | (_          , _    ) -> out oc "(%a)" pp_func t
+          begin
+            out oc "∀%a" pp_arg (x,a);
+            let rec pp_prods oc c =
+              match unfold c with
+              | Prod(a,b) when Bindlib.binder_occur b ->
+                  let (x,b) = Bindlib.unbind b in
+                  out oc " %a%a" pp_arg (x,a) pp_prods b
+              | _                                      ->
+                  out oc ", %a" (pp `Func) c
+            in
+            pp_prods oc c
+          end
+        else
+          out oc "%a ⇒ %a" (pp `Appl) a (pp `Func) c;
+        if wrap then out oc ")"
   in
   pp `Func oc (cleanup t)
 

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -133,6 +133,8 @@ type p_config =
   (** Sets the verbosity level. *)
   | P_config_debug   of bool * string
   (** Toggles logging functions described by string according to boolean. *)
+  | P_config_flag    of string * bool
+  (** Sets the boolean flag registered under the given name (if any). *)
   | P_config_builtin of string * qident
   (** Sets the configuration for a builtin syntax (e.g., nat literals). *)
   | P_config_binop   of binop


### PR DESCRIPTION
Several improvements on pretty-printing (not optimal, but already a lot better):
 1) Infix symbols are printed back as infix symbols (note that if you type `add n m` in the code, you will get `add n m`, but you will get `n + m` if you type `n + m`).
 2) the λ-abstractions are factorized, meaning that we always print `λx y z, t` instead of `λx, λy, λz, t`, and similarly for dependent products,
 3) a flag controls the printing (or not) of the domains of λ-abstractions (they are not printed by default).

The latter point is based on a new API in [Console] that allows registering boolean flags. Roughly, you declare a new flag by calling `Console.register_flag key default_value`, which gives you back a reference to a boolean. You can then use this reference in your code to perform actions depending on its value. Then the value of the flag can be changed by a new configuration command of the form `set flag "key" on` / `set flag "key" off` to enable / disable the flag.

To resume the printing of the domains of the λ-abstractions in some file, you thus need to write the following line.
```
set flag "print_domains" on
```

Things that could be improved later:
 - print less parentheses around symbols by taking into account their given associativity and precedence (not completely trivial),
 - ~~add another flag to disable the printing of implicit arguments.~~

Note that this is an alternative to #191 with some additions (contraction of binders, flag mechanism), ~~and some missing pieces (printing of implicits)~~.