### PR TITLE
local let

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - opam pin add -n -k path lambdapi .
   - opam install --deps-only -d -t lambdapi
   - opam pin remove lambdapi
-  - opam install alt-ergo
+  - opam install alt-ergo.2.3.1
   # Update why3 config after installing alt-ergo
   - why3 config --detect
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,15 @@
-#### Prepare for modern versions of OCaml (2020-03-26)
-
- - Use `Stdlib` instead of `Pervasives` (enforced by sanity checks).
- - Rely on `stdlib-shims` to provide `Stdlib` on older version of OCaml.
-
-#### Let bindings (2020-03-26)
+#### Let bindings (2020-03-31)
 
 Adding let-bindings to the terms structure.
 - Contexts can now contain term definitions.
 - Unification is carried out with a context.
-- Equality modulo can use a context to unfold the definition of variables.
+- Reduction functions (`whnf`, `hnf`, `snf` &c.) are called with a context.
+- Type annotation for `let` in the concrete syntax.
+
+#### Prepare for modern versions of OCaml (2020-03-26)
+
+ - Use `Stdlib` instead of `Pervasives` (enforced by sanity checks).
+ - Rely on `stdlib-shims` to provide `Stdlib` on older version of OCaml.
 
 #### File management and module mapping (2020-03-20)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ Adding let-bindings to the terms structure.
 
 #### File management and module mapping (2020-03-20)
 
+- New module system.
+- Revised command line arguments parsing.
+- LSP server run from `lambdapi`
+- `--no-warning` option (fixes #296).
+
 #### Trees simplification (2019-12-05)
 
 Simplification of the decision tree structure

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+#### Let bindings (2020-03-24)
+
+Adding let-bindings to the terms structure.
+- Contexts can now contain term definitions.
+- Unification is carried out with a context.
+- Equality modulo can use a context to unfold the definition of variables.
+
+#### File management and module mapping (2020-03-20)
+
 #### Trees simplification (2019-12-05)
 
 Simplification of the decision tree structure

--- a/doc/sections/terms.md
+++ b/doc/sections/terms.md
@@ -26,7 +26,8 @@ A user-defined term can be either:
 
  * a non-dependent product `A ⇒ T` (syntactic sugar for `∀x:A,T` with `x` not occurring in `T`)
 
- * a `let f (x:A) y z ≔ t in` construction
+ * a `let f (x:A) y z: T ≔ t in` construction (with `let f x : A ≔ t in u` being a
+   syntactic sugar for `let f : _ ⇒ A ≔ λx, t in u`)
 
  * application is written by space-separated juxtaposition, except for symbol identifiers declared as infix (e.g. `x+y`)
 

--- a/doc/sections/terms.md
+++ b/doc/sections/terms.md
@@ -27,7 +27,7 @@ A user-defined term can be either:
  * a non-dependent product `A ⇒ T` (syntactic sugar for `∀x:A,T` with `x` not occurring in `T`)
 
  * a `let f (x:A) y z: T ≔ t in` construction (with `let f x : A ≔ t in u` being a
-   syntactic sugar for `let f : _ ⇒ A ≔ λx, t in u`)
+   syntactic sugar for `let f : ∀x:_ ⇒ A ≔ λx, t in u`)
 
  * application is written by space-separated juxtaposition, except for symbol identifiers declared as infix (e.g. `x+y`)
 

--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -157,8 +157,8 @@ reserved "why3"
   | <exposition>? "theorem" <ident> <arg>* ":" <type> "proof" <tactic>*
     {"qed"|"admit"|"abort"}
   // Assertion
-  | "assert" <assertion>
-  | "assertnot" <assertion>
+  | "assert" arg* "⊢" <assertion>
+  | "assertnot" arg* "⊢" <assertion>
   // Set option
   | "set" "verbose" RE("[1-9][0-9]*")
   | "set" "debug" RE("[-+][a-zA-Z]+")

--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -90,7 +90,7 @@ reserved "why3"
   | <type> "⇒" <type>
   | "∀" <arg>+ "," <type>
   | "λ" <arg>+ "," <term>
-  | "let" <ident> <arg>* "≔" <term> "in" <term>
+  | "let" <ident> <arg>* {":" <term>}? "≔" <term> "in" <term>
   | <nat_lit>
   | <term> <infix_op> <term>
 

--- a/lib/example/bool.lp
+++ b/lib/example/bool.lp
@@ -52,6 +52,6 @@ set infix right 16 "⊕" ≔ bool_xor
 
 // Some tests.
 
-assert (λ x y z : B, x ∨ y ∨ ¬ z) ≡ (λ x y z : B, x ∨ (y ∨ ¬ z))
-assert (λ x y z : B, x ∨ y ∧ z) ≡ (λ x y z : B, x ∨ (y ∧ z))
-assert (λ x y z : B, z ⇨ x ∨ y ∧ z) ≡ (λ x y z : B, z ⇨ (x ∨ (y ∧ z)))
+assert (x y z : B) ⊢ x ∨ y ∨ ¬ z ≡ x ∨ (y ∨ ¬ z)
+assert (x y z : B) ⊢ x ∨ y ∧ z ≡ x ∨ (y ∧ z)
+assert (x y z : B) ⊢ z ⇨ x ∨ y ∧ z ≡ z ⇨ (x ∨ (y ∧ z))

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -207,8 +207,7 @@ let has_metas : bool -> term -> bool =
 (** [distinct_vars ctx ts]  checks  that terms of  [ts] are made of  variables
     that are themselves or their definition in  [ctx] (if it exists) distinct.
     If so, the variables are returned. *)
-let distinct_vars : ctxt -> term array -> tvar array option =
-  fun ctx ts ->
+let distinct_vars : ctxt -> term array -> tvar array option = fun ctx ts ->
   let exception Not_unique_var in
   let open Pervasives in
   let vars = ref VarSet.empty in

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -41,12 +41,6 @@ let rec count_products : term -> int = fun t ->
   | Prod(_,b) -> 1 + count_products (Bindlib.subst b Kind)
   | _         -> 0
 
-(** [imply t u] creates the term [t ⇒ u], that is, the dependent product
-    [∀x: t, u] where [u] does not depend on [x]. *)
-let imply : term -> term -> term = fun t u ->
-  let dummy = Bindlib.new_var mkfree "_" in
-  Prod(t, Bindlib.unbox (Bindlib.bind_var dummy (lift u)))
-
 (** [get_args t] decomposes the {!type:term} [t] into a pair [(h,args)], where
     [h] is the head term of [t] and [args] is the list of arguments applied to
     [h] in [t]. The returned [h] cannot be an [Appl] node. *)

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -67,6 +67,18 @@ let get_args_len : term -> term * term list * int = fun t ->
   in
   get_args_len [] 0 t
 
+(** [get_args_ctx ctx t] decomposes term [t] as [get_args] does, but any
+    variable encountered is replaced by its definition in [ctx] (if it
+    exists). *)
+let get_args_ctx : ctxt -> term -> term * term list = fun ctx t ->
+  let rec get_args acc t =
+    match unfold t with
+    | Appl(t,u)    -> get_args (u::acc) t
+    | Vari(x) as t -> (Option.get t (Ctxt.def_of x ctx), acc)
+    | t            -> (t, acc)
+  in
+  get_args [] t
+
 (** [add_args t args] builds the application of the {!type:term} [t] to a list
     arguments [args]. When [args] is empty, the returned value is (physically)
     equal to [t]. *)

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -74,7 +74,8 @@ let get_args_ctx : ctxt -> term -> term * term list = fun ctx t ->
   let rec get_args acc t =
     match unfold t with
     | Appl(t,u)    -> get_args (u::acc) t
-    | Vari(x) as t -> (Option.get t (Ctxt.def_of x ctx), acc)
+    | Vari(x) as t ->
+        Option.map_default (get_args acc) (t, acc) (Ctxt.def_of x ctx)
     | t            -> (t, acc)
   in
   get_args [] t

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -215,8 +215,9 @@ let distinct_vars : ctxt -> term array -> tvar array option = fun ctx ts ->
     match unfold t with
     | Vari(x) ->
         let x = Option.map_default to_var x (Ctxt.def_of x ctx) in
-        if not (VarSet.mem x !vars) then (vars := VarSet.add x !vars; x) else
-        raise Not_unique_var
+        if VarSet.mem x !vars then raise Not_unique_var;
+        vars := VarSet.add x !vars;
+        x
     | _       -> raise Not_unique_var
   in
   try Some (Array.map to_var ts) with Not_unique_var -> None

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -101,7 +101,7 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
     | (Prod(a1,b1), Prod(a2,b2))
     | (Abst(a1,b1), Abst(a2,b2)) -> let (_, b1, b2) = Bindlib.unbind2 b1 b2 in
                                     eq ((a1,a2)::(b1,b2)::l)
-    | (LLet(t1,a1,u1), LLet(t2,a2,u2)) ->
+    | (LLet(a1,t1,u1), LLet(a2,t2,u2)) ->
         let (_, u1, u2) = Bindlib.unbind2 u1 u2 in
         eq ((a1,a2)::(t1,t2)::(u1,u2)::l)
     | (Appl(t1,u1), Appl(t2,u2)) -> eq ((t1,t2)::(u1,u2)::l)
@@ -152,7 +152,7 @@ let iter : (term -> unit) -> term -> unit = fun action ->
     | Prod(a,b)
     | Abst(a,b)   -> iter a; iter (Bindlib.subst b Kind)
     | Appl(t,u)   -> iter t; iter u
-    | LLet(t,a,u) -> iter t; iter a; iter (Bindlib.subst u Kind)
+    | LLet(a,t,u) -> iter a; iter t; iter (Bindlib.subst u Kind)
   in iter
 
 (** {3 Metavariables} *)
@@ -182,7 +182,7 @@ let iter_meta : bool -> (meta -> unit) -> term -> unit = fun b f ->
     | Abst(a,b)   -> iter a; iter (Bindlib.subst b Kind)
     | Appl(t,u)   -> iter t; iter u
     | Meta(v,ts)  -> f v; Array.iter iter ts; if b then iter !(v.meta_type)
-    | LLet(t,a,u) -> iter t; iter a; iter (Bindlib.subst u Kind)
+    | LLet(a,t,u) -> iter a; iter t; iter (Bindlib.subst u Kind)
   in iter
 
 (** [occurs m t] tests whether the metavariable [m] occurs in the term [t]. *)

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -67,17 +67,6 @@ let get_args_len : term -> term * term list * int = fun t ->
   in
   get_args_len [] 0 t
 
-(** [get_args_ctx ctx t] decomposes term [t] as [get_args] does, but any
-    variable encountered is replaced by its definition in [ctx] (if it
-    exists). *)
-let get_args_ctx : ctxt -> term -> term * term list = fun ctx t ->
-  let rec get_args acc t =
-    match Ctxt.unfold ctx t with
-    | Appl(t,u)    -> get_args (u::acc) t
-    | t            -> (t, acc)
-  in
-  get_args [] t
-
 (** [add_args t args] builds the application of the {!type:term} [t] to a list
     arguments [args]. When [args] is empty, the returned value is (physically)
     equal to [t]. *)
@@ -105,6 +94,7 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
     | (a,b)::l ->
     match (Ctxt.unfold ctx a, Ctxt.unfold ctx b) with
     | (a          , b          ) when a == b -> eq l
+    | (Vari(x1)   , Vari(x2)   ) when Bindlib.eq_vars x1 x2 -> eq l
     | (Type       , Type       )
     | (Kind       , Kind       ) -> eq l
     | (Symb(s1,_) , Symb(s2,_) ) when s1 == s2 -> eq l
@@ -121,7 +111,6 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
     | (_          , Wild       ) -> eq l
     | (TRef(r)    , b          ) -> r := Some(b); eq l
     | (a          , TRef(r)    ) -> r := Some(a); eq l
-    | (Vari(x1)   , Vari(x2)   ) when Bindlib.eq_vars x1 x2 -> eq l
     | (Patt(_,_,_), _          )
     | (_          , Patt(_,_,_))
     | (TEnv(_,_)  , _          )

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -160,7 +160,7 @@ let iter : (term -> unit) -> term -> unit = fun action ->
 (** [make_meta ctx a] creates a metavariable of type [a],  with an environment
     containing the variables of context [ctx]. *)
 let make_meta : ctxt -> term -> term = fun ctx a ->
-  let prd, len = Ctxt.prod ctx a in
+  let prd, len = Ctxt.to_prod ctx a in
   let m = fresh_meta prd len in
   let get_var (x,_,_) = Vari(x) in
   Meta(m, Array.of_list (List.rev_map get_var ctx))

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -107,7 +107,6 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
     | (a,b)::l ->
     match (unfold a, unfold b) with
     | (a          , b          ) when a == b -> eq l
-    | (Vari(x1)   , Vari(x2)   ) when Bindlib.eq_vars x1 x2 -> eq l
     | (Type       , Type       )
     | (Kind       , Kind       ) -> eq l
     | (Symb(s1,_) , Symb(s2,_) ) when s1 == s2 -> eq l
@@ -124,6 +123,7 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
     | (_          , Wild       ) -> eq l
     | (TRef(r)    , b          ) -> r := Some(b); eq l
     | (a          , TRef(r)    ) -> r := Some(a); eq l
+    | (Vari(x1)   , Vari(x2)   ) when Bindlib.eq_vars x1 x2 -> eq l
     (* Try unfolding variable definitions. *)
     | (Vari(x)    , t          )
     | (t          , Vari(x)    ) ->

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -72,7 +72,7 @@ let get_args_len : term -> term * term list * int = fun t ->
     exists). *)
 let get_args_ctx : ctxt -> term -> term * term list = fun ctx t ->
   let rec get_args acc t =
-    match unfold_ctx ctx t with
+    match Ctxt.unfold ctx t with
     | Appl(t,u)    -> get_args (u::acc) t
     | t            -> (t, acc)
   in
@@ -103,7 +103,7 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
     match l with
     | []       -> ()
     | (a,b)::l ->
-    match (unfold_ctx ctx a, unfold_ctx ctx b) with
+    match (Ctxt.unfold ctx a, Ctxt.unfold ctx b) with
     | (a          , b          ) when a == b -> eq l
     | (Type       , Type       )
     | (Kind       , Kind       ) -> eq l
@@ -224,7 +224,7 @@ let distinct_vars : ctxt -> term array -> tvar array option = fun ctx ts ->
   let open Stdlib in
   let vars = ref VarSet.empty in
   let to_var t =
-    match unfold_ctx ctx t with
+    match Ctxt.unfold ctx t with
     | Vari(x) ->
         if VarSet.mem x !vars then raise Not_unique_var;
         vars := VarSet.add x !vars;
@@ -243,7 +243,7 @@ let nl_distinct_vars : ctxt -> term array -> tvar array option = fun ctx ts ->
   let vars = ref VarSet.empty
   and nl_vars = ref VarSet.empty in
   let to_var t =
-    match unfold_ctx ctx t with
+    match Ctxt.unfold ctx t with
     | Vari(x) ->
         if VarSet.mem x !vars then nl_vars := VarSet.add x !nl_vars else
         vars := VarSet.add x !vars;

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -207,7 +207,8 @@ let has_metas : bool -> term -> bool =
 (** [distinct_vars ts] checks that [ts] is made of distinct
    variables and returns these variables. *)
 let distinct_vars : ctxt -> term array -> tvar array option =
-  let exception Not_unique_var in fun ctx ts ->
+  fun ctx ts ->
+  let exception Not_unique_var in
   let open Pervasives in
   let vars = ref VarSet.empty in
   let to_var t =

--- a/src/core/basics.ml
+++ b/src/core/basics.ml
@@ -113,13 +113,6 @@ let eq : ctxt -> term -> term -> bool = fun ctx a b -> a == b ||
   in
   try eq [(a,b)]; true with Not_equal -> false
 
-(** [eq_vari t u] checks that [t] and [u] are both variables, and the they are
-    pariwise equal. *)
-let eq_vari : term -> term -> bool = fun t u ->
-  match (unfold t, unfold u) with
-  | (Vari(x), Vari(y)) -> Bindlib.eq_vars x y
-  | (_      , _      ) -> false
-
 (** [is_symb s t] tests whether [t] is of the form [Symb(s)]. *)
 let is_symb : sym -> term -> bool = fun s t ->
   match unfold t with

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -18,13 +18,6 @@ let unbind : ctxt -> term -> term option -> tbinder ->
 let type_of : tvar -> ctxt -> term = fun x ctx ->
   let (_,a,_) = List.find (fun (y,_,_) -> Bindlib.eq_vars x y) ctx in a
 
-(** [def_of x ctx] returns the definition of [x] in the context [ctx] if it
-    appears, and [None] otherwise *)
-let rec def_of : tvar -> ctxt -> term option = fun x ctx ->
-  match ctx with
-  | []         -> None
-  | (y,_,d)::l -> if Bindlib.eq_vars x y then d else def_of x l
-
 (** [mem x ctx] tells whether variable [x] is mapped in the context [ctx]. *)
 let mem : tvar -> ctxt -> bool = fun x ->
   List.exists (fun (y,_,_) -> Bindlib.eq_vars x y)

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -36,7 +36,7 @@ let to_prod : ctxt -> term -> term * int = fun ctx t ->
   let fn (t,c) elt =
     match elt with
     | (x,a,None   ) -> (_Prod (lift a) (Bindlib.bind_var x t), c + 1)
-    | (x,a,Some(u)) -> (_LLet (lift u) (lift a) (Bindlib.bind_var x t), c)
+    | (x,a,Some(u)) -> (_LLet (lift a) (lift u) (Bindlib.bind_var x t), c)
   in
   let (t, c) = List.fold_left fn (lift t, 0) ctx in
   (Bindlib.unbox t, c)
@@ -48,7 +48,7 @@ let rec to_llet ctx t =
   | []                 -> t
   | (_,_,None   )::ctx -> to_llet ctx t
   | (x,a,Some(u))::ctx -> let body = Bindlib.bind_var x (lift t) in
-                          to_llet ctx (LLet(u,a,Bindlib.unbox body))
+                          to_llet ctx (LLet(a,u,Bindlib.unbox body))
 
 (** [sub ctx vs] returns the sub-context of [ctx] made of the variables of
     [vs]. *)

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -42,14 +42,13 @@ let to_prod : ctxt -> term -> term * int = fun ctx t ->
   (Bindlib.unbox t, c)
 
 (** [to_llet ctx t] builds one let-binding on top of [t] for each defined
-    variable in [ctx]. *)
+    variable in [ctx]. Undefined variables of [ctx] or not bound in [t]. *)
 let rec to_llet ctx t =
   match ctx with
   | []                 -> t
-  | (_,_,None)::ctx    -> to_llet ctx t
-  | (x,a,Some(u))::ctx ->
-      let body = Bindlib.bind_var x (lift t) in
-      to_llet ctx (LLet(u,a,Bindlib.unbox body))
+  | (_,_,None   )::ctx -> to_llet ctx t
+  | (x,a,Some(u))::ctx -> let body = Bindlib.bind_var x (lift t) in
+                          to_llet ctx (LLet(u,a,Bindlib.unbox body))
 
 (** [sub ctx vs] returns the sub-context of [ctx] made of the variables of
     [vs]. *)

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -9,8 +9,8 @@ open Timed
     extension of context [ctx] with the assumption that [x] has type [a] (only
     if [x] occurs in [t]). If [def] is of the form [Some(u)], the context also
     registers the term [u] as the definition of variable [x]. *)
-let unbind : ctxt -> term -> term option -> tbinder ->
-  tvar * term * ctxt = fun ctx a def b ->
+let unbind : ctxt -> term -> term option -> tbinder -> tvar * term * ctxt =
+  fun ctx a def b ->
   let (x, t) = Bindlib.unbind b in
   (x, t, if Bindlib.binder_occur b then (x, a, def) :: ctx else ctx)
 
@@ -38,7 +38,7 @@ let to_prod : ctxt -> term -> term * int = fun ctx t ->
     | (x,a,None   ) -> (_Prod (lift a) (Bindlib.bind_var x t), c + 1)
     | (x,a,Some(u)) -> (_LLet (lift u) (lift a) (Bindlib.bind_var x t), c)
   in
-  let t, c = List.fold_left fn (lift t, 0) ctx in
+  let (t, c) = List.fold_left fn (lift t, 0) ctx in
   (Bindlib.unbox t, c)
 
 (** [to_llet ctx t] builds one let-binding on top of [t] for each defined

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -30,9 +30,9 @@ let rec def_of : term Bindlib.var -> ctxt -> term option = fun x ctx ->
 let mem : tvar -> ctxt -> bool = fun x ->
   List.exists (fun (y,_,_) -> Bindlib.eq_vars x y)
 
-(** [prod ctx t] builds a product by abstracting over the context [ctx], in
+(** [to_prod ctx t] builds a product by abstracting over the context [ctx], in
     the term [t]. It returns the number of products as well. *)
-let prod : ctxt -> term -> term * int = fun ctx t ->
+let to_prod : ctxt -> term -> term * int = fun ctx t ->
   let fn (t,c) elt =
     match elt with
     | (x,a,None   ) -> (_Prod (lift a) (Bindlib.bind_var x t), c + 1)
@@ -41,15 +41,15 @@ let prod : ctxt -> term -> term * int = fun ctx t ->
   let t, c = List.fold_left fn (lift t, 0) ctx in
   (Bindlib.unbox t, c)
 
-(** [llet ctx t] builds one let-binding on top of [t] for each defined
+(** [to_llet ctx t] builds one let-binding on top of [t] for each defined
     variable in [ctx]. *)
-let rec llet ctx t =
+let rec to_llet ctx t =
   match ctx with
   | []                 -> t
-  | (_,_,None)::ctx    -> llet ctx t
+  | (_,_,None)::ctx    -> to_llet ctx t
   | (x,a,Some(u))::ctx ->
       let body = Bindlib.bind_var x (lift t) in
-      llet ctx (LLet(u,a,Bindlib.unbox body))
+      to_llet ctx (LLet(u,a,Bindlib.unbox body))
 
 (** [sub ctx vs] returns the sub-context of [ctx] made of the variables of
     [vs]. *)

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -47,11 +47,3 @@ let sub : ctxt -> tvar array -> ctxt = fun ctx vs ->
     if Array.exists (Bindlib.eq_vars x) vs then hyp::ctx else ctx
   in
   List.fold_right f ctx []
-
-(** [merge c1 c2] merges contexts [c1] and [c2] and returns [None] if they
-    overlap. The new context is [c1] reversed and concatenated to [c2]. *)
-let rec merge : ctxt -> ctxt -> ctxt option = fun c1 c2 ->
-  match c1 with
-  | (x,_,_)::_ when mem x c2 -> None
-  | (x,a,d)::c1 -> merge c1 ((x,a,d)::c2)
-  | []          -> Some(c2)

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -49,10 +49,10 @@ let sub : ctxt -> tvar array -> ctxt = fun ctx vs ->
   in
   List.fold_right f ctx []
 
-(** [unfold ctx t] behaves like {!val:Terms.unfold t} except when [t] is a
-    term of the form [Vari(x)] with [x] defined in [ctx]. In this case, [t] is
-    replaced by the definition of [x] in [ctx]. In particular, if no operation
-    is carried out on [t], we have [unfold ctx t == t]. *)
+(** [unfold ctx t] behaves like {!val:Terms.unfold t} unless term[t] is of the
+    form [Vari(x)] with [x] defined in [ctx]. In this case, [t] is replaced by
+    the definition of [x] in [ctx].  In particular, if no operation is carried
+    out on [t], we have [unfold ctx t == t]. *)
 let rec unfold : ctxt -> term -> term = fun ctx t ->
   match t with
   | Meta(m, ar)          ->

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -60,7 +60,8 @@ let sub : ctxt -> tvar array -> ctxt = fun ctx vs ->
 
 (** [unfold ctx t] behaves like {!val:Terms.unfold t} except when [t] is a
     term of the form [Vari(x)] with [x] defined in [ctx]. In this case, [t] is
-    replaced by the definition of [x] in [ctx]. *)
+    replaced by the definition of [x] in [ctx]. In particular, if no operation
+    is carried out on [t], we have [unfold ctx t == t]. *)
 let rec unfold : ctxt -> term -> term = fun ctx t ->
   match t with
   | Meta(m, ar)          ->

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -41,15 +41,6 @@ let to_prod : ctxt -> term -> term * int = fun ctx t ->
   let (t, c) = List.fold_left fn (lift t, 0) ctx in
   (Bindlib.unbox t, c)
 
-(** [to_llet ctx t] builds one let-binding on top of [t] for each defined
-    variable in [ctx]. Undefined variables of [ctx] or not bound in [t]. *)
-let rec to_llet ctx t =
-  match ctx with
-  | []                 -> t
-  | (_,_,None   )::ctx -> to_llet ctx t
-  | (x,a,Some(u))::ctx -> let body = Bindlib.bind_var x (lift t) in
-                          to_llet ctx (LLet(a,u,Bindlib.unbox body))
-
 (** [sub ctx vs] returns the sub-context of [ctx] made of the variables of
     [vs]. *)
 let sub : ctxt -> tvar array -> ctxt = fun ctx vs ->

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -48,3 +48,10 @@ let sub : ctxt -> tvar array -> ctxt = fun ctx vs ->
   in
   List.fold_right f ctx []
 
+(** [merge c1 c2] merges contexts [c1] and [c2] and returns [None] if they
+    overlap. The new context is [c1] reversed and concatenated to [c2]. *)
+let rec merge : ctxt -> ctxt -> ctxt option = fun c1 c2 ->
+  match c1 with
+  | (x,_,_)::_ when mem x c2 -> None
+  | (x,a,d)::c1 -> merge c1 ((x,a,d)::c2)
+  | []          -> Some(c2)

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -40,6 +40,16 @@ let prod : ctxt -> term -> term * int = fun ctx t ->
   let t, c = List.fold_left fn (lift t, 0) ctx in
   (Bindlib.unbox t, c)
 
+(** [llet ctx t] builds one let-binding on top of [t] for each defined
+    variable in [ctx]. *)
+let rec llet ctx t =
+  match ctx with
+  | []                 -> t
+  | (_,_,None)::ctx    -> llet ctx t
+  | (x,a,Some(u))::ctx ->
+      let body = Bindlib.bind_var x (lift t) in
+      llet ctx (LLet(u,a,Bindlib.unbox body))
+
 (** [sub ctx vs] returns the sub-context of [ctx] made of the variables of
     [vs]. *)
 let sub : ctxt -> tvar array -> ctxt = fun ctx vs ->

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -27,22 +27,17 @@ let add : tvar -> tbox -> tbox option -> env -> env = fun v a t env ->
 let find : string -> env -> tvar = fun n env ->
   let (x,_,_) = List.assoc n env in x
 
-(** [to_prodbox env t] is like [to_prod] below except that it does not
-    unbox the term. *)
-let to_prodbox : env -> tbox -> tbox = fun env t ->
-  let fn t (_,(x,a,u)) =
-    match u with
-    | Some(u) -> _LLet u a (Bindlib.bind_var x t)
-    | None    -> _Prod a (Bindlib.bind_var x t)
-  in
-  List.fold_left fn t env
-
 (** [to_prod env t] builds a sequence of products or let-bindings whose
     domains are the variables of the environment [env] (from left to right),
     and which body is the term [t]:
     [to_prod [(xn,an,None);..;(x1,a1,None)] t = ∀x1:a1,..,∀xn:an,t]. *)
 let to_prod : env -> tbox -> term = fun env t ->
-  Bindlib.unbox (to_prodbox env t)
+  let fn t (_,(x,a,u)) =
+    match u with
+    | Some(u) -> _LLet u a (Bindlib.bind_var x t)
+    | None    -> _Prod a (Bindlib.bind_var x t)
+  in
+  Bindlib.unbox (List.fold_left fn t env)
 
 (** [to_abst env t] builds a sequence of abstractions or let bindings,
     depending on the definition of the elements in the environment whose

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -56,7 +56,7 @@ let of_prod_arity : int -> term -> env * term = fun n t ->
     else match Eval.whnf [] t with
          | Prod(a,b) ->
             let v,b = Bindlib.unbind b in
-            let a = Eval.simplify a in
+            let a = Eval.simplify [] a in
             let env = add v (lift a) env in
             build_env (i+1) env b
          | _ -> raise (Invalid_argument "of_prod")

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -34,7 +34,7 @@ let find : string -> env -> tvar = fun n env ->
 let to_prod : env -> tbox -> term = fun env t ->
   let fn t (_,(x,a,u)) =
     match u with
-    | Some(u) -> _LLet u a (Bindlib.bind_var x t)
+    | Some(u) -> _LLet a u (Bindlib.bind_var x t)
     | None    -> _Prod a (Bindlib.bind_var x t)
   in
   Bindlib.unbox (List.fold_left fn t env)
@@ -47,7 +47,7 @@ let to_prod : env -> tbox -> term = fun env t ->
 let to_abst : env -> tbox -> term = fun env t ->
   let fn t (_,(x,a,u)) =
     match u with
-    | Some(u) -> _LLet u a (Bindlib.bind_var x t)
+    | Some(u) -> _LLet a u (Bindlib.bind_var x t)
     | None    -> _Abst a (Bindlib.bind_var x t)
   in
   Bindlib.unbox (List.fold_left fn t env)

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -27,17 +27,22 @@ let add : tvar -> tbox -> tbox option -> env -> env = fun v a t env ->
 let find : string -> env -> tvar = fun n env ->
   let (x,_,_) = List.assoc n env in x
 
-(** [to_prod env t] builds a sequence of products or let-bindings whose
-    domains are the variables of the environment [env] (from left to right),
-    and which body is the term [t]:
-    [to_prod [(xn,an,None);..;(x1,a1,None)] t = ∀x1:a1,..,∀xn:an,t]. *)
-let to_prod : env -> tbox -> term = fun env t ->
+(** [to_prodbox env t] is like [to_prod] below except that it does not
+    unbox the term. *)
+let to_prodbox : env -> tbox -> tbox = fun env t ->
   let fn t (_,(x,a,u)) =
     match u with
     | Some(u) -> _LLet u a (Bindlib.bind_var x t)
     | None    -> _Prod a (Bindlib.bind_var x t)
   in
-  Bindlib.unbox (List.fold_left fn t env)
+  List.fold_left fn t env
+
+(** [to_prod env t] builds a sequence of products or let-bindings whose
+    domains are the variables of the environment [env] (from left to right),
+    and which body is the term [t]:
+    [to_prod [(xn,an,None);..;(x1,a1,None)] t = ∀x1:a1,..,∀xn:an,t]. *)
+let to_prod : env -> tbox -> term = fun env t ->
+  Bindlib.unbox (to_prodbox env t)
 
 (** [to_abst env t] builds a sequence of abstractions or let bindings,
     depending on the definition of the elements in the environment whose

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -53,7 +53,7 @@ let to_tbox : env -> tbox array = fun env ->
 let of_prod_arity : int -> term -> env * term = fun n t ->
   let rec build_env i env t =
     if i >= n then env, t
-    else match Eval.whnf t with
+    else match Eval.whnf [] t with
          | Prod(a,b) ->
             let v,b = Bindlib.unbind b in
             let a = Eval.simplify a in
@@ -70,7 +70,7 @@ let of_prod_vars : tvar array -> term -> env * term = fun vars t ->
   let n = Array.length vars in
   let rec build_env i env t =
     if i >= n then env, t
-    else match Eval.whnf t with
+    else match Eval.whnf [] t with
          | Prod(a,b) ->
             let v = vars.(i) in
             let env = add v (lift a) env in

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -2,84 +2,97 @@
     Note that since meta-variable types are closed, the contexts passed to
     {!val:Eval.whnf} and alike are empty. *)
 
+open Extra
 open Terms
 
 (** Type of an environment, used in scoping to associate names to
-   corresponding Bindlib variables and types. Note that it cannot be
-   implemented by a map as the order is important. *)
-type env = (string * (tvar * tbox)) list
+    corresponding Bindlib variables and types. Note that it cannot be
+    implemented by a map as the order is important. The boolean is used to
+    indicate whether the variable is defined in some context. *)
+type env = (string * (tvar * bool * tbox)) list
 
 type t = env
 
-(** [empty] is the empty environemnt. *)
+(** [empty] is the empty environment. *)
 let empty : env = []
 
-(** [add v a env] extends the environment [env] by mapping the string
-   [Bindlib.name_of v] to [(v,a)]. *)
-let add : tvar -> tbox -> env -> env = fun v a env ->
-  (Bindlib.name_of v, (v, a)) :: env
+(** [add v d a env] extends the environment [env] by mapping the string
+    [Bindlib.name_of v] to [(v,d,a)]. *)
+let add : tvar -> bool -> tbox -> env -> env = fun v d a env ->
+  (Bindlib.name_of v, (v, d, a)) :: env
 
 (** [find n env] returns the Bindlib variable associated to the variable  name
     [n] in the environment [env]. If none is found, [Not_found] is raised. *)
 let find : string -> env -> tvar = fun n env ->
-  fst (List.assoc n env)
+  let (x,_,_) = (List.assoc n env) in x
 
-(** [to_prod env t] builds a sequence of products whose  domains  are the
-    variables of the environment [env] (from left to right), and which body is
-    the term [t]: [to_prod [(xn,an);..;(x1,a1)] t = ∀x1:a1,..,∀xn:an,t]. *)
+(** [to_prod env t] builds a sequence of products whose domains are the {e not
+    defined} variables of the environment [env] (from left to right), and
+    which body is the term [t]: [to_prod [(xn,an);..;(x1,a1)] t =
+    ∀x1:a1,..,∀xn:an,t]. *)
 let to_prod : env -> tbox -> term = fun env t ->
-  let fn t (_,(x,a)) = _Prod a (Bindlib.bind_var x t) in
+  let fn t (_,(x,d,a)) = if d then t else _Prod a (Bindlib.bind_var x t) in
   Bindlib.unbox (List.fold_left fn t env)
 
-(** [to_abst env t] builds a sequence of abstractions whose  domains  are the
-    variables of the environment [env] (from left to right), and which body is
-    the term [t]: [to_prod [(xn,an);..;(x1,a1)] t = λx1:a1,..,λxn:an,t]. *)
+(** [to_abst env t] builds a sequence of abstractions whose domains are the {b
+    not defined} variables of the environment [env] (from left to right), and
+    which body is the term [t]: [to_prod [(xn,an);..;(x1,a1)] t =
+    λx1:a1,..,λxn:an,t]. *)
 let to_abst : env -> tbox -> term = fun env t ->
-  let fn t (_,(x,a)) = _Abst a (Bindlib.bind_var x t) in
+  let fn t (_,(x,d,a)) = if d then t else _Abst a (Bindlib.bind_var x t) in
   Bindlib.unbox (List.fold_left fn t env)
 
 (** [vars env] extracts the array of the Bindlib variables in [env]. Note that
     the order is reversed: [vars [(xn,an);..;(x1,a1)] = [|x1;..;xn|]]. *)
 let vars : env -> tvar array = fun env ->
-  Array.of_list (List.rev_map (fun (_,(x,_)) -> x) env)
+  let f (_, (x, d, _)) = if d then None else Some(x) in
+  Array.of_list (List.filter_rev_map f env)
 
-(** [to_term env] extracts the array of the variables in [env] and inject them
-    in the [tbox] type. This is the same as [Array.map _Vari (vars env)]. Note
-    that the order is reversed: [vars [(xn,an);..;(x1,a1)] = [|x1;..;xn|]]. *)
+(** [to_term env] extracts the array of the {e not defined} variables in [env]
+    and injects them in the [tbox] type.  This is the same as [Array.map _Vari
+    (vars env)]. Note that the order is reversed: [vars [(xn,an);..;(x1,a1)] =
+    [|x1;..;xn|]]. *)
 let to_tbox : env -> tbox array = fun env ->
-  Array.of_list (List.rev_map (fun (_,(x,_)) -> _Vari x) env)
+  let f (_, (x, d, _)) = if d then None else Some(_Vari x) in
+  Array.of_list (List.filter_rev_map f env)
 
-(** [of_prod n t] returns the environment [(xn,an),..,(x1,a1)] and the term
-   [b] if [t] is of the form [∀x1:a1,..,∀xn:an,b]. Raises [Invalid_argument]
-   if [t] is not of this form. *)
+(** [of_prod_arity n t] returns the environment [(xn,an),..,(x1,a1)] and the
+    term [b] if [t] is of the form [∀x1:a1,..,∀xn:an,b].
+    @raise Invalid_argument if [t] is not of this form. *)
 let of_prod_arity : int -> term -> env * term = fun n t ->
   let rec build_env i env t =
-    if i >= n then env, t
-    else match Eval.whnf [] t with
-         | Prod(a,b) ->
-            let v,b = Bindlib.unbind b in
-            let a = Eval.simplify [] a in
-            let env = add v (lift a) env in
-            build_env (i+1) env b
-         | _ -> raise (Invalid_argument "of_prod")
-  in build_env 0 [] t
+    if i >= n then (env, t) else
+    match Eval.whnf [] t with
+      | Prod(a,b) ->
+          let v,b = Bindlib.unbind b in
+          let a = Eval.simplify [] a in
+          let env = add v false (lift a) env in
+          build_env (i+1) env b
+      | _         -> raise (Invalid_argument "of_prod_arity")
+  in
+  build_env 0 [] t
 
 (** [of_prod vs t] returns the environment [(vn,an{x1=v1,..,xn-1=vn-1}),..,
-   (v1,a1)] and the term [b{x1=v1,..,xn=vn}] if [t] is of the form
-   [∀x1:a1,..,∀xn:an,b]. Raises [Invalid_argument] if [t] is not of this
-   form. *)
+    (v1,a1)] and the term [b{x1=v1,..,xn=vn}] if [t] is of the form
+    [∀x1:a1,..,∀xn:an,b]. Raises [Invalid_argument] if [t] is not of this
+    form. *)
 let of_prod_vars : tvar array -> term -> env * term = fun vars t ->
   let n = Array.length vars in
   let rec build_env i env t =
-    if i >= n then env, t
-    else match Eval.whnf [] t with
-         | Prod(a,b) ->
-            let v = vars.(i) in
-            let env = add v (lift a) env in
-            build_env (i+1) env (Bindlib.subst b (Vari v))
-         | _ -> raise (Invalid_argument "of_prod")
-  in build_env 0 [] t
+    if i >= n then (env, t) else
+    match Eval.whnf [] t with
+      | Prod(a,b) ->
+          let v = vars.(i) in
+          let env = add v false (lift a) env in
+          build_env (i+1) env (Bindlib.subst b (Vari v))
+      | _         -> raise (Invalid_argument "of_prod_vars")
+  in
+  build_env 0 [] t
 
-(** [to_ctxt] builds a context from an environment. *)
-let to_ctxt : t -> ctxt = fun e ->
-  List.map (fun (_,(v,bt)) -> (v, Bindlib.unbox bt, None)) e
+(** [to_ctxt env] builds a context made from undefined variables of
+    environment [env]. *)
+let to_ctxt : env -> ctxt = fun e ->
+  let f (_, (v, d, bt)) =
+    if d then None else Some(v, Bindlib.unbox bt, None)
+  in
+  List.filter_map f e

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -1,4 +1,6 @@
-(** Scoping environment for variables. *)
+(** Scoping environment for variables.
+    Note that since meta-variable types are closed, the contexts passed to
+    {!val:Eval.whnf} and alike are empty. *)
 
 open Terms
 

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -350,9 +350,8 @@ let snf : ctxt -> term -> term = fun ctx t -> snf (Ctxt.to_llet ctx t)
 (** [whnf t] computes a weak head-normal form of [t]. *)
 let whnf : ctxt -> term -> term = fun ctx t ->
   Stdlib.(steps := 0);
-  let t = unfold t in
   let u = whnf (Ctxt.to_llet ctx t) in
-  if Stdlib.(!steps = 0) then t else u
+  if Stdlib.(!steps = 0) then unfold t else u
 
 (** [simplify t] reduces simple redexes of [t]. *)
 let rec simplify : ctxt -> term -> term = fun ctx t ->

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -184,11 +184,11 @@ and tree_walk : dtree -> ctxt -> stack -> (term * stack) option =
   let vars = Array.make capacity Kind in (* dummy terms *)
   let bound = Array.make capacity TE_None in
   (* [walk tree stk cursor vars_id id_vars] where [stk] is the stack of terms
-   * to match and [cursor] the cursor indicating where to write in the [vars]
-   * array described in {!module:Terms} as the environment of the RHS during
-   * matching. [vars_id] maps the free variables contained in the term to the
-   * indexes defined during tree build, and [id_vars] is the inverse mapping
-   * of [vars_id]. *)
+     to match and [cursor] the cursor indicating where to write in the [vars]
+     array described in {!module:Terms} as the environment of the RHS during
+     matching. [vars_id] maps the free variables contained in the term to the
+     indexes defined during tree build, and [id_vars] is the inverse mapping
+     of [vars_id]. *)
   let rec walk tree stk cursor vars_id id_vars =
     let open Tree_types in
     match tree with

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -345,13 +345,13 @@ and snf : term -> term = fun t ->
 
 (** [snf ctx t] computes the strong normal form of term [t] in context
     [ctx]. *)
-let snf : ctxt -> term -> term = fun ctx t -> snf (Ctxt.llet ctx t)
+let snf : ctxt -> term -> term = fun ctx t -> snf (Ctxt.to_llet ctx t)
 
 (** [whnf t] computes a weak head-normal form of [t]. *)
 let whnf : ctxt -> term -> term = fun ctx t ->
   Stdlib.(steps := 0);
   let t = unfold t in
-  let u = whnf (Ctxt.llet ctx t) in
+  let u = whnf (Ctxt.to_llet ctx t) in
   if Stdlib.(!steps = 0) then t else u
 
 (** [simplify t] reduces simple redexes of [t]. *)

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -325,12 +325,7 @@ and tree_walk : dtree -> ctxt -> stack -> (term * stack) option =
 and snf : ctxt -> term -> term = fun ctx t ->
   let h = whnf ctx t in
   match h with
-  | Vari(x)     ->
-      begin
-        match Ctxt.def_of x ctx with
-        | None    -> h
-        | Some(t) -> snf ctx t
-      end
+  | Vari(_)     -> h
   | Type        -> h
   | Kind        -> h
   | Symb(_)     -> h

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -136,6 +136,7 @@ and eq_modulo : ctxt -> term -> term -> bool = fun ctx a b ->
     | (Kind       , _          )
     | (_          , Kind       ) -> assert false
     | (Type       , Type       ) -> eq_modulo l
+    | (Vari(x)    , Vari(y)    ) when Bindlib.eq_vars x y -> eq_modulo l
     | (Symb(s1,_) , Symb(s2,_) ) when s1 == s2 -> eq_modulo l
     | (Prod(a1,b1), Prod(a2,b2))
     | (Abst(a1,b1), Abst(a2,b2)) ->
@@ -148,7 +149,6 @@ and eq_modulo : ctxt -> term -> term -> bool = fun ctx a b ->
     | (Appl(t1,u1), Appl(t2,u2)) -> eq_modulo ((u1,u2)::(t1,t2)::l)
     | (Meta(m1,a1), Meta(m2,a2)) when m1 == m2 ->
         eq_modulo (if a1 == a2 then l else List.add_array2 a1 a2 l)
-    | (Vari(x)    , Vari(y)    ) when Bindlib.eq_vars x y -> eq_modulo l
     | (_          , _          ) -> raise Exit
   in
   let res = try eq_modulo [(a,b)]; true with Exit -> false in

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -361,11 +361,12 @@ let whnf : ctxt -> term -> term = fun ctx t ->
   if Pervasives.(!steps = 0) then t else u
 
 (** [simplify t] reduces simple redexes of [t]. *)
-let rec simplify : term -> term = fun t ->
-  match get_args (whnf [] t) with
+let rec simplify : ctxt -> term -> term = fun ctx t ->
+  match get_args (whnf ctx t) with
   | Prod(a,b), _ ->
-     let x,b = Bindlib.unbind b in
-     Prod (simplify a, Bindlib.unbox (Bindlib.bind_var x (lift (simplify b))))
+     let (x,b) = Bindlib.unbind b in
+     let b = Bindlib.bind_var x (lift (simplify ctx b)) in
+     Prod (simplify ctx a, Bindlib.unbox b)
   | h, ts -> add_args h (List.map whnf_beta ts)
 
 (** [hnf t] computes a head-normal form of the term [t]. *)

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -76,41 +76,43 @@ let whnf_beta : term -> term = fun t ->
   let u = whnf_beta t in
   if Stdlib.(!steps = 0) then unfold t else u
 
-(** [whnf t] computes a weak head normal form of the term [t]. *)
-let rec whnf : term -> term = fun t ->
+(** [whnf ctx t] computes a weak head normal form of the term [t] in context
+    [ctx]. *)
+let rec whnf : ctxt -> term -> term = fun ctx t ->
   if !log_enabled then log_eval "evaluating [%a]" pp t;
   let s = Stdlib.(!steps) in
-  let (u, stk) = whnf_stk t [] in
-  if Stdlib.(!steps) <> s then add_args u stk else unfold t
+  let (u, stk) = whnf_stk ctx t [] in
+  if Stdlib.(!steps) <> s then add_args u stk else Ctxt.unfold ctx t
 
-(** [whnf_stk t k] computes the weak head normal form of [t] applied to
-    stack [k].  Note that the normalisation is done in the sense of [whnf]. *)
-and whnf_stk : term -> stack -> term * stack = fun t stk ->
-  let st = (unfold t, stk) in
+(** [whnf_stk ctx t stk] computes the weak head normal form of [t] applied to
+    stack [stk] in context [ctx]. Note that the normalisation is done in the
+    sense of [whnf]. *)
+and whnf_stk : ctxt -> term -> stack -> term * stack = fun ctx t stk ->
+  let st = (Ctxt.unfold ctx t, stk) in
   match st with
   (* Push argument to the stack. *)
   | (Appl(f,u), stk   ) ->
-      whnf_stk f (appl_to_tref u::stk)
+      whnf_stk ctx f (appl_to_tref u::stk)
   (* Beta reduction. *)
   | (Abst(_,f), u::stk) ->
       Stdlib.incr steps;
-      whnf_stk (Bindlib.subst f u) stk
+      whnf_stk ctx (Bindlib.subst f u) stk
   (* Let unfolding *)
   | (LLet(_,t,u), stk ) ->
       Stdlib.incr steps;
-      whnf_stk (Bindlib.subst u t) stk
+      whnf_stk ctx (Bindlib.subst u t) stk
   (* Try to rewrite. *)
   | (Symb(s,_), stk   ) ->
       begin
       (* First check for symbol definition. *)
       match !(s.sym_def) with
-      | Some(t) -> Stdlib.incr steps; whnf_stk t stk
+      | Some(t) -> Stdlib.incr steps; whnf_stk ctx t stk
       | None    ->
       (* Otherwise try rewriting using decision tree. *)
-      match tree_walk !(s.sym_tree) stk with
+      match tree_walk !(s.sym_tree) ctx stk with
       (* If no rule is found, return the original term *)
       | None        -> st
-      | Some(t,stk) -> Stdlib.incr steps; whnf_stk t stk
+      | Some(t,stk) -> Stdlib.incr steps; whnf_stk ctx t stk
       end
   (* In head normal form. *)
   | (_         , _    ) -> st
@@ -125,7 +127,7 @@ and eq_modulo : ctxt -> term -> term -> bool = fun ctx a b ->
     | (a,b)::l ->
     let a = unfold a and b = unfold b in
     if a == b then eq_modulo l else
-    match (whnf a, whnf b) with
+    match (whnf ctx a, whnf ctx b) with
     | (Patt(_,_,_), _          )
     | (_          , Patt(_,_,_))
     | (TEnv(_,_)  , _          )
@@ -170,21 +172,23 @@ and eq_modulo : ctxt -> term -> term -> bool = fun ctx a b ->
     3. a {!constructor:Tree_types.TC.t.Vari} which is a simplified
        representation of a variable for trees. *)
 
-(** [tree_walk tree stk] tries to apply a rewriting rule by matching the stack
-    [stk] agains the decision tree [tree]. The resulting state of the abstract
-    machine is returned in case of success. Even if mathching fails, the stack
-    [stk] may be imperatively updated: any reduction step taken in elements of
-    the stack is preserved (this is done using {!constructor:TRef}). *)
-and tree_walk : dtree -> stack -> (term * stack) option = fun tree stk ->
+(** [tree_walk tr ctx stk] tries to apply a rewrite rule by matching the stack
+    [stk] against the decision tree [tr] in context [ctx]. The resulting state
+    of the abstract machine  is returned in case of success.  Even if matching
+    fails,  the stack [stk] may be imperatively updated since a reduction step
+    taken in elements of the stack is preserved (this is done using
+    {!constructor:Terms.term.TRef}). *)
+and tree_walk : dtree -> ctxt -> stack -> (term * stack) option =
+  fun tree ctx stk ->
   let (lazy capacity, lazy tree) = tree in
   let vars = Array.make capacity Kind in (* dummy terms *)
   let bound = Array.make capacity TE_None in
   (* [walk tree stk cursor vars_id id_vars] where [stk] is the stack of terms
-     to match and [cursor] the cursor indicating where to write in the [vars]
-     array described in {!module:Terms} as the environment of the RHS during
-     matching. [vars_id] maps the free variables contained in the term to the
-     indexes defined during tree build, and [id_vars] is the inverse mapping
-     of [vars_id]. *)
+   * to match and [cursor] the cursor indicating where to write in the [vars]
+   * array described in {!module:Terms} as the environment of the RHS during
+   * matching. [vars_id] maps the free variables contained in the term to the
+   * indexes defined during tree build, and [id_vars] is the inverse mapping
+   * of [vars_id]. *)
   let rec walk tree stk cursor vars_id id_vars =
     let open Tree_types in
     match tree with
@@ -236,7 +240,7 @@ and tree_walk : dtree -> stack -> (term * stack) option = fun tree stk ->
               if no_forbidden b
               then (bound.(i) <- TE_Some(Bindlib.unbox b); ok) else
               (* As a last resort we try matching the SNF. *)
-              let b = Bindlib.bind_mvar allowed (lift (snf vars.(i))) in
+              let b = Bindlib.bind_mvar allowed (lift (snf ctx vars.(i))) in
               if no_forbidden b
               then (bound.(i) <- TE_Some(Bindlib.unbox b); ok)
               else fail
@@ -261,7 +265,7 @@ and tree_walk : dtree -> stack -> (term * stack) option = fun tree stk ->
           Option.map_default fn None default
         else
           let s = Stdlib.(!steps) in
-          let (t, args) = whnf_stk examined [] in
+          let (t, args) = whnf_stk ctx examined [] in
           let args = if store then List.map appl_to_tref args else args in
           (* Introduce sharing on arguments *)
           if Stdlib.(!steps) <> s then
@@ -318,39 +322,40 @@ and tree_walk : dtree -> stack -> (term * stack) option = fun tree stk ->
   walk tree stk 0 VarMap.empty IntMap.empty
 
 (** [snf t] computes the strong normal form of the term [t]. *)
-and snf : term -> term = fun t ->
-  let h = whnf t in
+and snf : ctxt -> term -> term = fun ctx t ->
+  let h = whnf ctx t in
   match h with
-  | Vari(_)     -> h
+  | Vari(x)     ->
+      begin
+        match Ctxt.def_of x ctx with
+        | None    -> h
+        | Some(t) -> snf ctx t
+      end
   | Type        -> h
   | Kind        -> h
   | Symb(_)     -> h
-  | LLet(_,t,b) -> snf (Bindlib.subst b t)
+  | LLet(_,t,b) -> snf ctx (Bindlib.subst b t)
   | Prod(a,b)   ->
       let (x,b) = Bindlib.unbind b in
-      let b = snf b in
+      let b = snf ctx b in
       let b = Bindlib.unbox (Bindlib.bind_var x (lift b)) in
-      Prod(snf a, b)
+      Prod(snf ctx a, b)
   | Abst(a,b)   ->
       let (x,b) = Bindlib.unbind b in
-      let b = snf b in
+      let b = snf ctx b in
       let b = Bindlib.unbox (Bindlib.bind_var x (lift b)) in
-      Abst(snf a, b)
-  | Appl(t,u)   -> Appl(snf t, snf u)
-  | Meta(m,ts)  -> Meta(m, Array.map snf ts)
+      Abst(snf ctx a, b)
+  | Appl(t,u)   -> Appl(snf ctx t, snf ctx u)
+  | Meta(m,ts)  -> Meta(m, Array.map (snf ctx) ts)
   | Patt(_,_,_) -> assert false
   | TEnv(_,_)   -> assert false
   | Wild        -> assert false
   | TRef(_)     -> assert false
 
-(** [snf ctx t] computes the strong normal form of term [t] in context
-    [ctx]. *)
-let snf : ctxt -> term -> term = fun ctx t -> snf (Ctxt.to_llet ctx t)
-
 (** [whnf t] computes a weak head-normal form of [t]. *)
 let whnf : ctxt -> term -> term = fun ctx t ->
   Stdlib.(steps := 0);
-  let u = whnf (Ctxt.to_llet ctx t) in
+  let u = whnf ctx t in
   if Stdlib.(!steps = 0) then unfold t else u
 
 (** [simplify t] reduces simple redexes of [t]. *)
@@ -386,13 +391,14 @@ type config =
   { strategy : strategy   (** Evaluation strategy.          *)
   ; steps    : int option (** Max number of steps if given. *) }
 
-(** [eval cfg t] evaluates the term [t] according to configuration [cfg]. *)
-let eval : config -> term -> term = fun c t ->
+(** [eval cfg ctx t] evaluates the term [t] in the context [ctx] according to
+    configuration [cfg]. *)
+let eval : config -> ctxt -> term -> term = fun c ctx t ->
   match (c.strategy, c.steps) with
   | (_   , Some(0))
   | (NONE, _      ) -> t
-  | (WHNF, None   ) -> whnf [] t
-  | (SNF , None   ) -> snf [] t
-  | (HNF , None   ) -> hnf [] t
+  | (WHNF, None   ) -> whnf ctx t
+  | (SNF , None   ) -> snf ctx t
+  | (HNF , None   ) -> hnf ctx t
   (* TODO implement the rest. *)
   | (_   , Some(_)) -> wrn None "Number of steps not supported."; t

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -118,7 +118,7 @@ and whnf_stk : term -> stack -> term * stack = fun t stk ->
 (** [eq_modulo ctx a b] tests the equality of [a] and [b] modulo rewriting and
     the unfolding of variables from the context [ctx] (δ-reduction). *)
 and eq_modulo : ctxt -> term -> term -> bool = fun ctx a b ->
-  if !log_enabled then log_conv "%a[%a] == [%a]" pp_ctxt ctx pp a pp b;
+  if !log_enabled then log_conv "%a[%a] ≡ [%a]" pp_ctxt ctx pp a pp b;
   let rec eq_modulo l =
     match l with
     | []       -> ()

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -96,7 +96,7 @@ and whnf_stk : term -> stack -> term * stack = fun t stk ->
       Stdlib.incr steps;
       whnf_stk (Bindlib.subst f u) stk
   (* Let unfolding *)
-  | (LLet(t,_,u), stk ) ->
+  | (LLet(_,t,u), stk ) ->
       Stdlib.incr steps;
       whnf_stk (Bindlib.subst u t) stk
   (* Try to rewrite. *)
@@ -325,7 +325,7 @@ and snf : term -> term = fun t ->
   | Type        -> h
   | Kind        -> h
   | Symb(_)     -> h
-  | LLet(t,_,b) -> snf (Bindlib.subst b t)
+  | LLet(_,t,b) -> snf (Bindlib.subst b t)
   | Prod(a,b)   ->
       let (x,b) = Bindlib.unbind b in
       let b = snf b in

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -121,7 +121,7 @@ and whnf_stk : term -> stack -> term * stack = fun t stk ->
 (** [eq_modulo ctx a b] tests the equality of [a] and [b] modulo rewriting and
     the unfolding of variables from the context [ctx] (δ-reduction). *)
 and eq_modulo : ctxt -> term -> term -> bool = fun ctx a b ->
-  if !log_enabled then log_conv "%a[%a] == [%a]" wrap_ctxt ctx pp a pp b;
+  if !log_enabled then log_conv "%a[%a] == [%a]" pp_ctxt ctx pp a pp b;
   let rec eq_modulo l =
     match l with
     | []       -> ()

--- a/src/core/extra.ml
+++ b/src/core/extra.ml
@@ -102,24 +102,24 @@ module List =
 
     (** [filter_map f l] applies [f] to the elements of [l] and keeps the [x]
         such that [Some(x)] in [List.map f l]. *)
-    let rec filter_map : ('a -> 'b option) -> 'a list -> 'b list = fun f ->
-      function
+    let rec filter_map : ('a -> 'b option) -> 'a list -> 'b list = fun f l ->
+      match l with
       | []     -> []
       | h :: t ->
           match f h with
           | Some(x) -> x :: filter_map f t
           | None    -> filter_map f t
 
-    (** [filter_rev_map f l] is [filter_map f l] reversing the list, and being
-        tail recursive. *)
+    (** [filter_rev_map f l] is equivalent to [filter_map f (List.rev l)], but
+        it only traverses the list once and is tail-recursive. *)
     let filter_rev_map : ('a -> 'b option) -> 'a list -> 'b list = fun f ->
       let rec frm acc l =
         match l with
         | []     -> acc
         | hd::tl ->
             match f hd with
-              | Some(x) -> frm (x::acc) tl
-              | None    -> frm acc tl
+            | Some(x) -> frm (x::acc) tl
+            | None    -> frm acc tl
       in
       frm []
 

--- a/src/core/extra.ml
+++ b/src/core/extra.ml
@@ -110,6 +110,19 @@ module List =
           | Some(x) -> x :: filter_map f t
           | None    -> filter_map f t
 
+    (** [filter_rev_map f l] is [filter_map f l] reversing the list, and being
+        tail recursive. *)
+    let filter_rev_map : ('a -> 'b option) -> 'a list -> 'b list = fun f ->
+      let rec frm acc l =
+        match l with
+        | []     -> acc
+        | hd::tl ->
+            match f hd with
+              | Some(x) -> frm (x::acc) tl
+              | None    -> frm acc tl
+      in
+      frm []
+
     (** [filteri_map f l] applies [f] element wise on [l] and keeps [x] such
         that for [e] in [l], [f e = Some(x)]. *)
     let filteri_map : (int -> 'a -> 'b option) -> 'a list -> 'b list =

--- a/src/core/handle.ml
+++ b/src/core/handle.ml
@@ -23,7 +23,7 @@ let check_builtin_nat : popt -> sym StrMap.t -> string -> sym -> unit
   | "+1" ->
      let builtin = Sign.builtin pos builtins in
      let typ_0 = !((builtin "0").sym_type) in
-     let typ_s = Basics.imply typ_0 typ_0 in
+     let typ_s = let y = lift typ_0 in Bindlib.unbox (_Impl y y) in
      if not (Basics.eq [] typ_s !(sym.sym_type)) then
        fatal pos "The type of [%s] is not of the form [%a]."
          sym.sym_name pp typ_s

--- a/src/core/handle.ml
+++ b/src/core/handle.ml
@@ -22,8 +22,8 @@ let check_builtin_nat : popt -> sym StrMap.t -> string -> sym -> unit
   match s with
   | "+1" ->
      let builtin = Sign.builtin pos builtins in
-     let typ_0 = !((builtin "0").sym_type) in
-     let typ_s = let y = lift typ_0 in Bindlib.unbox (_Impl y y) in
+     let typ_0 = lift (!((builtin "0").sym_type)) in
+     let typ_s = Bindlib.unbox (_Impl typ_0 typ_0) in
      if not (Basics.eq [] typ_s !(sym.sym_type)) then
        fatal pos "The type of [%s] is not of the form [%a]."
          sym.sym_name pp typ_s

--- a/src/core/handle.ml
+++ b/src/core/handle.ml
@@ -24,7 +24,7 @@ let check_builtin_nat : popt -> sym StrMap.t -> string -> sym -> unit
      let builtin = Sign.builtin pos builtins in
      let typ_0 = !((builtin "0").sym_type) in
      let typ_s = Basics.imply typ_0 typ_0 in
-     if not (Basics.eq typ_s !(sym.sym_type)) then
+     if not (Basics.eq [] typ_s !(sym.sym_type)) then
        fatal pos "The type of [%s] is not of the form [%a]."
          sym.sym_name pp typ_s
   | _ -> ()

--- a/src/core/hrs.ml
+++ b/src/core/hrs.ml
@@ -40,7 +40,7 @@ let print_term : bool -> term pp = fun lhs ->
     | Prod(a,b)    ->
         let (x, b) = Bindlib.unbind b in
         out "pi(%a,\\%s.%a)" pp a (Bindlib.name_of x) pp b
-    | LLet(t,_,u)  -> pp oc (Bindlib.subst u t)
+    | LLet(_,t,u)  -> pp oc (Bindlib.subst u t)
   in pp
 
 (** [print_rule oc lhs rhs] outputs the rule declaration [lhs]->[rhs]

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -95,7 +95,7 @@ let rec infer : ctxt -> term -> term = fun ctx t ->
   | Appl(t,u)   ->
       (* We first infer a product type for [t]. *)
       let (a,b) =
-        let c = Eval.whnf (infer ctx t) in
+        let c = Eval.whnf ctx (infer ctx t) in
         match c with
         | Prod(a,b) -> (a,b)
         | Meta(_,ts) ->
@@ -162,7 +162,7 @@ and check : ctxt -> term -> term -> unit = fun ctx t c ->
       check ctx a Type;
       (* We (hopefully) evaluate [c] to a product, and get its body. *)
       let b =
-        let c = Eval.whnf c in
+        let c = Eval.whnf ctx c in
         match c with
         | Prod(d,b) -> conv ctx d a; b (* Domains must be convertible. *)
         | Meta(_,ts) ->

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -14,7 +14,7 @@ let constraints = Pervasives.ref []
 
 (** Function adding a constraint. *)
 let conv ctx a b =
-  if not (Basics.eq a b) then
+  if not (Basics.eq ctx a b) then
     begin
       if !log_enabled then log_infr (yel "add %a") pp_constr (ctx,a,b);
       let open Pervasives in constraints := (ctx,a,b) :: !constraints

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -111,12 +111,13 @@ let rec infer : ctxt -> term -> term = fun ctx t ->
       (* We produce the returned type. *)
       Bindlib.subst b u
 
-  (*  ctx ⊢ t ⇐ a       ctx, x := t : a ⊢ u ⇒ b
+  (*  ctx ⊢ t ⇐ a       ctx, x : a := t ⊢ u ⇒ b
      -------------------------------------------
-        ctx ⊢ let x ≔ t : a in u ⇒ subst b t     *)
+        ctx ⊢ let x : a ≔ t in u ⇒ subst b t     *)
   | LLet(t,a,u) ->
+      check ctx a Type;
       check ctx t a;
-      (* Unbind [u] and enrich context with [x:=t:a] *)
+      (* Unbind [u] and enrich context with [x: a ≔ t] *)
       let (x,u,ctx') = Ctxt.unbind ctx a (Some(t)) u in
       let b = infer ctx' u in
       (* Build back the term *)

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -114,7 +114,7 @@ let rec infer : ctxt -> term -> term = fun ctx t ->
   (*  ctx ⊢ t ⇐ a       ctx, x : a := t ⊢ u ⇒ b
      -------------------------------------------
         ctx ⊢ let x : a ≔ t in u ⇒ subst b t     *)
-  | LLet(t,a,u) ->
+  | LLet(a,t,u) ->
       check ctx a Type;
       check ctx t a;
       (* Unbind [u] and enrich context with [x: a ≔ t] *)

--- a/src/core/menhir_parser.mly
+++ b/src/core/menhir_parser.mly
@@ -56,8 +56,8 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
     let nb_args = List.length args in
     begin
       match h.elt with
-      | P_Appl(_,_)     -> assert false (* Cannot happen. *)
-      | P_Iden(x,_)     ->
+      | P_Appl(_,_)       -> assert false (* Cannot happen. *)
+      | P_Iden(x,_)       ->
           let (p,x) = x.elt in
           if p = [] && is_pat_var env x then
             begin
@@ -66,10 +66,10 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
                 if nb_args > n then Hashtbl.replace arity x nb_args
               with Not_found -> Hashtbl.add arity x nb_args
             end
-      | P_Wild          -> ()
-      | P_Type          -> fatal h.pos "Type in legacy pattern."
-      | P_Prod(_,_)     -> fatal h.pos "Product in legacy pattern."
-      | P_Abst(xs,t)    ->
+      | P_Wild            -> ()
+      | P_Type            -> fatal h.pos "Type in legacy pattern."
+      | P_Prod(_,_)       -> fatal h.pos "Product in legacy pattern."
+      | P_Abst(xs,t)      ->
           begin
             match xs with
             | [(_       ,Some(a),_)] ->
@@ -80,15 +80,15 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
                 compute_arities env t
             | _                      -> assert false
           end
-      | P_Impl(_,_)     -> fatal h.pos "Implication in legacy pattern."
-      | P_LLet(_,_,_,_) -> fatal h.pos "Let expression in legacy rule."
-      | P_Meta(_,_)     -> assert false
-      | P_Patt(_,_)     -> assert false
-      | P_NLit(_)       -> assert false
-      | P_UnaO(_,_)     -> assert false
-      | P_BinO(_,_,_)   -> assert false
-      | P_Wrap(_)       -> assert false
-      | P_Expl(_)       -> assert false
+      | P_Impl(_,_)       -> fatal h.pos "Implication in legacy pattern."
+      | P_LLet(_,_,_,_,_) -> fatal h.pos "Let expression in legacy rule."
+      | P_Meta(_,_)       -> assert false
+      | P_Patt(_,_)       -> assert false
+      | P_NLit(_)         -> assert false
+      | P_UnaO(_,_)       -> assert false
+      | P_BinO(_,_,_)     -> assert false
+      | P_Wrap(_)         -> assert false
+      | P_Expl(_)         -> assert false
     end;
     List.iter (fun (_,t) -> compute_arities env t) args
   in
@@ -147,8 +147,8 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
     match t.elt with
     | P_Iden(_)
     | P_Type
-    | P_Wild          -> t
-    | P_Prod(xs,b)    ->
+    | P_Wild            -> t
+    | P_Prod(xs,b)      ->
         let (x,a) =
           match xs with
           | [([Some x],Some(a),_)] -> (x, build env a)
@@ -156,8 +156,8 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
         in
         let b = build (x.elt::env) b in
         Pos.make t.pos (P_Prod([([Some x],Some(a),false)], b))
-    | P_Impl(a,b)     -> Pos.make t.pos (P_Impl(build env a, build env b))
-    | P_Abst(xs,u)    ->
+    | P_Impl(a,b)       -> Pos.make t.pos (P_Impl(build env a, build env b))
+    | P_Abst(xs,u)      ->
         let (x,a) =
           match xs with
           | [([x],ao,_)] -> (x, Option.map (build env) ao)
@@ -169,15 +169,15 @@ let translate_old_rule : old_p_rule -> p_rule = fun r ->
           | None    -> build env u
         in
         Pos.make t.pos (P_Abst([([x],a,false)], u))
-    | P_Appl(t1,t2)   -> Pos.make t.pos (P_Appl(build env t1, build env t2))
-    | P_Meta(_,_)     -> fatal t.pos "Invalid legacy rule syntax."
-    | P_Patt(_,_)     -> fatal h.pos "Pattern in legacy rule."
-    | P_LLet(_,_,_,_) -> fatal h.pos "Let expression in legacy rule."
-    | P_NLit(_)       -> fatal h.pos "Nat literal in legacy rule."
-    | P_UnaO(_,_)     -> fatal h.pos "Unary operator in legacy rule."
-    | P_BinO(_,_,_)   -> fatal h.pos "Binary operator in legacy rule."
-    | P_Wrap(_)       -> fatal h.pos "Wrapping constructor in legacy rule."
-    | P_Expl(_)       -> fatal h.pos "Explicit argument in legacy rule."
+    | P_Appl(t1,t2)     -> Pos.make t.pos (P_Appl(build env t1, build env t2))
+    | P_Meta(_,_)       -> fatal t.pos "Invalid legacy rule syntax."
+    | P_Patt(_,_)       -> fatal h.pos "Pattern in legacy rule."
+    | P_LLet(_,_,_,_,_) -> fatal h.pos "Let expression in legacy rule."
+    | P_NLit(_)         -> fatal h.pos "Nat literal in legacy rule."
+    | P_UnaO(_,_)       -> fatal h.pos "Unary operator in legacy rule."
+    | P_BinO(_,_,_)     -> fatal h.pos "Binary operator in legacy rule."
+    | P_Wrap(_)         -> fatal h.pos "Wrapping constructor in legacy rule."
+    | P_Expl(_)         -> fatal h.pos "Explicit argument in legacy rule."
   in
   (* NOTE the computation order is important for setting arities properly. *)
   let lhs = build [] lhs in

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -377,7 +377,7 @@ let parser term @(p : prio) =
   (* Local let. *)
   | _let_ x:ident a:arg* b:{":" (term PFunc)}? "≔" t:(term PFunc) _in_
       u:(term PFunc)
-      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,b,u))
+      when p >= PFunc -> in_pos _loc (P_LLet(x,a,b,t,u))
   (* Natural number literal. *)
   | n:nat_lit
       when p >= PAtom -> in_pos _loc (P_NLit(n))

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -375,11 +375,9 @@ let parser term @(p : prio) =
   | "λ" xs:arg_ident+ ":" a:(term PFunc) "," t:(term PFunc)
       when p >= PFunc -> in_pos _loc (P_Abst([xs,Some(a),false],t))
   (* Local let. *)
-  | _let_ x:ident a:arg* "≔" t:(term PFunc) _in_ u:(term PFunc)
-      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,None,u))
-  | _let_ x:ident a:arg* ":" b:(term PFunc) "≔" t:(term PFunc) _in_
+  | _let_ x:ident a:arg* b:{":" (term PFunc)}? "≔" t:(term PFunc) _in_
       u:(term PFunc)
-      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,Some(b),u))
+      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,b,u))
   (* Natural number literal. *)
   | n:nat_lit
       when p >= PAtom -> in_pos _loc (P_NLit(n))

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -376,7 +376,10 @@ let parser term @(p : prio) =
       when p >= PFunc -> in_pos _loc (P_Abst([xs,Some(a),false],t))
   (* Local let. *)
   | _let_ x:ident a:arg* "≔" t:(term PFunc) _in_ u:(term PFunc)
-      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,u))
+      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,None,u))
+  | _let_ x:ident a:arg* ":" b:(term PFunc) "≔" t:(term PFunc) _in_
+      u:(term PFunc)
+      when p >= PFunc -> in_pos _loc (P_LLet(x,a,t,Some(b),u))
   (* Natural number literal. *)
   | n:nat_lit
       when p >= PAtom -> in_pos _loc (P_NLit(n))

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -107,8 +107,8 @@ let declared_id = Prefix.grammar declared_ids
 (** The following should not appear as substrings of binary operators, as they
     would introduce ambiguity in the parsing. *)
 let forbidden_in_ops =
-  [ "("; ")"; "."; "λ"; "∀"; "&"; "["; "]"; "{"; "}"; "?"; ":"; "→"; "⇒"
-  ; "@"; ","; ";"; "\""; "\'"; "≔"; "//"; " "; "\r"; "\n"; "\t"; "\b" ]
+  [ "("; ")"; "."; "λ"; "∀"; "&"; "["; "]"; "{"; "}"; "?"; ":"; "→"; "⊢"
+  ; "⇒"; "@"; ","; ";"; "\""; "\'"; "≔"; "//"; " "; "\r"; "\n"; "\t"; "\b" ]
   @ List.init 10 string_of_int
 
 (** [get_ops loc p] loads the unary and binary operators associated to  module
@@ -480,6 +480,16 @@ let parser query =
       Pos.in_pos _loc (P_query_flag(s, b))
   | mf:assert_must_fail a:assertion ->
       Pos.in_pos _loc (P_query_assert(mf,a))
+  | mf:assert_must_fail ps:arg* "⊢" t:term "≡" u:term ->
+      let ps_t = Pos.in_pos _loc (P_Abst(ps,t)) in
+      let ps_u = Pos.in_pos _loc (P_Abst(ps,u)) in
+      let assert_conv = P_assert_conv(ps_t,ps_u) in
+      Pos.in_pos _loc (P_query_assert(mf,assert_conv))
+  | mf:assert_must_fail ps:arg* "⊢" t:term ":" u:term ->
+      let ps_t = Pos.in_pos _loc (P_Abst(ps,t)) in
+      let ps_u = Pos.in_pos _loc (P_Prod(ps,u)) in
+      let assert_typing = P_assert_typing(ps_t,ps_u) in
+      Pos.in_pos _loc (P_query_assert(mf,assert_typing))
   | _type_ t:term ->
       let c = Eval.{strategy = NONE; steps = None} in
       Pos.in_pos _loc (P_query_infer(t,c))

--- a/src/core/pretty.ml
+++ b/src/core/pretty.ml
@@ -55,43 +55,49 @@ let rec pp_p_term : p_term pp = fun oc t ->
     let pp_appl = pp PAppl in
     let pp_func = pp PFunc in
     match (t.elt, p) with
-    | (P_Type            , _    ) -> out "TYPE"
-    | (P_Iden(qid, false), _    ) -> out "%a" pp_qident qid
-    | (P_Iden(qid, true ), _    ) -> out "@%a" pp_qident qid
-    | (P_Wild            , _    ) -> out "_"
-    | (P_Meta(x,ar)      , _    ) -> out "?%a%a" pp_ident x pp_env ar
-    | (P_Patt(None   ,ar), _    ) -> out "&_%a" pp_env ar
-    | (P_Patt(Some(x),ar), _    ) -> out "&%a%a" pp_ident x pp_env ar
-    | (P_Appl(t,u)       , PAppl)
-    | (P_Appl(t,u)       , PFunc) -> out "%a@ %a" pp_appl t pp_atom u
-    | (P_Impl(a,b)       , PFunc) -> out "%a@ ⇒ %a" pp_appl a pp_func b
-    | (P_Abst(args,t)    , PFunc) -> out "λ%a,@ %a" pp_p_args args pp_func t
-    | (P_Prod(args,b)    , PFunc) -> out "∀%a,@ %a" pp_p_args args pp_func b
-    | (P_LLet(x,args,t,u), PFunc) ->
-        out "@[<hov 2>let %a%a = %a@]@ in@ %a"
-          pp_ident x pp_p_args args pp_func t pp_func u
-    | (P_NLit(i)         , _    ) -> out "%i" i
-    | (P_UnaO(u,t)       , _    ) ->
+    | (P_Type              , _    ) -> out "TYPE"
+    | (P_Iden(qid, false)  , _    ) -> out "%a" pp_qident qid
+    | (P_Iden(qid, true )  , _    ) -> out "@%a" pp_qident qid
+    | (P_Wild              , _    ) -> out "_"
+    | (P_Meta(x,ar)        , _    ) -> out "?%a%a" pp_ident x pp_env ar
+    | (P_Patt(None   ,ar)  , _    ) -> out "&_%a" pp_env ar
+    | (P_Patt(Some(x),ar)  , _    ) -> out "&%a%a" pp_ident x pp_env ar
+    | (P_Appl(t,u)         , PAppl)
+    | (P_Appl(t,u)         , PFunc) -> out "%a@ %a" pp_appl t pp_atom u
+    | (P_Impl(a,b)         , PFunc) -> out "%a@ ⇒ %a" pp_appl a pp_func b
+    | (P_Abst(args,t)      , PFunc) -> out "λ%a,@ %a" pp_p_args args pp_func t
+    | (P_Prod(args,b)      , PFunc) -> out "∀%a,@ %a" pp_p_args args pp_func b
+    | (P_LLet(x,args,t,a,u), PFunc) ->
+        out "@[<hov 2>let %a%a%a ≔@ %a@]@ in@ %a"
+          pp_ident x pp_p_args args pp_p_annot a pp_func t pp_func u
+    | (P_NLit(i)           , _    ) -> out "%i" i
+    | (P_UnaO(u,t)         , _    ) ->
         let (u, _, _) = u in
         out "(%s %a)" u pp_atom t
-    | (P_BinO(t,b,u)     , _    ) ->
+    | (P_BinO(t,b,u)       , _    ) ->
         let (b, _, _, _) = b in
         out "(%a %s %a)" pp_atom t b pp_atom u
     (* We print minimal parentheses, and ignore the [Wrap] constructor. *)
-    | (P_Wrap(t)         , _    ) -> out "%a" (pp p) t
-    | (P_Expl(t)         , _    ) -> out "{%a}" pp_func t
-    | (_                 , _    ) -> out "(%a)" pp_func t
+    | (P_Wrap(t)           , _    ) -> out "%a" (pp p) t
+    | (P_Expl(t)           , _    ) -> out "{%a}" pp_func t
+    | (_                   , _    ) -> out "(%a)" pp_func t
   in
   let rec pp_toplevel _ t =
     match t.elt with
-    | P_Abst(args,t)     -> out "λ%a,@ %a" pp_p_args args pp_toplevel t
-    | P_Prod(args,b)     -> out "∀%a,@ %a" pp_p_args args pp_toplevel b
-    | P_Impl(a,b)        -> out "%a@ ⇒ %a" (pp PAppl) a pp_toplevel b
-    | P_LLet(x,args,t,u) -> out "@[<hov 2>let %a%a =@ %a@]@ in@ %a" pp_ident x
-                              pp_p_args args pp_toplevel t pp_toplevel u
-    | _                  -> out "%a" (pp PFunc) t
+    | P_Abst(args,t)       -> out "λ%a,@ %a" pp_p_args args pp_toplevel t
+    | P_Prod(args,b)       -> out "∀%a,@ %a" pp_p_args args pp_toplevel b
+    | P_Impl(a,b)          -> out "%a@ ⇒ %a" (pp PAppl) a pp_toplevel b
+    | P_LLet(x,args,t,a,u) ->
+        out "@[<hov 2>let %a%a%a ≔@ %a@]@ in@ %a" pp_ident x
+          pp_p_args args pp_p_annot a pp_toplevel t pp_toplevel u
+    | _                    -> out "%a" (pp PFunc) t
   in
   pp_toplevel oc t
+
+and pp_p_annot : p_type option pp = fun oc a ->
+  match a with
+  | Some(a) -> Format.fprintf oc " :@ %a" pp_p_term a
+  | None    -> ()
 
 and pp_p_arg : p_arg pp = fun oc (ids,ao,b) ->
   let pp_ids = List.pp pp_arg_ident " " in

--- a/src/core/pretty.ml
+++ b/src/core/pretty.ml
@@ -67,7 +67,7 @@ let rec pp_p_term : p_term pp = fun oc t ->
     | (P_Impl(a,b)         , PFunc) -> out "%a@ ⇒ %a" pp_appl a pp_func b
     | (P_Abst(args,t)      , PFunc) -> out "λ%a,@ %a" pp_p_args args pp_func t
     | (P_Prod(args,b)      , PFunc) -> out "∀%a,@ %a" pp_p_args args pp_func b
-    | (P_LLet(x,args,t,a,u), PFunc) ->
+    | (P_LLet(x,args,a,t,u), PFunc) ->
         out "@[<hov 2>let %a%a%a ≔@ %a@]@ in@ %a"
           pp_ident x pp_p_args args pp_p_annot a pp_func t pp_func u
     | (P_NLit(i)           , _    ) -> out "%i" i
@@ -87,7 +87,7 @@ let rec pp_p_term : p_term pp = fun oc t ->
     | P_Abst(args,t)       -> out "λ%a,@ %a" pp_p_args args pp_toplevel t
     | P_Prod(args,b)       -> out "∀%a,@ %a" pp_p_args args pp_toplevel b
     | P_Impl(a,b)          -> out "%a@ ⇒ %a" (pp PAppl) a pp_toplevel b
-    | P_LLet(x,args,t,a,u) ->
+    | P_LLet(x,args,a,t,u) ->
         out "@[<hov 2>let %a%a%a ≔@ %a@]@ in@ %a" pp_ident x
           pp_p_args args pp_p_annot a pp_toplevel t pp_toplevel u
     | _                    -> out "%a" (pp PFunc) t

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -135,7 +135,7 @@ and pp_term : term pp = fun oc t ->
         else
           out oc "%a ⇒ %a" (pp `Appl) a (pp `Func) c;
         if wrap then out oc ")"
-    | LLet(t,a,u) ->
+    | LLet(a,t,u) ->
         if wrap then out oc "(";
         let x, u = Bindlib.unbind u in
         out oc "let %a" pp_tvar x;

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -155,23 +155,22 @@ let pp_rule : (sym * pp_hint * rule) pp = fun oc (s,h,r) ->
   let (_, rhs) = Bindlib.unmbind r.rhs in
   Format.fprintf oc "%a → %a" pp lhs pp rhs
 
-(** [pp oc ctx] prints the context [ctx] to the channel [oc]. *)
-let pp_ctxt : ctxt pp = fun oc ctx ->
-  let pp_e oc (x,a,t) =
-    match t with
-    | None    -> Format.fprintf oc "%a:%a" pp_tvar x pp a
-    | Some(t) -> Format.fprintf oc "%a:%a ≔ %a" pp_tvar x pp a pp t
-  in
-  if ctx = [] then Format.pp_print_string oc "∅"
-  else List.pp pp_e ", " oc (List.rev ctx)
-
-(** [wrap_ctxt oc ctx] displays context [ctx] if {!val:print_contexts} is
+(** [pp_ctxt oc ctx] displays context [ctx] if {!val:print_contexts} is
     true, with [ ⊢ ] after; and nothing otherwise. *)
-let wrap_ctxt : ctxt pp = fun oc ctx ->
+let pp_ctxt : ctxt pp = fun oc ctx ->
+  let pp_ctxt : ctxt pp = fun oc ctx ->
+    let pp_e oc (x,a,t) =
+      match t with
+      | None    -> Format.fprintf oc "%a:%a" pp_tvar x pp a
+      | Some(t) -> Format.fprintf oc "%a:%a ≔ %a" pp_tvar x pp a pp t
+    in
+    if ctx = [] then Format.pp_print_string oc "∅"
+    else List.pp pp_e ", " oc (List.rev ctx)
+  in
   let out = if !print_contexts then Format.fprintf else Format.ifprintf in
   out oc "%a ⊢ " pp_ctxt ctx
 
 (** [pp_constr oc (t,u)] prints the unification constraints [(t,u)] to the
     output channel [oc]. *)
 let pp_constr : (ctxt * term * term) pp = fun oc (ctx, t, u) ->
-  Format.fprintf oc "%a%a ≡ %a" wrap_ctxt ctx pp t pp u
+  Format.fprintf oc "%a%a ≡ %a" pp_ctxt ctx pp t pp u

--- a/src/core/proof.ml
+++ b/src/core/proof.ml
@@ -39,7 +39,7 @@ module Goal :
 
     let get_type : t -> Env.t * term = fun g -> (g.goal_hyps, g.goal_type)
 
-    let simpl : t -> t = fun g -> {g with goal_type = Eval.snf g.goal_type}
+    let simpl : t -> t = fun g -> {g with goal_type = Eval.snf [] g.goal_type}
   end
 
 (** Representation of the proof state of a theorem. *)

--- a/src/core/proof.ml
+++ b/src/core/proof.ml
@@ -80,7 +80,7 @@ let pp_goals : _ pp = fun oc gl ->
     let (hyps, _) = Goal.get_type g in
     if hyps <> [] then
       begin
-        let print_hyp (s,(_,_,t)) =
+        let print_hyp (s,(_,t,_)) =
           Format.fprintf oc "   %s : %a\n" s pp (Bindlib.unbox t)
         in
         List.iter print_hyp (List.rev hyps);

--- a/src/core/proof.ml
+++ b/src/core/proof.ml
@@ -32,14 +32,15 @@ module Goal :
     let of_meta : meta -> t = fun m ->
       let (goal_hyps, goal_type) =
         Env.of_prod_arity m.meta_arity !(m.meta_type) in
-      let goal_type = Eval.simplify goal_type in
+      let goal_type = Eval.simplify (Env.to_ctxt goal_hyps) goal_type in
       {goal_meta = m; goal_hyps; goal_type}
 
     let get_meta : t -> meta = fun g -> g.goal_meta
 
     let get_type : t -> Env.t * term = fun g -> (g.goal_hyps, g.goal_type)
 
-    let simpl : t -> t = fun g -> {g with goal_type = Eval.snf [] g.goal_type}
+    let simpl : t -> t = fun g ->
+      {g with goal_type = Eval.snf (Env.to_ctxt g.goal_hyps) g.goal_type}
   end
 
 (** Representation of the proof state of a theorem. *)

--- a/src/core/proof.ml
+++ b/src/core/proof.ml
@@ -80,7 +80,7 @@ let pp_goals : _ pp = fun oc gl ->
     let (hyps, _) = Goal.get_type g in
     if hyps <> [] then
       begin
-        let print_hyp (s,(_,t)) =
+        let print_hyp (s,(_,_,t)) =
           Format.fprintf oc "   %s : %a\n" s pp (Bindlib.unbox t)
         in
         List.iter print_hyp (List.rev hyps);

--- a/src/core/queries.ml
+++ b/src/core/queries.ml
@@ -35,11 +35,7 @@ let handle_query : sig_state -> Proof.t option -> p_query -> unit =
                 | None -> fatal q.pos "Infered types are not convertible."
                 | Some [] -> Eval.eq_modulo [] t u
                 | Some cs ->
-                    let fn (c,t,u) =
-                      fatal_msg "Cannot solve %a[%a] ≡ [%a].\n"
-                        wrap_ctxt c pp t pp u
-                    in
-                    List.iter fn cs;
+                    List.iter (fatal_msg "Cannot solve %a.\n" pp_constr) cs;
                     fatal q.pos "Infered types are not convertible."
               end
           | (None   , _      ) ->

--- a/src/core/queries.ml
+++ b/src/core/queries.ml
@@ -29,9 +29,9 @@ let handle_query : sig_state -> Proof.t option -> p_query -> unit =
           let infer = Typing.infer ss.builtins (Env.to_ctxt env) in
           match (infer t, infer u) with
           | (Some(a), Some(b)) ->
+              let pb = { no_problems with to_solve = [[], a, b] } in
               begin
-                match solve ss.builtins true
-                        { no_problems with to_solve = [[],a,b] } with
+                match solve ss.builtins true pb with
                 | None -> fatal q.pos "Infered types are not convertible."
                 | Some [] -> Eval.eq_modulo [] t u
                 | Some cs ->

--- a/src/core/queries.ml
+++ b/src/core/queries.ml
@@ -65,7 +65,7 @@ let handle_query : sig_state -> Proof.t option -> p_query -> unit =
       let t = scope pt in
       let a =
         match Typing.infer ss.builtins (Env.to_ctxt env) t with
-        | Some(a) -> Eval.eval cfg a
+        | Some(a) -> Eval.eval cfg [] a
         | None    -> fatal pt.pos "Cannot infer the type of [%a]." pp t
       in
       out 3 "(infr) %a : %a\n" pp t pp a
@@ -74,7 +74,7 @@ let handle_query : sig_state -> Proof.t option -> p_query -> unit =
       let t = scope pt in
       let v =
         match Typing.infer ss.builtins (Env.to_ctxt env) t with
-        | Some(_) -> Eval.eval cfg t
+        | Some(_) -> Eval.eval cfg [] t
         | None    -> fatal pt.pos "Cannot infer the type of [%a]." pp t
       in
       out 3 "(comp) %a\n" pp v

--- a/src/core/rewrite.ml
+++ b/src/core/rewrite.ml
@@ -85,7 +85,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
        and y = Bindlib.new_var mkfree "y" in
        let ta = Appl (symb symb_T, Vari a) in
        let c = [(y, ta, None); (x, ta, None); (a, term_U, None)] in
-       let (eq_type, _) = Ctxt.prod c term_Prop in
+       let (eq_type, _) = Ctxt.to_prod c term_Prop in
        if not (Basics.eq [] eq_type !(sym.sym_type)) then
          fatal pos "The type of [%s] is not of the form [%a]"
            sym.sym_name pp eq_type
@@ -103,7 +103,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
        and x = Bindlib.new_var mkfree "x" in
        let c = [(x, Appl(symb symb_T, Vari a), None); (a, term_U, None)] in
        let t = Basics.add_args (symb symb_eq) [Vari a; Vari x; Vari x] in
-       let (refl_type, _) = Ctxt.prod c (Appl (symb symb_P, t)) in
+       let (refl_type, _) = Ctxt.to_prod c (Appl (symb symb_P, t)) in
        if not (Basics.eq [] refl_type !(sym.sym_type))
        then fatal pos "The type of [%s] is not of the form [%a]."
               sym.sym_name pp refl_type
@@ -129,7 +129,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
        and py = Bindlib.new_var mkfree "py"
        and z = Bindlib.new_var mkfree "z" in
        let ta = Appl (symb symb_T, Vari a) in
-       let (typ_p, _) = Ctxt.prod [(z, ta, None)] term_Prop in
+       let (typ_p, _) = Ctxt.to_prod [(z, ta, None)] term_Prop in
        let eqaxy = Basics.add_args (symb symb_eq) [Vari a; Vari x; Vari y] in
        let p_of y = Appl (symb symb_P, Appl (Vari p, Vari y)) in
        let c =
@@ -140,7 +140,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
          ;(x , ta                      , None)
          ;(a , term_U                  , None)]
        in
-       let (eqind_type, _) = Ctxt.prod c (p_of x) in
+       let (eqind_type, _) = Ctxt.to_prod c (p_of x) in
        if not (Basics.eq [] eqind_type !(sym.sym_type))
        then fatal pos "The type of [%s] is not of the form [%a]."
               sym.sym_name pp eqind_type

--- a/src/core/rewrite.ml
+++ b/src/core/rewrite.ml
@@ -59,7 +59,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
   | "T" | "P" ->
      begin
        let exception Invalid_type in
-       try match Eval.whnf !(sym.sym_type) with
+       try match Eval.whnf [] !(sym.sym_type) with
            | Prod (_, b) ->
               let _, b = Bindlib.unbind b in
               if b <> Type then raise Invalid_type
@@ -181,7 +181,7 @@ let rec add_refs : term -> term = fun t ->
     products. These variables may appear free in the returned term. *)
 let break_prod : term -> term * tvar array = fun a ->
   let rec aux : term -> tvar list -> term * tvar array = fun a vs ->
-    match Eval.whnf a with
+    match Eval.whnf [] a with
     | Prod(_,b) -> let (v,b) = Bindlib.unbind b in aux b (v::vs)
     | a         -> (a, Array.of_list (List.rev vs))
   in aux a []
@@ -637,7 +637,7 @@ let reflexivity : popt -> Proof.t -> term = fun pos ps ->
   (* Get the type of the focused goal. *)
   let _, g_type = Proof.focus_goal pos ps in
   (* Check that the type of [g] is of the form “P (eq a t t)”. *)
-  let (a, l, r)  = get_eq_data pos cfg (Eval.whnf g_type) in
+  let (a, l, r)  = get_eq_data pos cfg (Eval.whnf [] g_type) in
   if not (Eval.eq_modulo [] l r) then fatal pos "Cannot apply reflexivity.";
   (* Build the witness. *)
   add_args (symb cfg.symb_refl) [a; l]

--- a/src/core/rewrite.ml
+++ b/src/core/rewrite.ml
@@ -86,7 +86,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
        let ta = Appl (symb symb_T, Vari a) in
        let c = [(y, ta, None); (x, ta, None); (a, term_U, None)] in
        let (eq_type, _) = Ctxt.prod c term_Prop in
-       if not (Basics.eq eq_type !(sym.sym_type)) then
+       if not (Basics.eq [] eq_type !(sym.sym_type)) then
          fatal pos "The type of [%s] is not of the form [%a]"
            sym.sym_name pp eq_type
      end
@@ -104,7 +104,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
        let c = [(x, Appl(symb symb_T, Vari a), None); (a, term_U, None)] in
        let t = Basics.add_args (symb symb_eq) [Vari a; Vari x; Vari x] in
        let (refl_type, _) = Ctxt.prod c (Appl (symb symb_P, t)) in
-       if not (Basics.eq refl_type !(sym.sym_type))
+       if not (Basics.eq [] refl_type !(sym.sym_type))
        then fatal pos "The type of [%s] is not of the form [%a]."
               sym.sym_name pp refl_type
      end
@@ -141,7 +141,7 @@ let check_builtin : popt -> sym StrMap.t -> string -> sym -> unit
          ;(a , term_U                  , None)]
        in
        let (eqind_type, _) = Ctxt.prod c (p_of x) in
-       if not (Basics.eq eqind_type !(sym.sym_type))
+       if not (Basics.eq [] eqind_type !(sym.sym_type))
        then fatal pos "The type of [%s] is not of the form [%a]."
               sym.sym_name pp eqind_type
      end
@@ -194,7 +194,7 @@ let break_prod : term -> term * tvar array = fun a ->
 let match_pattern : to_subst -> term -> term array option = fun (xs,p) t ->
   let ts = Array.map (fun _ -> TRef(ref None)) xs in
   let p = Bindlib.msubst (Bindlib.unbox (Bindlib.bind_mvar xs (lift p))) ts in
-  if Basics.eq p t then Some(Array.map unfold ts) else None
+  if Basics.eq [] p t then Some(Array.map unfold ts) else None
 
 (** [find_subst t (xs,p)] is given a term [t] and a pattern [p] (with “pattern
     variables” of [xs]),  and it finds the first instance of (a term matching)
@@ -227,7 +227,7 @@ let find_subst : term -> to_subst -> term array option = fun t (xs,p) ->
 let make_pat : term -> term -> bool = fun t p ->
   let time = Time.save () in
   let rec make_pat_aux : term -> bool = fun t ->
-    if Basics.eq t p then true else
+    if Basics.eq [] t p then true else
       begin
         Time.restore time;
         match unfold t with
@@ -247,7 +247,7 @@ let make_pat : term -> term -> bool = fun t p ->
 let bind_match : term -> term -> tbinder =  fun p t ->
   let x = Bindlib.new_var mkfree "X" in
   let rec lift_subst : term -> tbox = fun t ->
-    if Basics.eq p t then _Vari x else
+    if Basics.eq [] p t then _Vari x else
     match unfold t with
     | Vari(y)     -> _Vari y
     | Type        -> _Type

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -269,6 +269,8 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
           (cons a (Bindlib.bind_var v t), Env.add v a None env)
     in
     aux env xs
+  (* scope let-binding of the form [let f xs : a ≔ t in u] in environment
+   * [env]. *)
   and scope_let env f xs t a u =
     (* We start by transforming [let f x y : a ≔ t in u] in
      * [let f : a ≔ λx y, t in u] *)
@@ -278,7 +280,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
     let ty =
       (* Add the type annotation to the type of binder, that is,
        * [∀(x: ?) (y: ?[x]), a] *)
-      match a with Some(a) -> let a = scope env a in lift (Env.to_prod fenv a)
+      match a with Some(a) -> Env.to_prodbox fenv (scope env a)
                  | None    -> scope_domain env None
     in
     (* Final scoping can be seen as scoping a binder [let f, u] *)

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -373,8 +373,8 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
         fatal t.pos "Dependent products are not allowed in a pattern."
     | (P_Prod(xs,b)    , _                  ) ->
         fst (scope_binder _Prod env xs b)
-    | (P_LLet(x,xs,t,a,u), M_Term(_)        )
-    | (P_LLet(x,xs,t,a,u), M_RHS(_)         ) ->
+    | (P_LLet(x,xs,a,t,u), M_Term(_)        )
+    | (P_LLet(x,xs,a,t,u), M_RHS(_)         ) ->
         let a =
           let a = Option.get (Pos.none P_Wild) a in
           scope env (if xs = [] then a else Pos.none (P_Prod(xs, a)))
@@ -443,7 +443,7 @@ let patt_vars : p_term -> (string * int) list * string list =
     | P_Impl(a,b)        -> patt_vars (patt_vars acc a) b
     | P_Abst(xs,t)       -> patt_vars (arg_patt_vars acc xs) t
     | P_Prod(xs,b)       -> patt_vars (arg_patt_vars acc xs) b
-    | P_LLet(_,xs,t,a,u) ->
+    | P_LLet(_,xs,a,t,u) ->
         let pvs = patt_vars (patt_vars (arg_patt_vars acc xs) t) u in
         begin
           match a with

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -384,7 +384,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
         let u = scope (Env.add v a (Some(t)) env) u in
         if not (Bindlib.occur v u) then
           wrn x.pos "Useless let-binding ([%s] not bound)." x.elt;
-        _LLet t a (Bindlib.bind_var v u)
+        _LLet a t (Bindlib.bind_var v u)
     | (P_LLet(_)       , M_LHS(_)           ) ->
         fatal t.pos "Let-bindings are not allowed in a LHS."
     | (P_LLet(_)       , M_Patt             ) ->

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -262,7 +262,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
       | (Some x::l,d,i)::xs ->
           let v = Bindlib.new_var mkfree x.elt in
           let a = scope_domain env d in
-          let t = aux ((x.elt,(v,a)) :: env) ((l,d,i) :: xs) in
+          let t = aux ((x.elt,(v,is_let,a)) :: env) ((l,d,i) :: xs) in
           if x.elt.[0] <> '_' && not (Bindlib.occur v t) then
             wrn x.pos
               (if is_let then "Useless let-binding (variable [%s] not bound)."
@@ -531,19 +531,19 @@ let scope_rw_patt : sig_state ->  env -> p_rw_patt loc -> Rewrite.rw_patt =
   | P_rw_InTerm(t)             -> RW_InTerm(scope_pattern ss env t)
   | P_rw_InIdInTerm(x,t)       ->
       let v = Bindlib.new_var mkfree x.elt in
-      let t = scope_pattern ss ((x.elt,(v, _Kind))::env) t in
+      let t = scope_pattern ss ((x.elt,(v, false, _Kind))::env) t in
       RW_InIdInTerm(Bindlib.unbox (Bindlib.bind_var v (lift t)))
   | P_rw_IdInTerm(x,t)         ->
       let v = Bindlib.new_var mkfree x.elt in
-      let t = scope_pattern ss ((x.elt,(v, _Kind))::env) t in
+      let t = scope_pattern ss ((x.elt,(v, false, _Kind))::env) t in
       RW_IdInTerm(Bindlib.unbox (Bindlib.bind_var v (lift t)))
   | P_rw_TermInIdInTerm(u,x,t) ->
       let u = scope_pattern ss env u in
       let v = Bindlib.new_var mkfree x.elt in
-      let t = scope_pattern ss ((x.elt,(v, _Kind))::env) t in
+      let t = scope_pattern ss ((x.elt,(v, false, _Kind))::env) t in
       RW_TermInIdInTerm(u, Bindlib.unbox (Bindlib.bind_var v (lift t)))
   | P_rw_TermAsIdInTerm(u,x,t) ->
       let u = scope_pattern ss env u in
       let v = Bindlib.new_var mkfree x.elt in
-      let t = scope_pattern ss ((x.elt,(v, _Kind))::env) t in
+      let t = scope_pattern ss ((x.elt,(v, false, _Kind))::env) t in
       RW_TermAsIdInTerm(u, Bindlib.unbox (Bindlib.bind_var v (lift t)))

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -84,7 +84,7 @@ let link : t -> unit = fun sign ->
     | Symb(s,h)   -> Symb(link_symb s, h)
     | Prod(a,b)   -> Prod(link_term a, link_binder b)
     | Abst(a,t)   -> Abst(link_term a, link_binder t)
-    | LLet(t,a,u) -> LLet(link_term t, link_term a, link_binder u)
+    | LLet(a,t,u) -> LLet(link_term a, link_term t, link_binder u)
     | Appl(t,u)   -> Appl(link_term t, link_term u)
     | Meta(_,_)   -> assert false
     | Patt(i,n,m) -> Patt(i, n, Array.map link_term m)
@@ -154,7 +154,7 @@ let unlink : t -> unit = fun sign ->
     | Symb(s,_)    -> unlink_sym s
     | Prod(a,b)    -> unlink_term a; unlink_binder b
     | Abst(a,t)    -> unlink_term a; unlink_binder t
-    | LLet(t,a,u)  -> unlink_term t; unlink_term a; unlink_binder u
+    | LLet(a,t,u)  -> unlink_term a; unlink_term t; unlink_binder u
     | Appl(t,u)    -> unlink_term t; unlink_term u
     | Meta(_,_)    -> assert false (* Should not happen, uninstantiated. *)
     | Patt(_,_,_)  -> () (* The environment only contains variables. *)
@@ -241,7 +241,7 @@ let read : string -> t = fun fname ->
       | Symb(s,_)   -> shallow_reset_sym s
       | Prod(a,b)   -> reset_term a; reset_binder b
       | Abst(a,t)   -> reset_term a; reset_binder t
-      | LLet(t,a,u) -> reset_term t; reset_term a; reset_binder u
+      | LLet(a,t,u) -> reset_term a; reset_term t; reset_binder u
       | Appl(t,u)   -> reset_term t; reset_term u
       | Meta(_,_)   -> assert false
       | Patt(_,_,m) -> Array.iter reset_term m

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -143,8 +143,9 @@ let check_rule : sym StrMap.t -> sym * pp_hint * rule Pos.loc -> unit =
   | Some(cs) ->
   let is_constr c =
     let eq_comm (_,t1,u1) (_,t2,u2) =
-      (* Contexts ignored: [solve] doesn't generate contexts with defined
-         variables. *)
+      (* Contexts ignored: [infer_constr] is called with an empty context and
+       * neither [check] nor [solve] generate contexts with defined
+       * variables. *)
       (Eval.eq_modulo [] t1 t2 && Eval.eq_modulo [] u1 u2) ||
       (Eval.eq_modulo [] t1 u2 && Eval.eq_modulo [] t2 u1)
     in

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -22,7 +22,6 @@ let subst_from_constrs : unif_constrs -> subst = fun cs ->
     match cs with
     | []          -> List.split acc
     | (_,a,b)::cs ->
-      (* FIXME use ctxt? *)
       match Basics.get_args a with
       | Vari(x), [] -> build_sub ((x,b)::acc) cs
       | _, _ ->
@@ -145,10 +144,10 @@ let check_rule : sym StrMap.t -> sym * pp_hint * rule Pos.loc -> unit =
       fatal r.pos "Rule [%a] does not preserve typing." pp_rule (s,h,r.elt)
   | Some(cs) ->
   let is_constr c =
-    let eq_comm (_,t1,u1) (_,t2,u2) =
-      (* FIXME merge contexts and use them in eq_modulo *)
-      (Eval.eq_modulo [] t1 t2 && Eval.eq_modulo [] u1 u2) ||
-      (Eval.eq_modulo [] t1 u2 && Eval.eq_modulo [] t2 u1)
+    let eq_comm (c1,t1,u1) (c2,t2,u2) =
+      let ctx = match Ctxt.merge c1 c2 with None -> [] | Some(x) -> x in
+      (Eval.eq_modulo ctx t1 t2 && Eval.eq_modulo ctx u1 u2) ||
+      (Eval.eq_modulo ctx t1 u2 && Eval.eq_modulo ctx t2 u1)
     in
     List.exists (eq_comm c) lhs_constrs
   in

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -76,9 +76,6 @@ let check_rule : sym StrMap.t -> sym * pp_hint * rule Pos.loc -> unit =
     | Symb(s,h)   -> _Symb s h
     | Abst(a,t)   -> let (x,t) = Bindlib.unbind t in
                      _Abst (to_m 0 a) (Bindlib.bind_var x (to_m 0 t))
-    | LLet(t,a,u) ->
-        let (x, u) = Bindlib.unbind u in
-        _LLet (to_m 0 t) (to_m 0 a) (Bindlib.bind_var x (to_m 0 u))
     | Appl(t,u)   -> _Appl (to_m (k+1) t) (to_m 0 u)
     | Patt(i,n,a) ->
         begin
@@ -99,6 +96,7 @@ let check_rule : sym StrMap.t -> sym * pp_hint * rule Pos.loc -> unit =
     | Type        -> assert false (* Cannot appear in LHS. *)
     | Kind        -> assert false (* Cannot appear in LHS. *)
     | Prod(_,_)   -> assert false (* Cannot appear in LHS. *)
+    | LLet(_,_,_) -> assert false (* Cannot appear in LHS. *)
     | Meta(_,_)   -> assert false (* Cannot appear in LHS. *)
     | TEnv(_,_)   -> assert false (* Cannot appear in LHS. *)
     | Wild        -> assert false (* Cannot appear in LHS. *)

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -21,11 +21,11 @@ let subst_from_constrs : unif_constrs -> subst = fun cs ->
   let rec build_sub acc cs =
     match cs with
     | []          -> List.split acc
-    | (_,a,b)::cs ->
-      match Basics.get_args a with
+    | (c,a,b)::cs ->
+      match Basics.get_args_ctx c a with
       | Vari(x), [] -> build_sub ((x,b)::acc) cs
       | _, _ ->
-        match Basics.get_args b with
+        match Basics.get_args_ctx c b with
         | Vari(x), [] -> build_sub ((x,a)::acc) cs
         | _, _ -> build_sub acc cs
   in

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -22,10 +22,10 @@ let subst_from_constrs : unif_constrs -> subst = fun cs ->
     match cs with
     | []          -> List.split acc
     | (c,a,b)::cs ->
-      match Basics.get_args_ctx c a with
+      match Ctxt.get_args c a with
       | Vari(x), [] -> build_sub ((x,b)::acc) cs
       | _, _ ->
-        match Basics.get_args_ctx c b with
+        match Ctxt.get_args c b with
         | Vari(x), [] -> build_sub ((x,a)::acc) cs
         | _, _ -> build_sub acc cs
   in

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -121,7 +121,7 @@ let check_rule : sym StrMap.t -> sym * pp_hint * rule Pos.loc -> unit =
   if !log_enabled then
     begin
       log_subj "LHS has type [%a]" pp ty_lhs;
-      let fn (c,t,u) = log_subj "  if %a[%a] ~ [%a]" wrap_ctxt c pp t pp u in
+      let fn (c,t,u) = log_subj "  if %a[%a] ~ [%a]" pp_ctxt c pp t pp u in
       List.iter fn lhs_constrs
     end;
   (* Turn constraints into a substitution and apply it. *)

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -142,10 +142,11 @@ let check_rule : sym StrMap.t -> sym * pp_hint * rule Pos.loc -> unit =
       fatal r.pos "Rule [%a] does not preserve typing." pp_rule (s,h,r.elt)
   | Some(cs) ->
   let is_constr c =
-    let eq_comm (c1,t1,u1) (c2,t2,u2) =
-      let ctx = match Ctxt.merge c1 c2 with None -> [] | Some(x) -> x in
-      (Eval.eq_modulo ctx t1 t2 && Eval.eq_modulo ctx u1 u2) ||
-      (Eval.eq_modulo ctx t1 u2 && Eval.eq_modulo ctx t2 u1)
+    let eq_comm (_,t1,u1) (_,t2,u2) =
+      (* Contexts ignored: [solve] doesn't generate contexts with defined
+         variables. *)
+      (Eval.eq_modulo [] t1 t2 && Eval.eq_modulo [] u1 u2) ||
+      (Eval.eq_modulo [] t1 u2 && Eval.eq_modulo [] t2 u1)
     in
     List.exists (eq_comm c) lhs_constrs
   in

--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -49,9 +49,8 @@ and p_term_aux =
   (** Abstraction over several variables. *)
   | P_Prod of p_arg list * p_term
   (** Product over several variables. *)
-  | P_LLet of ident * p_arg list * p_term * p_term
+  | P_LLet of ident * p_arg list * p_term * p_type option * p_term
   (** Local let. *)
-  (* TODO add type annotation [T] of term [t] in [let x = t : T in u]. *)
   | P_NLit of int
   (** Natural number literal. *)
   | P_UnaO of unop * p_term
@@ -208,30 +207,30 @@ let eq_binop : binop eq = fun (n1,a1,p1,id1) (n2,a2,p2,id2) ->
 
 let rec eq_p_term : p_term eq = fun t1 t2 ->
   match (t1.elt, t2.elt) with
-  | (P_Iden(q1,b1)       , P_Iden(q2,b2)       ) ->
+  | (P_Iden(q1,b1)       , P_Iden(q2,b2)             ) ->
       eq_qident q1 q2 && b1 = b2
-  | (P_Meta(x1,ts1)      , P_Meta(x2,ts2)      ) ->
+  | (P_Meta(x1,ts1)      , P_Meta(x2,ts2)            ) ->
       eq_ident x1 x2 && Array.equal eq_p_term ts1 ts2
-  | (P_Patt(x1,ts1)      , P_Patt(x2,ts2)      ) ->
+  | (P_Patt(x1,ts1)      , P_Patt(x2,ts2)            ) ->
       Option.equal eq_ident x1 x2 && Array.equal eq_p_term ts1 ts2
-  | (P_Appl(t1,u1)       , P_Appl(t2,u2)       )
-  | (P_Impl(t1,u1)       , P_Impl(t2,u2)       ) ->
+  | (P_Appl(t1,u1)       , P_Appl(t2,u2)             )
+  | (P_Impl(t1,u1)       , P_Impl(t2,u2)             ) ->
       eq_p_term t1 t2 && eq_p_term u1 u2
-  | (P_Abst(xs1,t1)      , P_Abst(xs2,t2)      )
-  | (P_Prod(xs1,t1)      , P_Prod(xs2,t2)      ) ->
+  | (P_Abst(xs1,t1)      , P_Abst(xs2,t2)            )
+  | (P_Prod(xs1,t1)      , P_Prod(xs2,t2)            ) ->
       List.equal eq_p_arg xs1 xs2 && eq_p_term t1 t2
-  | (P_LLet(x1,xs1,t1,u1), P_LLet(x2,xs2,t2,u2)) ->
-      eq_ident x1 x2 && eq_p_term t1 t2 && eq_p_term u1 u2
-      && List.equal eq_p_arg xs1 xs2
-  | (P_UnaO(u1,t1)       , P_UnaO(u2,t2)       ) ->
+  | (P_LLet(x1,xs1,t1,a1,u1), P_LLet(x2,xs2,t2,a2,u2)) ->
+      eq_ident x1 x2 && Option.equal eq_p_term a1 a2 && eq_p_term t1 t2
+      && eq_p_term u1 u2 && List.equal eq_p_arg xs1 xs2
+  | (P_UnaO(u1,t1)       , P_UnaO(u2,t2)             ) ->
       eq_unop u1 u2 && eq_p_term t1 t2
-  | (P_BinO(t1,b1,u1)    , P_BinO(t2,b2,u2)    ) ->
+  | (P_BinO(t1,b1,u1)    , P_BinO(t2,b2,u2)          ) ->
       eq_binop b1 b2 && eq_p_term t1 t2 && eq_p_term u1 u2
-  | (P_Wrap(t1)          , P_Wrap(t2)          ) ->
+  | (P_Wrap(t1)          , P_Wrap(t2)                ) ->
       eq_p_term t1 t2
-  | (P_Expl(t1)          , P_Expl(t2)          ) ->
+  | (P_Expl(t1)          , P_Expl(t2)                ) ->
       eq_p_term t1 t2
-  | (t1                  ,                   t2) ->
+  | (t1                  ,                   t2      ) ->
       t1 = t2
 
 and eq_p_arg : p_arg eq = fun (x1,ao1,b1) (x2,ao2,b2) ->

--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -49,7 +49,7 @@ and p_term_aux =
   (** Abstraction over several variables. *)
   | P_Prod of p_arg list * p_term
   (** Product over several variables. *)
-  | P_LLet of ident * p_arg list * p_term * p_type option * p_term
+  | P_LLet of ident * p_arg list * p_type option * p_term * p_term
   (** Local let. *)
   | P_NLit of int
   (** Natural number literal. *)
@@ -219,7 +219,7 @@ let rec eq_p_term : p_term eq = fun t1 t2 ->
   | (P_Abst(xs1,t1)      , P_Abst(xs2,t2)            )
   | (P_Prod(xs1,t1)      , P_Prod(xs2,t2)            ) ->
       List.equal eq_p_arg xs1 xs2 && eq_p_term t1 t2
-  | (P_LLet(x1,xs1,t1,a1,u1), P_LLet(x2,xs2,t2,a2,u2)) ->
+  | (P_LLet(x1,xs1,a1,t1,u1), P_LLet(x2,xs2,a2,t2,u2)) ->
       eq_ident x1 x2 && Option.equal eq_p_term a1 a2 && eq_p_term t1 t2
       && eq_p_term u1 u2 && List.equal eq_p_arg xs1 xs2
   | (P_UnaO(u1,t1)       , P_UnaO(u2,t2)             ) ->

--- a/src/core/tactics.ml
+++ b/src/core/tactics.ml
@@ -50,7 +50,7 @@ let handle_tactic : sig_state -> Proof.t -> p_tactic -> Proof.t =
     log_tact "refining [%a] with term [%a]" pp_meta m pp t;
     if Basics.occurs m t then fatal tac.pos "Circular refinement.";
     (* Check that [t] is well-typed. *)
-    log_tact "proving [%a%a : %a]" wrap_ctxt (Env.to_ctxt env) pp t pp a;
+    log_tact "proving [%a%a : %a]" pp_ctxt (Env.to_ctxt env) pp t pp a;
     if not (check t a) then fatal tac.pos "Ill-typed refinement.";
     (* Instantiation. *)
     set_meta m (Bindlib.unbox (Bindlib.bind_mvar (Env.vars env) (lift t)));

--- a/src/core/terms.ml
+++ b/src/core/terms.ml
@@ -60,7 +60,7 @@ type term =
   | TRef of term option ref
   (** Reference cell (only used for surface matching). *)
   | LLet of term * term * (term, term) Bindlib.binder
-  (** [LLet(t, a, u)] is [let x : a ≔ t in u] (with [x] bound in [u]). *)
+  (** [LLet(a, t, u)] is [let x : a ≔ t in u] (with [x] bound in [u]). *)
 
 (** {b NOTE} that a wildcard "_" of the concrete (source code) syntax may have
     a different representation depending on the application. For instance, the
@@ -423,7 +423,7 @@ let _TRef : term option ref -> tbox = fun r ->
 
 (** [_LLet t a u] lifts let binding [let x := t : a in u<x>]. *)
 let _LLet : tbox -> tbox -> tbinder Bindlib.box -> tbox =
-  Bindlib.box_apply3 (fun t a u -> LLet(t, a, u))
+  Bindlib.box_apply3 (fun a t u -> LLet(a, t, u))
 
 (** [lift t] lifts the {!type:term} [t] to the {!type:tbox} type. This has the
     effect of gathering its free variables, making them available for binding.
@@ -447,7 +447,7 @@ let rec lift : term -> tbox = fun t ->
   | TEnv(te,m)  -> _TEnv (lift_term_env te) (Array.map lift m)
   | Wild        -> _Wild
   | TRef(r)     -> _TRef r
-  | LLet(t,a,u) -> _LLet (lift t) (lift a) (Bindlib.box_binder lift u)
+  | LLet(a,t,u) -> _LLet (lift a) (lift t) (Bindlib.box_binder lift u)
 
 (** [cleanup t] builds a copy of the {!type:term} [t] where every instantiated
     metavariable,  instantiated term environment,  and reference cell has been

--- a/src/core/terms.ml
+++ b/src/core/terms.ml
@@ -264,39 +264,6 @@ let is_private : sym -> bool = fun s -> s.sym_expo = Privat
     definition. *)
 type ctxt = (term Bindlib.var * term * term option) list
 
-(** [def_of x ctx] returns the definition of [x] in the context [ctx] if it
-    appears, and [None] otherwise *)
-let rec def_of : term Bindlib.var -> ctxt -> term option = fun x ctx ->
-  match ctx with
-  | []         -> None
-  | (y,_,d)::l -> if Bindlib.eq_vars x y then d else def_of x l
-
-(** [unfold_ctx ctx t] behaves like {!val:Terms.unfold t} except when [t] is a
-    term of the form [Vari(x)] with [x] defined in [ctx]. In this case, [t] is
-    replaced by the definition of [x] in [ctx]. *)
-let rec unfold_ctx : ctxt -> term -> term = fun ctx t ->
-  match t with
-  | Meta(m, ar)          ->
-      begin
-        match !(m.meta_value) with
-        | None    -> t
-        | Some(b) -> unfold_ctx ctx (Bindlib.msubst b ar)
-      end
-  | TEnv(TE_Some(b), ar) -> unfold_ctx ctx (Bindlib.msubst b ar)
-  | TRef(r)              ->
-      begin
-        match !r with
-        | None    -> t
-        | Some(v) -> unfold_ctx ctx v
-      end
-  | Vari(x)              ->
-      begin
-        match def_of x ctx with
-        | None    -> t
-        | Some(t) -> unfold_ctx ctx t
-      end
-  | _                    -> t
-
 (** Type of a list of unification constraints. *)
 type unif_constrs = (ctxt * term * term) list
 
@@ -322,7 +289,7 @@ let rec unfold : term -> term = fun t ->
       end
   | _                    -> t
 
-(** {b NOTE} [unfold] could be defined as [unfold_ctx []], but since [unfold]
+(** {b NOTE} [unfold] could be defined as [Ctxt.unfold []], but since [unfold]
     is critical regarding performance, it is kept as simple as possible. *)
 
 (** {b NOTE} that {!val:unfold} must (almost) always be called before matching

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -527,7 +527,7 @@ module CM = struct
       match ph, h with
       | Symb(_), Symb(_)
       | Vari(_), Vari(_) ->
-          if lenh = lenp && Basics.eq ph h
+          if lenh = lenp && Basics.eq [] ph h
           then Some({r with c_lhs = insert (Array.of_list args)})
           else None
       | _      , Patt(_) ->

--- a/src/core/typing.ml
+++ b/src/core/typing.ml
@@ -16,7 +16,7 @@ let check : sym StrMap.t -> ctxt -> term -> term -> bool =
   | Some([]) -> true
   | Some(cs) ->
       let fn (c,a,b) =
-        fatal_msg "Cannot solve %a[%a] ≡ [%a].\n" wrap_ctxt c pp a pp b
+        fatal_msg "Cannot solve %a.\n" pp_constr (c, a, b)
       in
       List.iter fn cs; false
 
@@ -40,7 +40,7 @@ let infer : sym StrMap.t -> ctxt -> term -> term option =
   | Some(a,[]) -> Some(a)
   | Some(_,cs) ->
       let fn (c,a,b) =
-        fatal_msg "Cannot solve %a[%a] ≡ [%a].\n" wrap_ctxt c pp a pp b
+        fatal_msg "Cannot solve %a.\n" pp_constr (c, a, b)
       in
       List.iter fn cs; None
 

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -92,7 +92,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
   let (h1, ts1) = Eval.whnf_stk t1 [] in
   let (h2, ts2) = Eval.whnf_stk t2 [] in
   if !log_enabled then
-    log_unif "solve %a" pp_constr (ctx, (add_args h1 ts1), (add_args h2 ts2));
+    log_unif "solve %a" pp_constr (ctx, add_args h1 ts1, add_args h2 ts2);
 
   let add_to_unsolved () =
     let t1 = add_args h1 ts1 in

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -187,7 +187,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
       | Prod(a,b) ->
          let x,b = Bindlib.unbind b in
          let a = lift a in
-         let env' = Env.add x a env in
+         let env' = Env.add x false a env in
          x,a,env',lift b,p
       | _ ->
          (* After type inference, a similar constraint should have already
@@ -196,7 +196,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
          let m2 = fresh_meta t2 n in
          let a = _Meta m2 (Env.to_tbox env) in
          let x = Bindlib.new_var mkfree "x" in
-         let env' = Env.add x a env in
+         let env' = Env.add x false a env in
          let t3 = Env.to_prod env' _Kind in
          let m3 = fresh_meta t3 (n+1) in
          let b = _Meta m3 (Env.to_tbox env') in

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -88,7 +88,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
 
   let decompose () =
     (* Propagate context *)
-    let add_arg_pb l t1 t2 = (ctx,t1,t2)::l in
+    let add_arg_pb l a b = (ctx,a,b)::l in
     let to_solve =
       try List.fold_left2 add_arg_pb p.to_solve ts1 ts2
       with Invalid_argument _ -> error () in

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -162,7 +162,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
       | Prod(a,b) ->
          let x,b = Bindlib.unbind b in
          let a = lift a in
-         let env' = Env.add x false a env in
+         let env' = Env.add x a None env in
          x,a,env',lift b,p
       | _ ->
          (* After type inference, a similar constraint should have already
@@ -171,7 +171,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
          let m2 = fresh_meta t2 n in
          let a = _Meta m2 (Env.to_tbox env) in
          let x = Bindlib.new_var mkfree "x" in
-         let env' = Env.add x false a env in
+         let env' = Env.add x a None env in
          let t3 = Env.to_prod env' _Kind in
          let m3 = fresh_meta t3 (n+1) in
          let b = _Meta m3 (Env.to_tbox env') in

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -36,31 +36,6 @@ let no_problems : problems =
 (** Boolean saying whether user metavariables can be set or not. *)
 let can_instantiate : bool ref = ref true
 
-(** [nl_distinct_vars ctx ts] checks that [ts] is made of variables  [vs] only
-    and returns some copy of [vs] where variables occurring more than once are
-    replaced by fresh variables.  Variables defined in  [ctx] are unfolded. It
-    returns [None] otherwise. *)
-let nl_distinct_vars : ctxt -> term array -> tvar array option =
-  fun ctx ts ->
-  let exception Not_a_var in
-  let open Stdlib in
-  let vars = ref VarSet.empty
-  and nl_vars = ref VarSet.empty in
-  let rec to_var t =
-    match unfold t with
-    | Vari(x) ->
-        let x = Option.map_default to_var x (Ctxt.def_of x ctx) in
-        if VarSet.mem x !vars then nl_vars := VarSet.add x !nl_vars else
-        vars := VarSet.add x !vars;
-        x
-    | _       -> raise Not_a_var
-  in
-  let replace_nl_var x =
-    if VarSet.mem x !nl_vars then Bindlib.new_var mkfree "_" else x
-  in
-  try Some (Array.map replace_nl_var (Array.map to_var ts))
-  with Not_a_var -> None
-
 (** [instantiate ctx m ts u] check whether [m] can be instantiated for solving
     the unification problem “m[ts] = u” in context [ctx]. The returned boolean
     tells whether [m] was instantiated or not. *)

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -90,8 +90,8 @@ let rec solve : problems -> unif_constrs = fun p ->
     the constraint [(t1,t2)], starting with the latter. *)
 and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
   fun ctx t1 t2 p ->
-  let (h1, ts1) = Eval.whnf_stk ctx t1 [] in
-  let (h2, ts2) = Eval.whnf_stk ctx t2 [] in
+  let (h1, ts1) = Basics.get_args (Eval.whnf ctx t1) in
+  let (h2, ts2) = Basics.get_args (Eval.whnf ctx t2) in
   if !log_enabled then
     log_unif "solve %a" pp_constr (ctx, add_args h1 ts1, add_args h2 ts2);
 
@@ -183,7 +183,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
     let n = m.meta_arity in
     let env, t = Env.of_prod_arity n !(m.meta_type) in
     let x,a,env',b,p =
-      match Eval.whnf ctx t with
+      match Eval.whnf [] t with
       | Prod(a,b) ->
          let x,b = Bindlib.unbind b in
          let a = lift a in
@@ -258,7 +258,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
 
   let rec inverse s v =
     if !log_enabled then log_unif "inverse [%a] [%a]" pp (symb s) pp v;
-    match get_args (Eval.whnf ctx v) with
+    match get_args (Eval.whnf [] v) with
     | Symb(s',_), [u] when s' == s -> u
     | Prod(a,b), _ -> find_inverse_prod a b (inverses_for_prod s)
     | _, _ -> raise Not_invertible

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -92,8 +92,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
   let (h1, ts1) = Eval.whnf_stk t1 [] in
   let (h2, ts2) = Eval.whnf_stk t2 [] in
   if !log_enabled then
-    log_unif "solve %a%a ≡ %a"
-      wrap_ctxt ctx pp (add_args h1 ts1) pp (add_args h2 ts2);
+    log_unif "solve %a" pp_constr (ctx, (add_args h1 ts1), (add_args h2 ts2));
 
   let add_to_unsolved () =
     let t1 = add_args h1 ts1 in

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -341,8 +341,8 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
   | (Meta(_,_)  , _          )
   | (_          , Meta(_,_)  ) -> add_to_unsolved ()
 
-  | (Symb(s,_)  , _          ) -> solve_inj s ts1 (add_args h2 ts2)
-  | (_          , Symb(s,_)  ) -> solve_inj s ts2 (add_args h1 ts1)
+  | (Symb(s,_)  , _          ) -> solve_inj s ts1 t2
+  | (_          , Symb(s,_)  ) -> solve_inj s ts2 t1
 
   | (_          , _          ) -> error ()
 

--- a/src/core/why3_tactic.ml
+++ b/src/core/why3_tactic.ml
@@ -104,7 +104,7 @@ let encode : Pos.popt -> sym StrMap.t -> Env.env -> term -> Why3.Task.task =
     fun pos builtins hs g ->
   let cfg = get_config pos builtins in
   let (constants, hypothesis) =
-    let translate_hyp (tbl, map) (name, (_, hyp)) =
+    let translate_hyp (tbl, map) (name, (_, _, hyp)) =
       match translate_term cfg tbl (Bindlib.unbox hyp) with
       | Some(tbl, why3_hyp) -> (tbl, StrMap.add name why3_hyp map)
       | None                -> (tbl, map)
@@ -197,6 +197,6 @@ let handle : Pos.popt -> Proof.proof_state -> sig_state -> string option ->
   (* Tell the user that the goal is proved (verbose 2). *)
   if !log_enabled then log_why3 "goal proved: axiom [%s] created" axiom_name;
   (* Return the variable terms of each item in the context. *)
-  let terms = List.rev_map (fun (_, (x, _)) -> Vari x) hyps in
+  let terms = List.rev_map (fun (_, (x, _, _)) -> Vari x) hyps in
   (* Apply the instance of the axiom with context. *)
   Basics.add_args (symb a) terms

--- a/src/core/why3_tactic.ml
+++ b/src/core/why3_tactic.ml
@@ -104,7 +104,7 @@ let encode : Pos.popt -> sym StrMap.t -> Env.env -> term -> Why3.Task.task =
     fun pos builtins hs g ->
   let cfg = get_config pos builtins in
   let (constants, hypothesis) =
-    let translate_hyp (tbl, map) (name, (_, _, hyp)) =
+    let translate_hyp (tbl, map) (name, (_, hyp, _)) =
       match translate_term cfg tbl (Bindlib.unbox hyp) with
       | Some(tbl, why3_hyp) -> (tbl, StrMap.add name why3_hyp map)
       | None                -> (tbl, map)

--- a/src/core/why3_tactic.ml
+++ b/src/core/why3_tactic.ml
@@ -88,7 +88,7 @@ let translate_term : config -> cnst_table -> term ->
         (tbl, Why3.Term.t_true)
     | (_        , _       )                        ->
         (* If the term [p] is mapped in [tbl] then use it. *)
-        try (tbl, Why3.Term.ps_app (List.assoc_eq Basics.eq t tbl) [])
+        try (tbl, Why3.Term.ps_app (List.assoc_eq (Basics.eq []) t tbl) [])
         with Not_found ->
           (* Otherwise generate a new constant in why3. *)
           let sym = Why3.Term.create_psymbol (Why3.Ident.id_fresh "P") [] in

--- a/src/core/xtc.ml
+++ b/src/core/xtc.ml
@@ -57,7 +57,7 @@ let rec print_term : int -> string -> term pp = fun i s oc t ->
      let (x, t) = Bindlib.unbind t in
      out "<lambda>@.<var>v_%s</var>@.<type>%a<type>@.%a</lambda>@."
        (Bindlib.name_of x) (print_type i s) a (print_term i s) t
-  | LLet(t,_,u)             -> print_term i s oc (Bindlib.subst u t)
+  | LLet(_,t,u)             -> print_term i s oc (Bindlib.subst u t)
 
 and print_type : int -> string -> term pp = fun i s oc t ->
   let out fmt = Format.fprintf oc fmt in
@@ -91,7 +91,7 @@ and print_type : int -> string -> term pp = fun i s oc t ->
        out "<arrow>@.<var>v_%s</var>@." (Bindlib.name_of x);
        out "<type>@.%a</type>@.<type>@.%a</type>@.</arrow>"
          (print_type i s) a (print_type i s) b
-  | LLet(t,_,u)             -> print_type i s oc (Bindlib.subst u t)
+  | LLet(_,t,u)             -> print_type i s oc (Bindlib.subst u t)
 
 (** [print_rule oc s r] outputs the rule declaration corresponding [r] (on the
     symbol [s]), to the output channel [oc]. *)

--- a/src/lsp/lsp_base.ml
+++ b/src/lsp/lsp_base.ml
@@ -36,7 +36,7 @@ let mk_range (p : Pos.pos) : J.t =
           "end",   `Assoc ["line", `Int (line2 - 1); "character", `Int col2]]
 
 let json_of_goal g =
-  let pr_hyp (s,(_,_,t)) =
+  let pr_hyp (s,(_,t,_)) =
     `Assoc ["hname", `String s;
             "htype", `String (Format.asprintf "%a" Print.pp_term (Bindlib.unbox t))] in
   let open Proof in

--- a/src/lsp/lsp_base.ml
+++ b/src/lsp/lsp_base.ml
@@ -36,7 +36,7 @@ let mk_range (p : Pos.pos) : J.t =
           "end",   `Assoc ["line", `Int (line2 - 1); "character", `Int col2]]
 
 let json_of_goal g =
-  let pr_hyp (s,(_,t)) =
+  let pr_hyp (s,(_,_,t)) =
     `Assoc ["hname", `String s;
             "htype", `String (Format.asprintf "%a" Print.pp_term (Bindlib.unbox t))] in
   let open Proof in

--- a/tests/OK/298_lp.lp
+++ b/tests/OK/298_lp.lp
@@ -1,0 +1,9 @@
+// natural numbers
+constant symbol N : TYPE
+constant symbol z : N
+constant symbol s : N ⇒ N
+
+// three parameters function
+constant symbol f : N ⇒ N ⇒ N ⇒ N
+assert n m (o:N) ⊢ f n m o ≡ f n m o
+assert n (m:N) ⊢ f n m : N ⇒ N

--- a/tests/OK/let.lp
+++ b/tests/OK/let.lp
@@ -16,7 +16,8 @@ assert let f x ≔ x in f a ≡ a
 // With type annotated arguments
 set flag "print_domains" on
 type let f (x : T) ≔ λ _, x in f a
-assert let f (x: T) ≔ λ_, x in f a ≡ λ_, a
+// assert let f (x: T) ≔ λ(_:T), x in f a ≡ λ(_:T), a
+// TODO: need type annotation for bound variable of let
 
 // In rewrite rules
 symbol f : T ⇒ T

--- a/tests/OK/let.lp
+++ b/tests/OK/let.lp
@@ -25,4 +25,7 @@ compute let x : T ≔ a in x
 type let f x : T ≔ a in f
 type let f (x : T) ≔ λ _, x in f a
 assert let f (x:T) : T ⇒ T ≔ λ(_:T), x in f a ≡ λ(_:T), a
-// TODO: need type annotation for bound variable of let
+// dependent type let
+symbol Dt : T ⇒ TYPE
+symbol dt x : Dt x
+type let f x : Dt x ≔ dt x in f

--- a/tests/OK/let.lp
+++ b/tests/OK/let.lp
@@ -1,6 +1,6 @@
 // Let syntax
-symbol T : TYPE
-symbol a : T
+constant symbol T : TYPE
+constant symbol a : T
 
 // Simple
 type let x ≔ a in x
@@ -14,6 +14,7 @@ type let f x ≔ x in f a
 assert let f x ≔ x in f a ≡ a
 
 // With type annotated arguments
+set flag "print_domains" on
 type let f (x : T) ≔ λ _, x in f a
 assert let f (x: T) ≔ λ_, x in f a ≡ λ_, a
 
@@ -21,6 +22,3 @@ assert let f (x: T) ≔ λ_, x in f a ≡ λ_, a
 symbol f : T ⇒ T
 rule f _ → let x ≔ a in x
 assert f a ≡ a
-
-// Should raise a warning (x not used in body)
-assert f a ≡ let x ≔ a in a

--- a/tests/OK/let.lp
+++ b/tests/OK/let.lp
@@ -13,13 +13,16 @@ assert let x ≔ a in let y ≔ a in λ_, y ≡ λ_, a
 type let f x ≔ x in f a
 assert let f x ≔ x in f a ≡ a
 
-// With type annotated arguments
-set flag "print_domains" on
-type let f (x : T) ≔ λ _, x in f a
-// assert let f (x: T) ≔ λ(_:T), x in f a ≡ λ(_:T), a
-// TODO: need type annotation for bound variable of let
-
 // In rewrite rules
 symbol f : T ⇒ T
 rule f _ → let x ≔ a in x
 assert f a ≡ a
+
+// With type annotated arguments
+set flag "print_domains" on
+compute let x : T ≔ a in x
+// Type annotation on products
+type let f x : T ≔ a in f
+type let f (x : T) ≔ λ _, x in f a
+assert let f (x:T) : T ⇒ T ≔ λ(_:T), x in f a ≡ λ(_:T), a
+// TODO: need type annotation for bound variable of let

--- a/tests/OK/perf_rw_fib-nonRightLin.lp
+++ b/tests/OK/perf_rw_fib-nonRightLin.lp
@@ -13,4 +13,4 @@ rule fib3 0              → 0
 
 assert fib 15 ≡ 610
 assert fib 24 ≡ 46368
-compute fib3 22
+compute fib3 21


### PR DESCRIPTION
Introduce local let in the `term` datatype.
Unlike in #307, when inferring the type of a `let x := t in u`, there is no substitution of `t` in `u`. Instead, the following have changed
- contexts contain type declarations as well as definitions, they thus are of the form
  ```
  C ::= x : A :: C | x := t : A :: C | []
  ```
- a unification problem contains equalities as well as a context, and is of the form `C |- t =? u`.

**Note** commits up to 7aefcae are shared with #307.