### PR TITLE
Allow extra variables in RHS

### DIFF
--- a/src/core/handle.ml
+++ b/src/core/handle.ml
@@ -282,10 +282,11 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
             let pur = (scope_rule ss h).elt in
             let urule =
               { lhs = pur.pr_lhs
-              ; rhs = Bindlib.unbox (Bindlib.bind_mvar pur.pr_vars pur.pr_rhs)
+              ; rhs = Bindlib.(unbox (bind_mvar pur.pr_vars pur.pr_rhs))
               ; arity = List.length pur.pr_lhs
               ; arities = pur.pr_arities
-              ; vars = pur.pr_vars }
+              ; vars = pur.pr_vars
+              ; xvars_nb = pur.pr_xvars_nb }
             in
             Sign.add_rule ss.signature Unif_rule.equiv urule;
             Tree.update_dtree Unif_rule.equiv;

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -483,15 +483,17 @@ let parser rule =
 let parser unif_rule =
   | l:{term "≡" term} "↪" r:{term "≡" term} rs:{";" term "≡" term}* ->
       let equiv = Pos.none (P_Iden(Pos.none ([], "#equiv"), true)) in
-      let cons = Pos.none (P_Iden(Pos.none ([], "#cons"), true)) in
       let p_appl t u = Pos.none (P_Appl(t, u)) in
       let mkequiv (l, r) = p_appl (p_appl equiv l) r in
       let lhs = mkequiv l in
       match rs with
       | [] -> Pos.in_pos _loc (lhs, mkequiv r)
       | _  ->
-          let cat eqlst eq = p_appl (p_appl cons (mkequiv eq)) eqlst in
-          let rhs = List.fold_left cat (mkequiv r) rs in
+          let cons = Pos.none (P_Iden(Pos.none ([], "#cons"), true)) in
+          let rs = List.rev_map mkequiv (r::rs) in
+          let (r, rs) = (List.hd rs, List.tl rs) in
+          let cat eqlst eq = p_appl (p_appl cons eq) eqlst in
+          let rhs = List.fold_left cat r rs in
           Pos.in_pos _loc (lhs, rhs)
 
 (** [rw_patt_spec] is a parser for a rewrite pattern specification. *)

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -47,19 +47,6 @@ let get_root : p_term -> sig_state -> sym = fun t ss ->
   in
   get_root t
 
-(** Data used when scoping a LHS. *)
-type m_lhs_data =
-  { m_lhs_indices : (string, int   ) Hashtbl.t
-  (** Stores the index reserved for a pattern variable of the given name. *)
-  ; m_lhs_arities : (int   , int   ) Hashtbl.t
-  (** Stores the arity of the pattern variable at the given index. *)
-  ; m_lhs_names   : (int   , string) Hashtbl.t
-  (** Stores the name of the pattern variable at the given index (if any). *)
-  ; mutable m_lhs_size : int
-  (** Stores the current known size of the environment of the RHS. *)
-  ; m_lhs_in_env  : string list
-  (** Pattern variables definitely needed in the RHS environment. *) }
-
 (** Representation of the different scoping modes.  Note that the constructors
     hold specific information for the given mode. *)
 type mode =
@@ -69,10 +56,20 @@ type mode =
       scoped term. *)
   | M_Patt
   (** Scoping mode for patterns in the rewrite tactic. *)
-  | M_LHS  of bool * m_lhs_data
-  (** Scoping mode for rewriting rule left-hand sides. The constructor carries
-      a flag that is set to [true] if {!constructor:Terms.expo.Privat} symbols
-      are allowed, and also additional data. *)
+  | M_LHS  of
+      { m_lhs_prv              : bool
+      (** True if {!constructor:Terms.expo.Privat} symbols are allowed. *)
+      ; m_lhs_indices          : (string, int   ) Hashtbl.t
+      (** Stores index reserved for a pattern variable of the given name. *)
+      ; m_lhs_arities          : (int   , int   ) Hashtbl.t
+      (** Stores the arity of the pattern variable at the given index. *)
+      ; m_lhs_names            : (int   , string) Hashtbl.t
+      (** Stores the name of the pattern variable at given index (if any). *)
+      ; mutable m_lhs_size     : int
+      (** Stores the current known size of the environment of the RHS. *)
+      ; m_lhs_in_env           : string list
+      (** Pattern variables definitely needed in the RHS environment. *) }
+  (** Scoping mode for rewriting rule left-hand sides. *)
   | M_RHS  of
       { m_rhs_prv             : bool
       (** True if {!constructor:Terms.expo.Privat} symbols are allowed. *)
@@ -121,25 +118,30 @@ let get_args : p_term -> p_term * p_term list =
     state [ss] is used to hande module aliasing according to [find_qid]. *)
 let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
   (* Unique pattern variable generation for wildcards in a LHS. *)
-  let fresh_patt data name env =
+  let fresh_patt md name env =
+    match md with
+    | M_LHS(data) ->
     let fresh_index () =
       let i = data.m_lhs_size in
       data.m_lhs_size <- i + 1;
       let arity = Array.length env in
       Hashtbl.add data.m_lhs_arities i arity; i
     in
-    match name with
-    | Some(name) ->
-        let i =
-          try Hashtbl.find data.m_lhs_indices name with Not_found ->
+    begin
+      match name with
+      | Some(name) ->
+          let i =
+            try Hashtbl.find data.m_lhs_indices name with Not_found ->
+            let i = fresh_index () in
+            Hashtbl.add data.m_lhs_indices name i;
+            Hashtbl.add data.m_lhs_names i name; i
+          in
+          _Patt (Some(i)) (Printf.sprintf "v%i_%s" i name) env
+      | None       ->
           let i = fresh_index () in
-          Hashtbl.add data.m_lhs_indices name i;
-          Hashtbl.add data.m_lhs_names i name; i
-        in
-        _Patt (Some(i)) (Printf.sprintf "v%i_%s" i name) env
-    | None       ->
-        let i = fresh_index () in
-        _Patt (Some(i)) (Printf.sprintf "v%i" i) env
+          _Patt (Some(i)) (Printf.sprintf "v%i" i) env
+    end
+    | _           -> invalid_arg "fresh_patt mode must be M_LHS"
   in
   (* Toplevel scoping function, with handling of implicit arguments. *)
   let rec scope : env -> p_term -> tbox = fun env t ->
@@ -195,7 +197,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
     match (a, md) with
     | (Some(a), M_LHS(_)    ) ->
         fatal a.pos "Annotation not allowed in a LHS."
-    | (None   , M_LHS(_,d)  ) -> fresh_patt d None (Env.to_tbox env)
+    | (None   , M_LHS(_)    ) -> fresh_patt md None (Env.to_tbox env)
     | (Some(a), _           ) -> scope env a
     | (None   , _           ) ->
         (* Create a new metavariable of type [TYPE] for the missing domain. *)
@@ -236,14 +238,15 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
     | (P_Type          , M_LHS(_)          ) ->
         fatal t.pos "TYPE is not allowed in a LHS."
     | (P_Type          , _                 ) -> _Type
-    | (P_Iden(qid,_)   , M_LHS(p,_)        ) -> find_qid true p ss env qid
+    | (P_Iden(qid,_)   , M_LHS(d)          ) ->
+        find_qid true d.m_lhs_prv ss env qid
     | (P_Iden(qid,_)   , M_Term(_,Privat ) ) -> find_qid false true ss env qid
     | (P_Iden(qid,_)   , M_RHS(d)          ) ->
         find_qid false d.m_rhs_prv ss env qid
     | (P_Iden(qid,_)   , _                 ) ->
         find_qid false false ss env qid
-    | (P_Wild          , M_LHS(_,d)        ) ->
-        fresh_patt d None (Env.to_tbox env)
+    | (P_Wild          , M_LHS(_)          ) ->
+        fresh_patt md None (Env.to_tbox env)
     | (P_Wild          , M_Patt            ) -> _Wild
     | (P_Wild          , _                 ) ->
         (* We create a metavariable [m] of type [tm], which itself is also a
@@ -279,7 +282,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
         _Meta m2 (Array.map (scope env) ts)
     | (P_Meta(_,_)     , _                ) ->
         fatal t.pos "Metavariables are not allowed in rewriting rules."
-    | (P_Patt(id,ts)   , M_LHS(_,d)       ) ->
+    | (P_Patt(id,ts)   , M_LHS(d)         ) ->
         (* Check that [ts] are variables. *)
         let scope_var t =
           match unfold (Bindlib.unbox (scope env t)) with
@@ -311,7 +314,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
                            named." id.elt
           | _                                                  -> ()
         end;
-        fresh_patt d (Option.map (fun id -> id.elt) id) ar
+        fresh_patt md (Option.map (fun id -> id.elt) id) ar
     | (P_Patt(id,ts)   , M_RHS(r)         ) ->
         let x =
           match id with
@@ -485,19 +488,22 @@ let scope_rule : sig_state -> p_rule -> pre_rule loc = fun ss r ->
     with Not_found -> ()
   in
   List.iter check_arity pvs_rhs;
-  (* Get privacy of head of the rule, scope the rest accordingly. *)
-  let prv = is_private (get_root p_lhs ss) in
   (* Scope the LHS and get the reserved index for named pattern variables. *)
-  let (pr_lhs, data) =
-    let data =
-      { m_lhs_indices = Hashtbl.create 7
-      ; m_lhs_arities = Hashtbl.create 7
-      ; m_lhs_names   = Hashtbl.create 7
-      ; m_lhs_size    = 0
-      ; m_lhs_in_env  = nl @ (List.map fst pvs_rhs) }
+  let (pr_lhs, lhs_indices, lhs_arities, lhs_names, lhs_size) =
+    let mode =
+      M_LHS{ m_lhs_prv     = is_private (get_root p_lhs ss)
+           ; m_lhs_indices = Hashtbl.create 7
+           ; m_lhs_arities = Hashtbl.create 7
+           ; m_lhs_names   = Hashtbl.create 7
+           ; m_lhs_size    = 0
+           ; m_lhs_in_env  = nl @ (List.map fst pvs_rhs) }
     in
-    let pr_lhs = scope (M_LHS(prv, data)) ss Env.empty p_lhs in
-    (Bindlib.unbox pr_lhs, data)
+    let pr_lhs = scope mode ss Env.empty p_lhs in
+    match mode with
+    | M_LHS{ m_lhs_indices; m_lhs_names; m_lhs_size; m_lhs_arities; _} ->
+        (Bindlib.unbox pr_lhs, m_lhs_indices, m_lhs_arities, m_lhs_names,
+         m_lhs_size)
+    | _                                                  -> assert false
   in
   (* Check the head symbol and build actual LHS. *)
   let (sym, pr_lhs) =
@@ -517,19 +523,19 @@ let scope_rule : sig_state -> p_rule -> pre_rule loc = fun ss r ->
   let pr_vars =
     let fn i =
       let name =
-        try Printf.sprintf "%i_%s" i (Hashtbl.find data.m_lhs_names i)
+        try Printf.sprintf "%i_%s" i (Hashtbl.find lhs_names i)
         with Not_found -> Printf.sprintf "%i" i
       in
       Bindlib.new_var te_mkfree name
     in
-    Array.init data.m_lhs_size fn
+    Array.init lhs_size fn
   in
   (* We scope the RHS and retrieve the variables not occurring in the LHS. *)
   let (pr_rhs, xvars) =
     let mode =
-      let htbl_vars = Hashtbl.create (Hashtbl.length data.m_lhs_indices) in
+      let htbl_vars = Hashtbl.create (Hashtbl.length lhs_indices) in
       let fn k i = Hashtbl.add htbl_vars k pr_vars.(i) in
-      Hashtbl.iter fn data.m_lhs_indices;
+      Hashtbl.iter fn lhs_indices;
       M_RHS{ m_rhs_prv = is_private sym; m_rhs_data = htbl_vars
            ; m_rhs_vars_nb = Array.length pr_vars; m_rhs_xvars = [] }
     in
@@ -551,14 +557,14 @@ let scope_rule : sig_state -> p_rule -> pre_rule loc = fun ss r ->
   (* We put everything together to build the pre-rule. *)
   let pr_arities =
     let fn i =
-      try Hashtbl.find data.m_lhs_arities i
+      try Hashtbl.find lhs_arities i
       with Not_found -> assert false (* Unreachable. *)
     in
-    Array.init data.m_lhs_size fn
+    Array.init lhs_size fn
   in
   let pr =
     { pr_sym = sym ; pr_lhs ; pr_vars ; pr_rhs ; pr_arities
-    ; pr_names = data.m_lhs_names ; pr_xvars_nb }
+    ; pr_names = lhs_names ; pr_xvars_nb }
   in
   Pos.make r.pos pr
 

--- a/src/core/sr.ml
+++ b/src/core/sr.ml
@@ -134,13 +134,18 @@ let symb_to_tenv
 (** [check_rule r] checks whether the pre-rule [r] is well-typed in
    signature state [ss] and then construct the corresponding rule. Note that
    [Fatal] is raised in case of error. *)
-let check_rule : Scope.pre_rule Pos.loc -> rule = fun pr ->
-  (* Unwrap the contents of the pre-rule. *)
-  let (pos, s, lhs, vars, rhs_vars, arities) =
-    let Pos.{elt=Scope.{pr_sym;pr_lhs;pr_vars;pr_rhs;pr_arities;_}; pos} = pr
-    in
-    (pos, pr_sym, pr_lhs, pr_vars, pr_rhs, pr_arities)
+let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
+  let Scope.{pr_sym = s ; pr_lhs = lhs ; pr_vars = vars
+            ; pr_rhs = rhs_vars; pr_arities = arities
+            ; pr_xvars_nb = xvars ; _} = elt
   in
+  (* Check that the variables of the RHS are in the LHS. *)
+  if xvars <> 0 then
+    begin
+      let xvars = Array.drop (Array.length vars - xvars) vars in
+      fatal pos "Unknown pattern variables [%a]"
+        (Array.pp Print.pp_var ",") xvars
+    end;
   let arity = List.length lhs in
   if !log_enabled then
     begin
@@ -148,7 +153,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun pr ->
          unboxed twice. However things should be fine here since the result is
          only used for printing. *)
       let rhs = Bindlib.(unbox (bind_mvar vars rhs_vars)) in
-      let naive_rule = {lhs; rhs; arity; arities; vars} in
+      let naive_rule = {lhs; rhs; arity; arities; vars; xvars_nb = 0} in
       log_subj "check rule [%a]" pp_rule (s, naive_rule);
     end;
   (* Replace [Patt] nodes of LHS with corresponding elements of [vars]. *)
@@ -264,4 +269,4 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun pr ->
   (* TODO optimisation for evaluation: environment minimisation. *)
   (* Construct the rule. *)
   let rhs = Bindlib.unbox (Bindlib.bind_mvar vars rhs) in
-  { lhs ; rhs ; arity ; arities ; vars }
+  { lhs ; rhs ; arity ; arities ; vars; xvars_nb = 0 }

--- a/src/core/terms.ml
+++ b/src/core/terms.ml
@@ -69,8 +69,14 @@ type term =
     the {!constructor:Patt} constructor to represend wildcards of the concrete
     syntax. They are thus considered to be fresh, unused pattern variables. *)
 
+(** Representation of a rewriting rule RHS (or action) as given in the type of
+    rewriting rules (see {!field:Terms.rhs}) with the number of variables that
+    are not in the LHS. In decision trees, a RHS is stored in every leaf since
+    they correspond to matched rules. *)
+ and rhs = (term_env, term) Bindlib.mbinder * int
+
 (** Representation of a decision tree (used for rewriting). *)
- and dtree = (term_env, term) Bindlib.mbinder Tree_types.dtree
+ and dtree = rhs Tree_types.dtree
 
 (** Representation of a user-defined symbol. Symbols carry a "mode" indicating
     whether they may be given rewriting rules or a definition. Invariants must
@@ -121,16 +127,19 @@ type term =
     rule to apply, and a RHS (right hand side) giving the action to perform if
     the rule applies. More explanations are given below. *)
  and rule =
-  { lhs     : term list
+  { lhs      : term list
   (** Left hand side (or LHS). *)
-  ; rhs     : (term_env, term) Bindlib.mbinder
+  ; rhs      : (term_env, term) Bindlib.mbinder
   (** Right hand side (or RHS). *)
-  ; arity   : int
+  ; arity    : int
   (** Required number of arguments to be applicable. *)
-  ; arities : int array
+  ; arities  : int array
   (** Arities of the pattern variables bound in the RHS. *)
-  ; vars    : term_env Bindlib.var array
-  (** Bindlib variables used to build [rhs]. *) }
+  ; vars     : term_env Bindlib.var array
+  (** Bindlib variables used to build [rhs]. The last [xvars_nb] variables
+      appear only in the RHS *)
+  ; xvars_nb : int
+  (** Number of variables in RHS but not in LHS. *) }
 
 (** The LHS (or pattern) of a rewriting rule is always formed of a head symbol
     (on which the rule is defined) applied to a list of pattern arguments. The
@@ -174,6 +183,13 @@ type term =
     {!type:term_env} type) are bound. To effectively apply the rewriting rule,
     these  bound variables must be substituted using "terms with environments"
     that are constructed when matching the LHS of the rule. *)
+
+(** All variables of rewriting rules that appear in the RHS must appear in the
+    LHS. This constraint is checked in {!module:Sr}.In the case of unification
+    rules, we allow variables to appear only in the RHS.  In that case, these
+    variables are replaced by fresh meta-variables each time the rule is used.
+    The last  {!field:terms.rule.xvars} variables of  {!field:terms.rule.vars}
+    are such RHS-only variables. *)
 
 (** Representation of a "term with environment", which intuitively corresponds
     to a term with bound variables (or a "higher-order" term) represented with

--- a/src/core/tree_graphviz.ml
+++ b/src/core/tree_graphviz.ml
@@ -98,7 +98,7 @@ let to_dot : Format.formatter -> sym -> unit = fun oc s ->
     let rec write_tree father_l swon t =
       incr node_count;
       match t with
-      | Leaf(_, a)  ->
+      | Leaf(_,(a,_))                                           ->
           let _, acte = Bindlib.unmbind a in
           out "@ %d [label=\"%a\"];" !node_count Print.pp_term acte;
           out "@ %d -- %d [label=<%a>];" father_l !node_count pp_dotterm swon

--- a/src/core/tree_types.ml
+++ b/src/core/tree_types.ml
@@ -63,10 +63,15 @@ type 'rhs tree =
   (** Empty decision tree, used when there are no rewriting rules. *)
   | Leaf of (int * (int * int array)) list * 'rhs
   (** The value [Leaf(m, rhs)] stores the RHS [rhs] of the rewriting rule that
-      can be applied upon reaching the leaf.  The association list [m] is used
+      can be applied upon reaching the  leaf. The association list [m] is used
       to construct the environment of the RHS. Note that we do not need to use
-      a map here since we only need to insert at the head, and iterate over
-      the elements of the structure. *)
+      a map here  since we only need  to insert at the head,  and iterate over
+      the elements of the structure. Triplet  [(p, (v, xs))] of [m] means that
+      when a rule  matches, the term to  be used as the [v]th  variable of the
+      RHS  is found  in position  [p] in  the array  containing all  the terms
+      gathered during  matching. The pattern  may have an environment  made of
+      variables [xs]. The  integer [x] indicates the number  of meta variables
+      to generate to replace the extra variables of the RHS. *)
   | Cond of
       { ok   : 'rhs tree
       (** Branch to follow if the condition is verified. *)
@@ -107,7 +112,7 @@ type 'rhs tree =
     define the capacity [c] of [t] is [c = max{nb_store(p) | p ∈ P}]. *)
 let rec tree_capacity : 'r tree -> int = fun tr ->
   match tr with
-  | Leaf(_,_)  | Fail   -> 0
+  | Leaf(_)  | Fail     -> 0
   | Eos(l,r)            -> max (tree_capacity l) (tree_capacity r)
   | Cond({ok; fail; _}) -> max (tree_capacity ok) (tree_capacity fail)
   | Node({store; children=ch; abstraction=abs; default; _}) ->

--- a/tests/KO/pat_rhs.lp
+++ b/tests/KO/pat_rhs.lp
@@ -1,0 +1,4 @@
+symbol T: TYPE
+symbol f: T → T
+symbol x: T
+rule f x ↪ $x

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -1,6 +1,6 @@
 // Simple unification hints
 symbol U: TYPE
-symbol T: U → TYPE
+injective symbol T: U → TYPE
 symbol bool: U
 symbol Bool: TYPE
 rule T bool ↪ Bool
@@ -43,8 +43,19 @@ set unif_rule (plus $x $y) ≡ z ↪ $x ≡ z; $y ≡ z
 // Trigger the unification problem plus ?1 ?2 ≡ z
 compute H (plus _ _) iz
 
+constant symbol Pair: U → TYPE
+constant symbol pair {t: U}:  T t → T t → Pair t
+symbol fst {t}: Pair t → T t
+symbol snd {t}: Pair t → T t
+set unif_rule fst $p ≡ $f ↪ $p ≡ pair $f $s
+set unif_rule snd $p ≡ $s ↪ $p ≡ pair $f $s
+constant symbol K {t}: T t → TYPE
+constant symbol J {t} (p: Pair t): K (fst p) → TYPE
+constant symbol kz: K z
+compute J (pair _ z) kz
+
 // The arrow problem
 symbol arrow : U → U → U
 rule T (arrow $t $u) ↪ T $t → T $u
-// hint (T $a → T $b) ≡ T (arrow $c $d) ↪ $a ≡ $c; $b ≡ $d
+// set unif_rule $a → $b ≡ T $c ↪ $a ≡ T $aa; $b ≡ T $bb; $c ≡ arrow $aa $bb
 // FIXME: implications not allowed in LHS (scoping level)


### PR DESCRIPTION
This PR is in preparation of unification on products. It solves two issues with the previous implementation of unification rules:
- the order of sub problems (`x = y, t = u, ...`) was poorly managed,
- we allow the creation of metavariables in the right hand side of unification rules.

The creation of metavariables is needed for instance for the arrow rule,
```
set unif_rule $a → $b ≡ T $c ↪ $a ≡ T ?aa, $b ≡ T ?bb, $c ≡ arrow ?aa ?bb
```

