### PR TITLE
Conversion modulo eta

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -134,7 +134,7 @@ and eq_modulo : term -> term -> bool = fun a b ->
     | (Abst(_ ,b ), t          )
     | (t          , Abst(_ ,b )) when !eta_equality ->
         let (x,b) = Bindlib.unbind b in
-        eq_modulo ((b,(Appl(t, Vari(x))))::l)
+        eq_modulo ((b,Appl(t, Vari(x)))::l)
     | (Appl(t1,u1), Appl(t2,u2)) -> eq_modulo ((u1,u2)::(t1,t2)::l)
     | (Meta(m1,a1), Meta(m2,a2)) when m1 == m2 ->
         eq_modulo (if a1 == a2 then l else List.add_array2 a1 a2 l)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -33,7 +33,7 @@ let log_conv = new_logger 'c' "conv" "conversion"
 let log_conv = log_conv.logger
 
 (** Convert modulo eta. *)
-let eta_conv : bool Pervasives.ref = Pervasives.ref false
+let eta_equality : bool ref = Console.register_flag "eta_equality" false
 
 (** Counter used to preserve physical equality in {!val:whnf}. *)
 let steps : int Pervasives.ref = Pervasives.ref 0
@@ -132,7 +132,7 @@ and eq_modulo : term -> term -> bool = fun a b ->
         let (_,b1,b2) = Bindlib.unbind2 b1 b2 in
         eq_modulo ((a1,a2)::(b1,b2)::l)
     | (Abst(_ ,b ), t          )
-    | (t          , Abst(_ ,b )) when Pervasives.(! eta_conv) ->
+    | (t          , Abst(_ ,b )) when !eta_equality ->
         let (x,b) = Bindlib.unbind b in
         eq_modulo ((b,(Appl(t, Vari(x))))::l)
     | (Appl(t1,u1), Appl(t2,u2)) -> eq_modulo ((u1,u2)::(t1,t2)::l)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -32,6 +32,9 @@ let log_eval = log_eval.logger
 let log_conv = new_logger 'c' "conv" "conversion"
 let log_conv = log_conv.logger
 
+(** Convert modulo eta. *)
+let eta_conv : bool Pervasives.ref = Pervasives.ref false
+
 (** Counter used to preserve physical equality in {!val:whnf}. *)
 let steps : int Pervasives.ref = Pervasives.ref 0
 
@@ -128,6 +131,10 @@ and eq_modulo : term -> term -> bool = fun a b ->
     | (Abst(a1,b1), Abst(a2,b2)) ->
         let (_,b1,b2) = Bindlib.unbind2 b1 b2 in
         eq_modulo ((a1,a2)::(b1,b2)::l)
+    | (Abst(_ ,b ), t          )
+    | (t          , Abst(_ ,b )) when Pervasives.(! eta_conv) ->
+        let (x,b) = Bindlib.unbind b in
+        eq_modulo ((b,(Appl(t, Vari(x))))::l)
     | (Appl(t1,u1), Appl(t2,u2)) -> eq_modulo ((u1,u2)::(t1,t2)::l)
     | (Meta(m1,a1), Meta(m2,a2)) when m1 == m2 ->
         eq_modulo (if a1 == a2 then l else List.add_array2 a1 a2 l)

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -14,10 +14,10 @@ let constraints = Pervasives.ref []
 
 (** Function adding a constraint. *)
 let conv a b =
-  log_infr "conv [%a] ~ [%a]" pp a pp b;
+  if !log_enabled then log_infr "conv [%a] ~ [%a]" pp a pp b;
   if not (Basics.eq a b) then
     begin
-      log_infr (yel "add [%a] ~ [%a]") pp a pp b;
+      if !log_enabled then log_infr (yel "add [%a] ~ [%a]") pp a pp b;
       let open Pervasives in constraints := (a,b) :: !constraints
     end
 
@@ -38,7 +38,7 @@ let make_meta_codomain : Ctxt.t -> term -> tbinder = fun ctx a ->
    constraints are satisfied. [ctx] must be well-formed. This function
    never fails (but constraints may be unsatisfiable). *)
 let rec infer : Ctxt.t -> term -> term = fun ctx t ->
-  log_infr "infer [%a]" pp t;
+  if !log_enabled then log_infr "infer [%a]" pp t;
   match unfold t with
   | Patt(_,_,_) -> assert false (* Forbidden case. *)
   | TEnv(_,_)   -> assert false (* Forbidden case. *)
@@ -122,7 +122,8 @@ let rec infer : Ctxt.t -> term -> term = fun ctx t ->
      ----------------------------
          ctx ⊢ Meta(m,e) ⇒ a      *)
   | Meta(m,e)   ->
-      log_infr (yel "%s is of type [%a]") (meta_name m) pp !(m.meta_type);
+      if !log_enabled then
+        log_infr (yel "%s is of type [%a]") (meta_name m) pp !(m.meta_type);
       infer ctx (term_of_meta m e)
 
 (** [check ctx t c] checks that the term [t] has type [c] in context
@@ -140,7 +141,7 @@ let rec infer : Ctxt.t -> term -> term = fun ctx t ->
 
    This avoids to build a product to destructure it just after. *)
 and check : Ctxt.t -> term -> term -> unit = fun ctx t c ->
-  log_infr "check [%a] [%a]" pp t pp c;
+  if !log_enabled then log_infr "check [%a] [%a]" pp t pp c;
   match unfold t with
   (*  c → Prod(d,b)    a ~ d    ctx, x : A ⊢ t<x> ⇐ b<x>
       ----------------------------------------------------

--- a/src/lambdapi.ml
+++ b/src/lambdapi.ml
@@ -104,6 +104,9 @@ let spec =
     ; ( "--just-parse"
       , Arg.Unit (fun _ -> mode := JustParse)
       , " Only parse the input files (no type-checking)" )
+    ; ( "--eta-conv"
+      , Arg.Set Eval.eta_conv
+      , " Convert modulo eta" )
     ; ( "--beautify"
       , Arg.Unit (fun _ -> mode := Beautify; set_default_verbose 0)
       , " Parse input files and pretty-print them (in the new syntax)" )

--- a/src/lambdapi.ml
+++ b/src/lambdapi.ml
@@ -104,9 +104,6 @@ let spec =
     ; ( "--just-parse"
       , Arg.Unit (fun _ -> mode := JustParse)
       , " Only parse the input files (no type-checking)" )
-    ; ( "--eta-conv"
-      , Arg.Set Eval.eta_conv
-      , " Convert modulo eta" )
     ; ( "--beautify"
       , Arg.Unit (fun _ -> mode := Beautify; set_default_verbose 0)
       , " Parse input files and pretty-print them (in the new syntax)" )

--- a/src/rewrite.ml
+++ b/src/rewrite.ml
@@ -610,15 +610,18 @@ let rewrite : popt -> Proof.t -> rw_patt option -> term -> term =
   let term = add_args eqind [a; l; r; t; pred; goal_term] in
 
   (* Debugging data to the log. *)
-  log_rewr "Rewriting with:";
-  log_rewr "  goal           = [%a]" pp g_type;
-  log_rewr "  equality proof = [%a]" pp t;
-  log_rewr "  equality type  = [%a]" pp t_type;
-  log_rewr "  equality LHS   = [%a]" pp l;
-  log_rewr "  equality RHS   = [%a]" pp r;
-  log_rewr "  pred           = [%a]" pp pred;
-  log_rewr "  new goal       = [%a]" pp goal_type;
-  log_rewr "  produced term  = [%a]" pp term;
+  if !log_enabled then
+    begin
+      log_rewr "Rewriting with:";
+      log_rewr "  goal           = [%a]" pp g_type;
+      log_rewr "  equality proof = [%a]" pp t;
+      log_rewr "  equality type  = [%a]" pp t_type;
+      log_rewr "  equality LHS   = [%a]" pp l;
+      log_rewr "  equality RHS   = [%a]" pp r;
+      log_rewr "  pred           = [%a]" pp pred;
+      log_rewr "  new goal       = [%a]" pp goal_type;
+      log_rewr "  produced term  = [%a]" pp term;
+    end;
 
   (* Return the proof-term. *)
   term
@@ -663,10 +666,13 @@ let symmetry : popt -> Proof.t -> term = fun pos ps ->
   let term =
     add_args (symb cfg.symb_eqind) [a; r; l; meta_term; pred; refl_a_l] in
   (* Debugging data to the log. *)
-  log_rewr "Symmetry with:";
-  log_rewr "  goal       = [%a]" pp g_type;
-  log_rewr "  new goal   = [%a]" pp meta_type;
-  log_rewr "  predicate  = [%a]" pp pred;
-  log_rewr "  proof term = [%a]" pp term;
+  if !log_enabled then
+    begin
+      log_rewr "Symmetry with:";
+      log_rewr "  goal       = [%a]" pp g_type;
+      log_rewr "  new goal   = [%a]" pp meta_type;
+      log_rewr "  predicate  = [%a]" pp pred;
+      log_rewr "  proof term = [%a]" pp term
+    end;
   (* Return the proof-term. *)
   term

--- a/src/sr.ml
+++ b/src/sr.ml
@@ -7,8 +7,7 @@ open Print
 open Extra
 
 (** Logging function for typing. *)
-let log_subj =
-  new_logger 's' "subj" "subject-reduction"
+let log_subj = new_logger 's' "subj" "subject-reduction"
 let log_subj = log_subj.logger
 
 (** Representation of a substitution. *)

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -200,12 +200,11 @@ and solve_aux : term -> term -> problems -> unif_constrs = fun t1 t2 p ->
   in
 
   (* [inverse_prod s] returns [Some(s0,s1,s2)] if [s] has a rule of the form
-     [s(s0 t0 ...) → ∀x:s1(t1),s2(t2)], and [None] otherwise. *)
+     [s(s0 l1 l2) → ∀x:s1(r1),s2(r2)], and [None] otherwise. *)
   let inverse_prod =
     let exception Found of (sym * sym * sym) in
     fun s ->
     let f rule =
-      log_unif "inverse_prod %a ?" pp_rule (s, Nothing, rule);
       let n = Bindlib.mbinder_arity rule.rhs in
       match Bindlib.msubst rule.rhs (Array.make n TE_None) with
       | Prod (Appl (Symb(s1,_), _), b) ->
@@ -217,11 +216,7 @@ and solve_aux : term -> term -> problems -> unif_constrs = fun t1 t2 p ->
                   | [l1] ->
                       begin
                         match get_args l1 with
-                        | Symb(s0,_),_ ->
-                            log_unif "inverse_prod %a = %a, %a, %a"
-                              pp (symb s) pp (symb s0) pp (symb s1)
-                              pp (symb s2);
-                            raise (Found (s0,s1,s2))
+                        | Symb(s0,_),[_;_] -> raise (Found (s0,s1,s2))
                         | _,_ -> ()
                       end
                   | _ -> ()
@@ -235,7 +230,6 @@ and solve_aux : term -> term -> problems -> unif_constrs = fun t1 t2 p ->
   (* [inverse s v] computes [s^{-1}(v)], that is, a term [u] such that [s(u)]
      reduces to [v], or raises [Unsolvable]. *)
   let rec inverse s v =
-    log_unif "%a^{-1}(%a)" pp (symb s) pp v;
     match get_args (Eval.whnf v) with
     | Symb(s',_), [u] when s' == s -> u
     | Prod(a,b), _ ->

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -218,8 +218,9 @@ and solve_aux : term -> term -> problems -> unif_constrs = fun t1 t2 p ->
                       begin
                         match get_args l1 with
                         | Symb(s0,_),_ ->
-                            log_unif "inverse_prod %a = %a, %a, %a" pp (symb s)
-                              pp (symb s0) pp (symb s1) pp (symb s2);
+                            log_unif "inverse_prod %a = %a, %a, %a"
+                              pp (symb s) pp (symb s0) pp (symb s1)
+                              pp (symb s2);
                             raise (Found (s0,s1,s2))
                         | _,_ -> ()
                       end

--- a/tests/OK/245.lp
+++ b/tests/OK/245.lp
@@ -1,0 +1,24 @@
+symbol const Type : TYPE
+symbol injective eta : Type ⇒ TYPE
+
+// function type
+symbol const Ar : Type ⇒ Type ⇒ Type
+set infix right 6 ">" ≔ Ar
+rule eta (&a > &b) → eta &a ⇒ eta &b
+
+symbol const i : Type
+symbol const o : Type
+
+symbol injective eps : eta o ⇒ TYPE
+
+symbol const imp : eta (o > o > o)
+rule eps (imp &a &b) → eps &a ⇒ eps &b
+set infix right 6 "-->" ≔ imp
+
+symbol const all : ∀ {A : Type}, eta ((A > o) > o)
+rule eps (@all &a &b) → ∀ (x : eta &a), eps (&b x)
+
+// Leibniz equality
+definition eq : ∀ A, eta (A > A > o) ≔ λ A x y, all (λ p, p x --> p y)
+
+//type λ A x y, all (λ p, p x --> p y)

--- a/tests/OK/eta-conv.lp
+++ b/tests/OK/eta-conv.lp
@@ -1,0 +1,6 @@
+symbol const Type : TYPE
+symbol const f : Type ⇒ Type
+symbol const g : (Type ⇒ Type) ⇒ Type
+assert g (λ x, f x) ≡ g f
+assert (λ x, f x) ≡ f
+assert f ≡ (λ x, f x)

--- a/tests/OK/eta_equality.lp
+++ b/tests/OK/eta_equality.lp
@@ -1,3 +1,5 @@
+set flag "eta_equality" on
+
 symbol const Type : TYPE
 symbol const f : Type ⇒ Type
 symbol const g : (Type ⇒ Type) ⇒ Type


### PR DESCRIPTION
To quote Makarius Wenzel:

> Isabelle proof terms are always understood modulo beta-eta.

This commit adds an option to Lambdapi allowing typechecking modulo eta, thus allowing checking of Isabelle proof terms.