### PR TITLE
[ci] [build] Fix problem with LAMBDAPI invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,17 @@ env:
 
 before_install:
   # Obtain and install opam locally.
-  - sudo wget https://github.com/ocaml/opam/releases/download/2.0.0/opam-2.0.0-x86_64-linux -O /usr/bin/opam
+  - sudo wget https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -O /usr/bin/opam
   - sudo chmod 755 /usr/bin/opam
   # Initialize the switch.
   - opam init -a --disable-sandboxing --compiler="$OCAML_VERSION"
   - opam update
   - opam switch "$OCAML_VERSION"
   - eval $(opam env)
-  - opam install menhir dune bindlib.5.0.0 timed.1.0 earley.2.0.0 yojson cmdliner ppx_inline_test why3.1.2.0 alt-ergo $EXTRA_OPAM
+  - opam pin add -n -k path lambdapi .
+  - opam install --deps-only -d -t lambdapi
+  - opam pin remove lambdapi
+  - opam install alt-ergo
   # Update why3 config after installing alt-ergo
   - why3 config --detect
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ doc:
 
 #### Unit tests and sanity check #############################################
 
-LAMBDAPI     = 'dune exec -- lambdapi'
+LAMBDAPI     = dune exec -- lambdapi
 OK_TESTFILES = $(sort $(wildcard tests/OK/*.dk tests/OK/*.lp))
 KO_TESTFILES = $(sort $(wildcard tests/KO/*.dk tests/KO/*.lp))
 
@@ -65,37 +65,37 @@ sanity_check: tools/sanity_check.sh
 .PHONY: matita
 matita: bin
 	@printf "## Compiling the Matita's arithmetic library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./matita.sh
+	@cd libraries && dune exec -- ./matita.sh
 
 .PHONY: focalide
 focalide: bin
 	@printf "## Compiling focalide library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./focalide.sh
+	@cd libraries && dune exec -- ./focalide.sh
 
 .PHONY: holide
 holide: bin
 	@printf "## Compiling holide library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./holide.sh
+	@cd libraries && dune exec -- ./holide.sh
 
 .PHONY: verine
 verine: bin
 	@printf "## Compiling verine library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./verine.sh
+	@cd libraries && dune exec -- ./verine.sh
 
 .PHONY: iprover
 iprover: bin
 	@printf "## Compiling iProverModulo library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./iprover.sh
+	@cd libraries && dune exec -- ./iprover.sh
 
 .PHONY: dklib
 dklib: bin
 	@printf "## Compiling the dklib library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./dklib.sh
+	@cd libraries && dune exec -- ./dklib.sh
 
 .PHONY: zenon_modulo
 zenon_modulo: bin
 	@printf "## Compiling the zenon library ##\n"
-	@cd libraries && LAMBDAPI=${LAMBDAPI} ./zenon_modulo.sh
+	@cd libraries && dune exec -- ./zenon_modulo.sh
 
 #### Cleaning targets ########################################################
 

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -20,8 +20,8 @@ license: "CeCILL 2.1"
 doc: "https://deducteam.github.io/lambdapi/"
 
 depends: [
-  "ocaml"        {         >= "4.04.0" }
-  "dune"         { build & >= "1.3.0"  }
+  "ocaml"        { >= "4.04.0" }
+  "dune"         { >= "1.3.0"  }
   "menhir"
   "bindlib"      { >= "5.0.0" }
   "earley"       { >= "2.0.0" }


### PR DESCRIPTION
We fix the bug introduced in c7caa6f44af665ad567ae39b235dc85119b84764
indeed quoting of makefile variables is tricky.

I'd chosen to use `PATH` to locate lambdapi in the `libraries` tests,
however other choices are possible.

I took the opportunity to update the travis and opam files to recent
conventions and compilers.