### PR TITLE
Syntax of patterns

### DIFF
--- a/doc/biblio.md
+++ b/doc/biblio.md
@@ -14,6 +14,8 @@ Bibliographic references
 
 * [Definitions by rewriting in the Calculus of Constructions](https://doi.org/10.1017/S0960129504004426), Frédéric Blanqui, in Mathematical Structures in Computer Science 15(1):37-92.
 
+* [The New Rewriting Engine of Dedukti](https://www.semanticscholar.org/paper/The-New-Rewriting-Engine-of-Dedukti-Hondet-Blanqui/8ff6f9790779f9345ffa9bb02679b40e8d1d83aa), Gabriel Hondet and Frédéric Blanqui, 2020.
+
 * [Hints in Unification](http://www.cs.unibo.it/~asperti/PAPERS/tphol09.pdf),
   Andrea Asperti, Wilmer Ricciotti, Claudio Sacerdoti Cohen and Enrico Tassi.
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -128,48 +128,50 @@ Rewriting rules for definable symbols are declared using the `rule` command.
 ```
 rule add zero      $n ↪ $n
 rule add (succ $n) $m ↪ succ (add $n $m)
+rule mul zero      _  ↪ zero
 ```
 
-Note that rewriting rules can also be defined simultaneously, using the `with`
-keyword instead of the `rule` keyword for all but the first rule.
-
-```
-rule add zero      $n ↪ $n
-with add (succ $n) $m ↪ succ (add $n $m)
-```
-
-Pattern variables need to be prefixed by `$`.
+Terms prefixed by the sigil `$` and `_` are pattern variables.
 
 **Higher-order pattern-matching**.
-Lambdapi allows higher-order pattern-matching (not in full generality
-though):
+Lambdapi allows higher-order pattern-matching on patterns à la Miller but modulo
+β-equivalence only (and not βη).
 
 ```
 rule diff (λx, sin $F[x]) ↪ λx, diff (λx, $F[x]) x × cos $F[x]
+```
+
+Patterns can contain abstractions `λx, _` and the user may attach an environment
+made of *distinct* bound variables to a pattern variable to indicate which bound
+variable can occur in the matched term. The environment is a semicolon-separated
+list of variables enclosed in square brackets `[x;y;...]`. For instance, a term
+of the form `λx y,t` matches the pattern `λx y,$F[x]` only if `y` does not
+freely occur in `t`.
+
+```
 rule lam (λx, app $F[] x) ↪ $F // η-reduction
 ```
 
 Hence, the rule `lam (λx, app $F[] x) ↪ $F` implements η-reduction
 since no valid instance of `$F` can contain `x`.
 
-Pattern variables can be applied to distinct bound variables only,
-that is, the terms between `[` and `]` must be distinct bound
-variables only.
+Pattern variables cannot appear at the head of an application: `$F[] x` is not
+allowed. The converse `x $F[]` is.
 
-`$P` without square brackets is a short-hand for `$P[]`. This
-short-hand cannot be used though when `$P` occurs in a rule left-hand
-side below a binder like in the rule η above.
+A pattern variable `$P[]` can be shortened to `$P` when there is no ambiguity,
+i.e. when the variable is not under a binder (unlike in the rule η above).
 
 It is possible to define an unnamed pattern variable with the syntax
-`$_[x,y]`.
+`$_[x;y]`.
 
-If `x` and `y` are the only variables in scope, then `_` is equivalent
-to `$_[x,y]`.
+The unnamed pattern variable `_` is always the most general:
+if `x` and `y` are the only variables in scope, then `_` is equivalent
+to `$_[x;y]`.
 
-In rule left-hand sides, λ-expressions must have no type annotations.
+In rule left-hand sides, λ-expressions cannot have type annotations.
 
 **Important**. In contrast to languages like OCaml, Coq, Agda, etc. rule
- left-hand sides can contain defined symbols:
+left-hand sides can contain defined symbols:
 
 ```
 rule add (add x y) z ↪ add x (add y z)
@@ -187,6 +189,19 @@ And they can be non-linear:
 ```
 rule minus x x ↪ zero
 ```
+
+Note that rewriting rules can also be defined simultaneously, using the `with`
+keyword instead of the `rule` keyword for all but the first rule.
+
+```
+rule add zero      $n ↪ $n
+with add (succ $n) $m ↪ succ (add $n $m)
+```
+
+Adding sets of rules allows to maintain confluence.
+
+Examples of patterns are available in the file
+[`patterns.lp`](../tests/OK/patterns.lp) of the test suite.
 
 <!---------------------------------------------------------------------------->
 ### `definition`

--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -112,7 +112,7 @@ reserved "why3"
 
 // Rewriting rule
 <rule> ::=
-  | <patt> "↪" <term>
+  | <qident> {<patt>}* "↪" <term>
 
 // TODO rule naming, positive / negative
 

--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -98,8 +98,11 @@ reserved "why3"
 // Synonym for types
 <type> ::= <term>
 
-// Synonym for patterns
-<patt> ::= <term>
+// Patterns
+<patt> ::=
+  | "$" - {<ident> | "_"} {"[" <ident> {";" <ident>}* "]"}?
+  | "λ" <arg>+ "," <patt>
+  | <qident> {<patt>}*
 
 // Argument (of abstraction, product, ...), may be marked implicit
 <arg> ::=

--- a/doc/terms.md
+++ b/doc/terms.md
@@ -20,7 +20,7 @@ An identifier can be:
   
 **Convention:** identifiers starting with a capital letter denote types and predicates (e.g. `Nat`, `List`), and identifiers starting with a small letter denote constructors, functions and proofs (e.g. `zero`, `add`, `refl`).
 
-**Terms:* A user-defined term can be either:
+**Terms:** A user-defined term can be either:
 
  * `TYPE`
 

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -546,9 +546,12 @@ module CM = struct
           let arity = List.length pargs in
           let e = Array.make arity (Patt(None, "", [||])) in
           Some({ r with c_lhs = insert e })
+      | Symb(_), Vari(_)
+      | Vari(_), Symb(_)
       | _      , Prod(_)
       | _      , Abst(_) -> None
       | _      , _       -> assert false
+          (* Terms matched (in this case) should not appear in matrices. *)
     in
     (pos, List.filter_map filtrans cls)
 

--- a/tests/OK/patterns.lp
+++ b/tests/OK/patterns.lp
@@ -61,7 +61,7 @@ symbol diff1: (E → E → E) → E → E → E
 // the environment.
 rule diff1 (λx, λy, $v[x]) ↪ λ_, diff (λx, $v[x])
 assertnot diff1 (λx y, bin x y) ≡ λ_ _, e
-// assert diff1 (λx _, x) ≡ λ_, λ_, succ e // FIXME: assertion failed
+assert diff1 (λx _, x) ≡ λ_, λ_, succ e
 // this rule can be written more simply as
 rule diff1 (λx _, _) ↪ λ_ _, e
 assertnot diff1 (λx y, bin x y) ≡ λ_ _, e

--- a/tests/OK/patterns.lp
+++ b/tests/OK/patterns.lp
@@ -1,0 +1,80 @@
+// Rewrite rule patterns
+symbol E: TYPE
+symbol e: E
+symbol e': E
+symbol Bool: TYPE
+symbol true: Bool
+symbol false: Bool
+
+symbol id : E → E
+// The pattern ‘$x’ filters any term making ‘id’ the identity on ‘E’
+rule id $x ↪ $x
+assert λx, id x ≡ λx, x
+
+symbol succ: E → E
+symbol pred: E → E
+// A pattern can contain (possibly applied) function symbols, as the pattern
+// ‘pred $e’ here, or ‘pred (succ e)’.
+rule succ (pred $e) ↪ $e
+assert succ (pred e) ≡ e
+assert succ (pred (succ e)) ≡ succ e
+
+symbol ListE: TYPE
+symbol cons: E → ListE → ListE
+symbol nil: ListE
+symbol map: (E → E) → ListE → ListE
+// A pattern can filter functions as well, such as the pattern ‘$f’ which
+// filters functions from ‘E’ to ‘E’.
+rule map $f (cons $e $l) ↪ cons ($f $e) (map $f $l)
+// The wildcard ‘_’ is always the most general pattern, it filters any term (it
+// is an unnamed pattern).
+rule map _ nil ↪ nil
+assert map id (cons e (cons e nil)) ≡ cons e (cons e nil)
+// Another example
+symbol diff: (E → E) → E → E
+symbol fprod: (E → E) → (E → E) → E → E
+symbol o: (E → E) → (E → E) → E → E
+// ‘$f’ and ‘$g’ both filter functions
+rule diff (o $f $g) ↪ fprod (diff $f) (o (diff $g) $f)
+
+symbol mem: E → ListE → Bool
+// Terms filtered by patterns with the same name must be convertible
+rule mem $x (cons $x _) ↪ true
+assert mem e (cons e nil) ≡ true
+assertnot mem e' (cons e nil) ≡ true
+
+// Abstractions can be matched, as well as bound variables
+rule diff (λx, x) ↪ λ_, succ e
+
+// Since application is matched, the previous rule can be written
+rule diff (λx, x) _ ↪ succ e
+
+symbol cos: E → E    symbol sin: E → E
+// Terms filtered may contain bound variables if the allowed variables are
+// indicated inside brackets as in ‘$v[x]’, which can contain variable ‘x’.
+rule diff (λx, sin $v[x]) ↪ fprod (diff (λx, $v[x])) cos
+
+symbol bin: E → E → E
+symbol diff1: (E → E → E) → E → E → E
+// A pattern variable with an environment filters terms that, among the bound
+// variables in the scope of the pattern variable, contain at most the ones in
+// the environment.
+rule diff1 (λx, λy, $v[x]) ↪ λ_, diff (λx, $v[x])
+assertnot diff1 (λx y, bin x y) ≡ λ_ _, e
+// assert diff1 (λx _, x) ≡ λ_, λ_, succ e // FIXME: assertion failed
+// this rule can be written more simply as
+rule diff1 (λx _, _) ↪ λ_ _, e
+assertnot diff1 (λx y, bin x y) ≡ λ_ _, e
+
+symbol scope: (E → E) → E
+rule scope (λ_, $p[]) ↪ $p[]
+// The environment of a pattern variable only concerns variables in its
+// scope at declaration time
+assert λx, scope (λ_, x) ≡ λx, x
+// Here the ‘x’ variable is not introduced by the abstraction matched in the
+// rule on ‘scope’, so it may appear in the term that matches ‘$p[]’.
+
+symbol f: ((E → E) → E → E) → E
+// Application of bound variables to patterns are authorised
+rule f (λx _, x $p[]) ↪ $p[]
+assert f (λx _, x e) ≡ e


### PR DESCRIPTION
Detail the syntax of patterns in the BNF, plus a correction in `terms.md`.