### PR TITLE
Fixing the behavior of wildcards + unused warning cleanup.

### DIFF
--- a/doc/sections/commands.md
+++ b/doc/sections/commands.md
@@ -153,6 +153,10 @@ rule diff (λx, sin &F[x]) → λx, diff (λx, &F[x]) x × cos &F[x]
 rule lam (λx, app &F x) → &F // η-reduction
 ```
 
+It is possible to define an unnamed pattern variable with the syntax `&_[x,y]`
+(it matches any term with at most `x` and `y` as its free variables). If `x`
+and `y` are the only variables in scope, then `_` is equivalent to `&_[x,y]`.
+
 In left-hand side, λ-expressions must have no type annotations.
 
 Pattern variables can be applied to distinct bound variables only,

--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -83,7 +83,7 @@ reserved "why3"
   | "@"? <qident>
   | "_"
   | "?" - <ident> {"[" <term> {"," <term>}* "]"}?
-  | "&" - <ident> {"[" <term> {"," <term>}* "]"}?
+  | "&" - {<ident> | "_"} {"[" <term> {"," <term>}* "]"}?
   | "(" <term> ")"
   | "{" <term> "}"
   | <term> <term>

--- a/src/menhir_parser.mly
+++ b/src/menhir_parser.mly
@@ -112,7 +112,7 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
           (* No η-expansion required (enough arguments). *)
           let (lts1, lts2) = List.cut lts max in
           let ts1 = Array.of_list (List.map snd lts1) in
-          let patt = Pos.make p (P_Patt(Pos.make h.pos x, ts1)) in
+          let patt = Pos.make p (P_Patt(Some(Pos.make h.pos x), ts1)) in
           add_args patt lts2
         else
           (* We need to η-expense (not enough arguments). *)
@@ -133,7 +133,7 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
           (* Build the pattern. *)
           let fn x = Pos.none (P_Iden(Pos.none ([],x), false)) in
           let args = Array.append ts (Array.map fn vars) in
-          let patt = Pos.make p (P_Patt(Pos.make h.pos x, args)) in
+          let patt = Pos.make p (P_Patt(Some(Pos.make h.pos x), args)) in
           (* Build the abstraction. *)
           let xs = Array.map (fun x -> Some(Pos.none x)) vars in
           Pos.make p (P_Abst([Array.to_list xs, None, false], patt))

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -303,15 +303,17 @@ let parser arg_ident =
 
 (** Metavariable identifier (regular or escaped, prefixed with ['?']). *)
 let parser meta =
-  | "?" - id:{regular_ident | escaped_ident} -> in_pos _loc id
+  | "?" - id:{regular_ident | escaped_ident} ->
+      if id = "_" then Earley.give_up (); in_pos _loc id
 
 (** Pattern variable identifier (regular or escaped, prefixed with ['&']). *)
 let parser patt =
-  | "&" - id:{regular_ident | escaped_ident} -> in_pos _loc id
+  | "&" - id:{regular_ident | escaped_ident} ->
+      if id = "_" then None else Some(in_pos _loc id)
 
 (** Any path member identifier (escaped idents are stripped). *)
 let parser path_elem =
-  | id:regular_ident -> KW.check id; (id, false)
+  | id:regular_ident          -> KW.check id; (id, false)
   | id:escaped_ident_no_delim -> (id, true)
 
 (** Module path (dot-separated identifiers. *)

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -60,7 +60,8 @@ let rec pp_p_term : p_term pp = fun oc t ->
     | (P_Iden(qid, true ), _    ) -> out "@%a" pp_qident qid
     | (P_Wild            , _    ) -> out "_"
     | (P_Meta(x,ar)      , _    ) -> out "?%a%a" pp_ident x pp_env ar
-    | (P_Patt(x,ar)      , _    ) -> out "&%a%a" pp_ident x pp_env ar
+    | (P_Patt(None   ,ar), _    ) -> out "&_%a" pp_env ar
+    | (P_Patt(Some(x),ar), _    ) -> out "&%a%a" pp_ident x pp_env ar
     | (P_Appl(t,u)       , PAppl)
     | (P_Appl(t,u)       , PFunc) -> out "%a@ %a" pp_appl t pp_atom u
     | (P_Impl(a,b)       , PFunc) -> out "%a@ ⇒ %a" pp_appl a pp_func b

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -39,8 +39,8 @@ and p_term_aux =
   (** Wildcard (place-holder for terms). *)
   | P_Meta of strloc * p_term array
   (** Meta-variable with the given environment. *)
-  | P_Patt of strloc * p_term array
-  (** Higher-order pattern (used for rules LHS / RHS). *)
+  | P_Patt of strloc option * p_term array
+  (** Named or unnamed higher-order pattern (used for rules LHS / RHS). *)
   | P_Appl of p_term * p_term
   (** Application. *)
   | P_Impl of p_term * p_term
@@ -209,9 +209,10 @@ let rec eq_p_term : p_term eq = fun t1 t2 ->
   match (t1.elt, t2.elt) with
   | (P_Iden(q1,b1)       , P_Iden(q2,b2)       ) ->
       eq_qident q1 q2 && b1 = b2
-  | (P_Meta(x1,ts1)      , P_Meta(x2,ts2)      )
-  | (P_Patt(x1,ts1)      , P_Patt(x2,ts2)      ) ->
+  | (P_Meta(x1,ts1)      , P_Meta(x2,ts2)      ) ->
       eq_ident x1 x2 && Array.equal eq_p_term ts1 ts2
+  | (P_Patt(x1,ts1)      , P_Patt(x2,ts2)      ) ->
+      Option.equal eq_ident x1 x2 && Array.equal eq_p_term ts1 ts2
   | (P_Appl(t1,u1)       , P_Appl(t2,u2)       )
   | (P_Impl(t1,u1)       , P_Impl(t2,u2)       ) ->
       eq_p_term t1 t2 && eq_p_term u1 u2

--- a/tests/OK/292.lp
+++ b/tests/OK/292.lp
@@ -1,0 +1,22 @@
+set flag "print_domains" on
+
+symbol R : TYPE
+constant symbol zero : R
+symbol d2_1 : (R ⇒ R ⇒ R) ⇒ (R ⇒ R ⇒ R)
+
+// The following are equivalent
+rule d2_1 (λ_ y, &F[y]) → λ_ _,zero // warning
+rule d2_1 (λ_ y, &_[y]) → λ_ _,zero // warning
+rule d2_1 (λ_ y, _    ) → λ_ _,zero // no warning
+
+// The following two are currently NOT the same
+// (see https://github.com/Deducteam/lambdapi/issues/294)
+rule d2_1 (λx y, &_[y]) → λ_ _,zero // no warning
+rule d2_1 (λ_ y, _    ) → λ_ _,zero // no warning
+// The difference is that in the former variable "x" may appear in the type
+// of the "y" variable. That is not the case in the second line.
+
+// New warnings for (unused) bound λ-variables.
+definition fst1 : R ⇒ R ⇒ R ≔ λ x y , x // warning since y not bound.
+definition fst2 : R ⇒ R ⇒ R ≔ λ x _ , x // no warning
+definition fst3 : R ⇒ R ⇒ R ≔ λ x _y, x // no warning either


### PR DESCRIPTION
This is aimed as a fix for #292.

A couple of things are fixed:
 - Syntax `&_[x,y]` can now be used in a LHS to match any term `t` with `FV(t) ⊆ {x,y}`.
 - Syntax `?_[t,u]` is now forbidden (it was mistakenly allowed before).
 - We now get a warning in case of unused λ-variable (except if its name is prefixed by `_`.
 - Warnings now seem to have the expected behavior regarding wildcards.
 - Warnings are printed unconditionally (they do not depend on the verbosity level). This is more consistent with the rest of the warnings in the code.