### PR TITLE
Fix various typos in the documentation

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -104,7 +104,7 @@ Exposition obeys the following rules: inside a module,
 **Implicit arguments:** Some function symbol arguments can be declared
 as implicit meaning that they must not be given by the user
 later. Implicit arguments are replaced by `_` at parsing time,
-generating a fresh metavariables. An argument declared as implicit can
+generating fresh metavariables. An argument declared as implicit can
 be explicitly given by enclosing it between curly brackets `{` ... `}`
 though. If a function symbol is prefixed by `@` then the implicit
 arguments mechanism is disabled and all the arguments must be

--- a/doc/dedukti.md
+++ b/doc/dedukti.md
@@ -19,4 +19,4 @@ using the `--beautify` command line flag (see the related section).
 Note that Lambdapi is able to type-check all the generated libraries that were
 aimed at Dedukti (with minor modifications).  Translation scripts are provided
 in the `libraries` folder and performance comparisons are given in
-[PERFS.md](../PERFS.md).
+[PERFS.md](./PERFS.md).

--- a/doc/terms.md
+++ b/doc/terms.md
@@ -51,4 +51,4 @@ An identifier can be:
 
 Subterms can be parenthesized to avoid ambiguities.
 
-In case of a the application of a function symbol, an implicit argument can be given by enclosing it between curly brackets `{` ... `}`.
+In case of the application of a function symbol, an implicit argument can be given by enclosing it between curly brackets `{` ... `}`.


### PR DESCRIPTION
While reading the documentation, I have noticed a few typos.  Here is a set of proposed changes.