### PR TITLE
[vscode] Fix vscode after command line changes.

### DIFF
--- a/doc/sections/ui.md
+++ b/doc/sections/ui.md
@@ -26,6 +26,9 @@ This requires to have `npm` and `node-typescript` installed:
 sudo apt install npm node-typescript
 ```
 
+_note_: as of today the vscode mode requires a full lambdapi install,
+it won't unfortunately run from a developer tree.
+
 ### Emacs
 
 The `emacs` mode is automatically installed during lambdapi installation

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -23,9 +23,11 @@ let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
 
+    // XXX: Get from configuration
     let serverOptions = {
-        command: 'lp-lsp',    // XXX: Get from configuration
-        args: [ '--std' ]
+        command: 'lambdapi',
+        args: [ 'lsp', '' ]
+        // args: [ '--std' ]
     };
 
     let clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
The PR #289 broke the vscode plugin.

We do a hotfix for now, but the mode still remains broken if using
from the dev tree [for example with `dune exec -- code`].

This is quite inconvenient, for now lambdapi must be fully installed
as to be used from vscode.