### PR TITLE
Silence compiler warnings per MELPA

### DIFF
--- a/editors/emacs/lambdapi-capf.el
+++ b/editors/emacs/lambdapi-capf.el
@@ -9,7 +9,9 @@
 (require 'lambdapi-vars)
 (require 'eglot)
 
-(defvar-local company-backends nil) ; Silence warnings
+;; Silence warnings
+(defvar company-backends nil)
+(declare-function company-math-symbols-unicode "ext:company-math.el" t t)
 
 (defconst lambdapi--all-keywords
   (append lambdapi-sig-commands


### PR DESCRIPTION
Per https://github.com/melpa/melpa/pull/6827

@gabrielhdt and @fblanqui fyi (since I saw you both on https://github.com/Deducteam/lambdapi/pull/364).

The `defvar-local` I suggested for the earlier PR was incorrect.  I also noticed a new warning about `company-math-symbols-unicode` not being defined popped up, so I also declare-function'd it in this PR.  Thanks!