### PR TITLE
Matching on product (and domain of binders)

### DIFF
--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -78,7 +78,9 @@ let decision_tree_cmd : Config.t -> (Path.t * string) -> unit =
     Config.init cfg;
     let sym =
       let sign = Compile.compile false mp in
-      try fst (StrMap.find sym Timed.(!(sign.sign_symbols)))
+      let ss = Sig_state.of_sign sign in
+      let (prt, prv) = (true, true) in
+      try Sig_state.find_sym false ss (Pos.none ([], sym)) ~prt ~prv
       with Not_found -> fatal_no_pos "Symbol not found."
     in
     out 0 "%a" Tree_graphviz.to_dot sym

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -196,7 +196,7 @@ and tree_walk : dtree -> ctxt -> stack -> (term * stack) option =
         (* Allocate an environment where to place terms coming from the
            pattern variables for the action. *)
         let env_len = Bindlib.mbinder_arity act in
-        (* We have [length env_builder = env_len - xvars] *)
+        assert (List.length env_builder = env_len - xvars);
         let env = Array.make env_len TE_None in
         (* Retrieve terms needed in the action from the [vars] array. *)
         let fn (pos, (slot, xs)) =

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -337,9 +337,6 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
         fatal t.pos "Pattern variables are only allowed in rewriting rules."
     | (P_Appl(_,_)     , _                  ) ->
         assert false (* Unreachable. *)
-    | (P_Impl(_,_)     , M_LHS(_)           ) ->
-        (* FIXME: should be allowed for hints *)
-        fatal t.pos "Implications are not allowed in a LHS."
     | (P_Impl(_,_)     , M_Patt             ) ->
         fatal t.pos "Implications are not allowed in a pattern."
     | (P_Impl(a,b)     , _                  ) ->
@@ -348,8 +345,6 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
         fatal t.pos "Abstractions are not allowed in a pattern."
     | (P_Abst(xs,t)    , _                  ) ->
         fst (scope_binder _Abst env xs t)
-    | (P_Prod(_,_)     , M_LHS(_)           ) ->
-        fatal t.pos "Dependent products are not allowed in a LHS."
     | (P_Prod(_,_)     , M_Patt             ) ->
         fatal t.pos "Dependent products are not allowed in a pattern."
     | (P_Prod(xs,b)    , _                  ) ->

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -494,10 +494,19 @@ module CM = struct
           | None    -> cond_pool
         in
         let env_builder =
+          (* If the pattern has a slot, either it is used in the RHS, in which
+             case a  tuple [(j,vs)] consisting of  the index [j] to  which the
+             matched term is bound in the  binder of the RHS and the variables
+             making up the  environment of the term (if any)  as indexes among
+             the  variables  collected.  Or  the  variable  is  subject  to  a
+             non-linearity  constraint. In  this  case we  do  not enrich  the
+             environment builder. *)
+          let se i (_,(j,_)) = i = j in
           match i with
-          | Some(i) ->
+          | Some(i) when not (List.exists (se i) r.env_builder) ->
               (slot, (i, Array.map (index_var vi) e)) :: r.env_builder
-          | None    -> r.env_builder
+          | _                                                   ->
+              r.env_builder
         in
         {r with env_builder; cond_pool}
     | _             -> r

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -310,6 +310,7 @@ module CM = struct
     | Patt(_) -> false
     | Vari(_)
     | Abst(_)
+    | Prod(_)
     | Symb(_) -> true
     | _       -> assert false
 
@@ -536,6 +537,7 @@ module CM = struct
           let arity = List.length pargs in
           let e = Array.make arity (Patt(None, "", [||])) in
           Some({ r with c_lhs = insert e })
+      | _      , Prod(_)
       | _      , Abst(_) -> None
       | _      , _       -> assert false
     in
@@ -560,37 +562,55 @@ module CM = struct
               (Array.drop (col + 1) r.c_lhs)
           in
           Some({r with c_lhs})
+      | Prod(_)
       | Symb(_) | Abst(_)
       | Vari(_) | Appl(_) -> None
       | _ -> assert false in
     (pos, List.filter_map transf cls)
 
-  (** [abstract col v pos cls] selects and transforms clauses [cls] assuming
-      that terms in column [col] match an abstraction.  The term under the
-      abstraction has its bound variable substituted by [v]; [pos] is the
-      position of terms in clauses [cl]. *)
-  let abstract : int -> tvar -> arg list -> clause list ->
-    arg list * clause list = fun col v pos cls ->
+  (** [binder get col v pos cls] selects and transforms clauses [cls] assuming
+      that each  term [t] in  column [col]  is a binder  such that [get  t] is
+      [Some(b)]. The term under the  binder has its bound variable substituted
+      by [v]; [pos] is the position of terms in clause [cls]. *)
+  let binder : (term -> tbinder option) -> int -> tvar -> arg list ->
+    clause list -> arg list * clause list = fun get col v pos cls ->
     let (l, {arg_path; arg_rank}, r) = List.destruct pos col in
     let a = {arg_path = 0 :: arg_path; arg_rank = arg_rank + 1} in
     let pos = List.rev_append l (a :: r) in
-    let insert r e = [ Array.sub r.c_lhs 0 col
-                     ; [| e |]
-                     ; Array.drop (col + 1) r.c_lhs ]
+    let insert r e =
+      Array.concat [ Array.sub r.c_lhs 0 col; [| e |]
+                   ; Array.drop (col + 1) r.c_lhs ]
     in
     let transf (r:clause) =
       let ph, pargs = get_args r.c_lhs.(col) in
       match ph with
-      | Abst(_, b)     ->
-          assert (pargs = []) ; (* Patterns in β-normal form *)
-          let b = Bindlib.subst b (mkfree v) in
-          Some({r with c_lhs = Array.concat (insert r b)})
-      | Patt(_) as pat -> Some({r with c_lhs = Array.concat (insert r pat)})
+      | Patt(_) as pat -> Some({r with c_lhs = insert r pat})
       | Symb(_)
       | Vari(_)        -> None
-      | _                    -> assert false
+      | t              ->
+      match get t with
+      | Some(b) ->
+          assert (pargs = []) ; (* Patterns in β-normal form *)
+          let b = Bindlib.subst b (mkfree v) in
+          Some({r with c_lhs = insert r b})
+      | None    -> assert false (* Term is ill formed *)
+
     in
     (pos, List.filter_map transf cls)
+
+  (** [abstract col  v pos cls] selects and transforms  clauses [cls] assuming
+      that terms  in column  [col] match  an abstraction.  The term  under the
+      abstraction  has its  bound variable  substituted by  [v]; [pos]  is the
+      position of terms in clauses [cl]. *)
+  let abstract : int -> tvar -> arg list -> clause list ->
+    arg list * clause list =
+    binder (function Abst(_,b) -> Some(b) | _ -> None)
+
+  (** [product col v pos cls] is like [abstract col v pos cls] for
+      products. *)
+  let product : int -> tvar -> arg list -> clause list ->
+    arg list * clause list =
+    binder (function Prod(_, b) -> Some(b) | _ -> None)
 
   (** [cond_ok cond cls] updates the clause list [cls] assuming that condition
       [cond] is satisfied. *)
@@ -619,7 +639,7 @@ let harvest : term array -> rhs -> CM.env_builder -> int VarMap.t -> int ->
   tree = fun lhs rhs env_builder vi slot ->
   let default_node store child =
     Node { swap = 0 ; store ; children = TCMap.empty
-         ; abstraction = None ; default = Some(child) }
+         ; abstraction = None ; product = None ; default = Some(child) }
   in
   let rec loop lhs env_builder slot =
     match lhs with
@@ -655,6 +675,14 @@ let harvest : term array -> rhs -> CM.env_builder -> int VarMap.t -> int ->
     {!field:CM.store}.  The instructions to copy adequately terms from [vars]
     to the RHS are in an environment builder (of type
     {!type:CM.env_builder}). *)
+
+(** [is_abst t] returns [true] iff [t] is of the form [Abst(_)]. *)
+let is_abst : term -> bool = fun t ->
+  match t with Abst(_) -> true | _ -> false
+
+(** [is_prod t] returns [true] iff [t] is of the form [Prod(_)]. *)
+let is_prod : term -> bool = fun t ->
+  match t with Prod(_) -> true | _ -> false
 
 (** [compile m] translates the pattern matching problem encoded by the matrix
     [m] into a decision tree. *)
@@ -704,19 +732,19 @@ let compile : CM.t -> tree = fun m ->
         let ncm = CM.{clauses; slot; positions} in
         if CM.is_empty ncm then None else Some(compile_cv ncm)
       in
-      (* Abstraction specialisation *)
-      let abstraction =
-        let is_abst = function Abst(_) -> true | _ -> false in
-        if List.for_all (fun x -> not (is_abst x)) column then None else
+      let binder recon mat_transf =
+        if List.for_all (fun x -> not (recon x)) column then None else
         let var = Bindlib.new_var mkfree "var" in
         let vars_id = VarMap.add var count vars_id in
-        let (positions, clauses) = CM.abstract swap var positions updated in
+        let (positions, clauses) = mat_transf swap var positions updated in
         let next =
           compile (count + 1) vars_id CM.{clauses; slot; positions}
         in
         Some(count, next)
       in
-      Node({swap ; store ; children ; abstraction ; default})
+      let abstraction = binder is_abst CM.abstract in
+      let product = binder is_prod CM.product in
+      Node({swap ; store ; children ; abstraction ; default; product})
   in
   compile 0 VarMap.empty m
 

--- a/src/core/tree_graphviz.ml
+++ b/src/core/tree_graphviz.ml
@@ -60,6 +60,7 @@ open Tree_types
 type dot_term =
   | DotDefa (* Default case *)
   | DotAbst of int
+  | DotProd of int
   | DotCons of TC.t
   | DotSuccess
   | DotFailure
@@ -77,6 +78,7 @@ let to_dot : Format.formatter -> sym -> unit = fun oc s ->
       let var_px = "v" in
       match dh with
       | DotAbst(id)          -> out "λ%s%d" var_px id
+      | DotProd(id)          -> out "Π%s%d" var_px id
       | DotDefa              -> out "*"
       | DotCons(Symb(_,n,a)) -> out "%s<sub>%d</sub>" n a
       | DotCons(Vari(i))     -> out "%s%d" var_px i
@@ -98,11 +100,11 @@ let to_dot : Format.formatter -> sym -> unit = fun oc s ->
     let rec write_tree father_l swon t =
       incr node_count;
       match t with
-      | Leaf(_,(a,_))                                           ->
+      | Leaf(_,(a,_))                                                    ->
           let _, acte = Bindlib.unmbind a in
           out "@ %d [label=\"%a\"];" !node_count Print.pp_term acte;
           out "@ %d -- %d [label=<%a>];" father_l !node_count pp_dotterm swon
-      | Node({swap; children; store; abstraction=abs; default}) ->
+      | Node({swap; children; store; abstraction=abs; default; product}) ->
           let tag = !node_count in
           (* Create node *)
           out "@ %d [label=\"@%d\"%s];" tag swap
@@ -111,20 +113,21 @@ let to_dot : Format.formatter -> sym -> unit = fun oc s ->
           out "@ %d -- %d [label=<%a>];" father_l tag pp_dotterm swon;
           TCMap.iter (fun s e -> write_tree tag (DotCons(s)) e) children;
           Option.iter (fun (x,t) -> write_tree tag (DotAbst(x)) t) abs;
+          Option.iter (fun (x,t) -> write_tree tag (DotProd(x)) t) product;
           Option.iter (write_tree tag DotDefa) default
-      | Cond({ ok ; cond ; fail })                              ->
+      | Cond({ ok ; cond ; fail })                                       ->
           let tag = !node_count in
           out "@ %d [label=<%a> shape=\"diamond\"];" tag pp_tcstr cond;
           out "@ %d -- %d [label=<%a>];" father_l tag pp_dotterm swon;
           write_tree tag DotSuccess ok;
           write_tree tag DotFailure fail
-      | Eos(l,r)                                                ->
+      | Eos(l,r)                                                         ->
           let tag = !node_count in
           out "@ %d [label=\"\" shape=\"triangle\"];" tag;
           out "@ %d -- %d [label=<%a>];" father_l tag pp_dotterm swon;
           write_tree tag DotFailure l;
           write_tree tag DotSuccess r
-      | Fail                                                    ->
+      | Fail                                                             ->
           out "@ %d [label=<!>];" !node_count;
           out "@ %d -- %d [label=\"!\"];" father_l !node_count
     in
@@ -132,11 +135,12 @@ let to_dot : Format.formatter -> sym -> unit = fun oc s ->
     begin
       match tree with
       (* First step must be done to avoid drawing a top node. *)
-      | Node({swap; store; children; default; abstraction=abs}) ->
+      | Node{swap; store; children; default; abstraction; product} ->
           out "@ 0 [label=\"@%d\"%s];" swap
             (if store then " shape=\"box\"" else "");
           TCMap.iter (fun sw c -> write_tree 0 (DotCons(sw)) c) children;
-          Option.iter (fun (x,t) -> write_tree 0 (DotAbst(x)) t) abs;
+          Option.iter (fun (x,t) -> write_tree 0 (DotAbst(x)) t) abstraction;
+          Option.iter (fun (x,t) -> write_tree 0 (DotProd(x)) t) product;
           Option.iter (fun t -> write_tree 0 DotDefa t) default
       | Leaf(_) -> ()
       | _       -> assert false

--- a/src/core/tree_types.ml
+++ b/src/core/tree_types.ml
@@ -7,13 +7,19 @@ open Extra
 (** Representation of an atomic pattern constructor. *)
 module TC =
   struct
-    (** Atomic pattern constructor. *)
+    (** Atomic pattern constructor. Terms are identified by these constructors
+        in the  trees. During  matching (in {!val:Eval.tree_walk}),  terms are
+        transformed into these constructors to get the right sub-tree. *)
     type t =
       | Symb of Files.Path.t * string * int
-      (** Symbol with its module path, name and effective arity. *)
+      (** Symbol identified by a fully qualified name (module path and name)
+          and its arity in the pattern. *)
       | Vari of int
-      (** A bound variable identified by a ({e branch}-wise) unique
-          integer. *)
+      (** A bound  variable identified by a ({e  branch}-wise) unique integer.
+          These variables  are used with  a bidirectional map  (implemented as
+          two maps) to  a higher order (Bindlib) variable. They  are also used
+          in the environment builder to refer  to the higher order variables a
+          term may depend on. *)
 
     (** {b NOTE} the effective arity carried by the representation of a symbol
         is specific to a given symbol instance. Indeed, a symbol (in the sense

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -57,5 +57,6 @@ compute J (pair _ z) kz
 // The arrow problem
 symbol arrow : U → U → U
 rule T (arrow $t $u) ↪ T $t → T $u
-// set unif_rule $a → $b ≡ T $c ↪ $a ≡ T $aa; $b ≡ T $bb; $c ≡ arrow $aa $bb
-// FIXME: implications not allowed in LHS (scoping level)
+set unif_rule $a → $b ≡ T $c ↪ $a ≡ T $ea; $b ≡ T $eb; $c ≡ arrow $ea $eb
+symbol eq (t: U): T t → T t → Bool
+compute eq _ (λ_, z) (λ_, z)


### PR DESCRIPTION
This PR introduces rewriting on products, for unification rules. Is based off #390.

Products are treated just like abstractions.

The ability to match against the domain of binders has been added, it is required to write a unification rule since `$a → $b` is syntactic sugar for `Π_:$a, $b`
```
set unif_rule $a → $b ≡ T $c ↪ $a ≡ T $ea; $b ≡ T $eb; $c ≡ arrow $ea $eb
```

Commit 57c43d2ce904a0e1bc78c8a573aac1080f783c89 is an optimisation of the rewriting engine (not really related): it ensures non linear variables are not recorded twice in the environment builder, which may reduce its size in some cases, and thus should speed up rewriting (less iterations in`List.iter fn env_builder`).

Commit d868c95 allows to print decision trees of symbols from ghost signatures (for debug).