### PR TITLE
[WIP] Configuration to enforce rule order

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -76,30 +76,35 @@ Data types and predicates must be given types of the form
 We recommend to start types and predicates by a capital letter.
 
 **Modifiers:**
- - `constant`: no rule can be added to the symbol
- - `injective`: the symbol can be considered as injective, that is,
- if `f t1 .. tn` ≡ `f u1 .. un`, then `t1`≡`u1`, ..., `tn`≡`un`.
- For the moment, the verification is left to the user.
+- Modifiers for the unification engine,
+  - `constant`: no rule can be added to the symbol
+  - `injective`: the symbol can be considered as injective, that is, if `f t1 ..
+     tn` ≡ `f u1 .. un`, then `t1`≡`u1`, ..., `tn`≡`un`. For the moment, the
+     verification is left to the user.
 
-These modifiers are used to help the unification engine.
+- Exposition markers define how a symbol can be used outside the module where it
+  is defined.
+  - `public` (default): the symbol can be used without restriction
+  - `private`: the symbol cannot be used
+  - `protected`: the symbol can only be used in left-hand side of rewrite rules.
 
-**Exposition markers:**
-Exposition defines how a symbol can be used outside the module where it is
-defined. By default any symbol is _public_, which means it can be used without
-restriction anywhere. There are two exposition markers available:
-- `private`: the symbol cannot be used outside of its module (can be compared to
-  a symbol not in the interface in OCaml);
-- `protected`: the symbol can only be used in left-hand side of rewrite rules
-  outside of its module.
+  Exposition markers obey the following rules: inside a module,
+  - private symbols cannot appear in the type of public symbols;
+  - private symbols cannot appear in the right-hand side of a rewriting rule
+    defining a public symbol
+  - externally defined protected symbols cannot appear at the head of a
+    left-hand side
+  - externally defined protected symbols cannot appear in the right hand side of
+    a rewriting rule
 
-Exposition obeys the following rules: inside a module,
-- private symbols cannot appear in the type of public symbols;
-- private symbols cannot appear in the right-hand side of a rewriting rule
-  defining a public symbol
-- externally defined protected symbols cannot appear at the head of a left-hand
-  side
-- externally defined protected symbols cannot appear in the right hand side of a
-  rewriting rule
+- `sequential`: modifies the pattern matching algorithm. By default, the order
+  of rule declarations is not taken into account. This modifier tells Lambdapi
+  to apply rules defining a sequential symbol in the order they have been
+  declared (note that the order of the rules may depend on the order of the
+  `require` commands). An example can be seen in 
+  [`rule_order.lp`](../tests/OK/rule_order.lp).  
+  *WARNING:* using this modifier can break important properties.
+
 
 **Implicit arguments:** Some function symbol arguments can be declared
 as implicit meaning that they must not be given by the user

--- a/src/cli/config.ml
+++ b/src/cli/config.ml
@@ -13,7 +13,6 @@ type config =
   { gen_obj     : bool
   ; lib_root    : string option
   ; map_dir     : (string * string) list
-  ; keep_order  : bool
   ; verbose     : int option
   ; no_warnings : bool
   ; debug       : string
@@ -30,7 +29,6 @@ let default_config =
   { gen_obj     = false
   ; lib_root    = None
   ; map_dir     = []
-  ; keep_order  = false
   ; verbose     = None
   ; no_warnings = false
   ; debug       = ""
@@ -46,7 +44,6 @@ let init : config -> unit = fun cfg ->
   Compile.gen_obj := cfg.gen_obj;
   Option.iter Files.set_lib_root cfg.lib_root;
   List.iter (fun (m,d) -> Files.new_lib_mapping (m ^ ":" ^ d)) cfg.map_dir;
-  Tree.rule_order := cfg.keep_order;
   Option.iter set_default_verbose cfg.verbose;
   no_wrn := cfg.no_warnings;
   set_default_debug cfg.debug;
@@ -181,13 +178,13 @@ let termination : string option Term.t =
 
 (** [full] gathers the command line arguments common to most commands. *)
 let full : config Term.t =
-  let fn gen_obj lib_root map_dir keep_order verbose no_warnings
+  let fn gen_obj lib_root map_dir verbose no_warnings
       debug no_colors too_long confluence termination =
-    { gen_obj ; lib_root ; map_dir ; keep_order ; verbose ; no_warnings
+    { gen_obj ; lib_root ; map_dir ; verbose ; no_warnings
     ; debug ; no_colors ; too_long ; confluence ; termination }
   in
   let open Term in
-  const fn $ gen_obj $ lib_root $ map_dir $ keep_order $ verbose
+  const fn $ gen_obj $ lib_root $ map_dir $ verbose
   $ no_warnings $ debug $ no_colors $ too_long $ confluence $ termination
 
 (** [minimal] gathers the minimal command line options to enable debugging and

--- a/src/core/handle.ml
+++ b/src/core/handle.ml
@@ -102,7 +102,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
   | P_open(ps)                  ->
      let ps = List.map (List.map fst) ps in
      (List.fold_left (handle_open cmd.pos) ss ps, None)
-  | P_symbol(e, p, x, xs, a) ->
+  | P_symbol(e, p, st, x, xs, a) ->
       (* We check that [x] is not already used. *)
       if Sign.mem ss.signature x.elt then
         fatal x.pos "Symbol [%s] already exists." x.elt;
@@ -122,7 +122,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
         end;
       (* Actually add the symbol to the signature and the state. *)
       out 3 "(symb) %s : %a\n" x.elt pp_term a;
-      (Sig_state.add_symbol ss e p x a impl None, None)
+      (Sig_state.add_symbol ss e p st x a impl None, None)
   | P_rules(rs)                ->
       (* Scoping and checking each rule in turn. *)
       let handle_rule r =
@@ -185,7 +185,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
       (* Actually add the symbol to the signature. *)
       out 3 "(symb) %s ≔ %a\n" x.elt pp_term t;
       let d = if op then None else Some(t) in
-      let ss = Sig_state.add_symbol ss e Defin x a impl d in
+      let ss = Sig_state.add_symbol ss e Defin Eager x a impl d in
       (ss, None)
   | P_theorem(e, stmt, ts, pe) ->
       let (x,xs,a) = stmt.elt in
@@ -223,7 +223,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
             (* Add a symbol corresponding to the proof, with a warning. *)
             out 3 "(symb) %s (admit)\n" x.elt;
             wrn cmd.pos "Proof admitted.";
-            Sig_state.add_symbol ss e Const x a impl None
+            Sig_state.add_symbol ss e Const Eager x a impl None
         | P_proof_qed   ->
             (* Check that the proof is indeed finished. *)
             if not (Proof.finished st) then
@@ -233,7 +233,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
               end;
             (* Add a symbol corresponding to the proof. *)
             out 3 "(symb) %s (qed)\n" x.elt;
-            Sig_state.add_symbol ss e Const x a impl None
+            Sig_state.add_symbol ss e Const Eager x a impl None
       in
       let data =
         { pdata_stmt_pos = stmt.pos ; pdata_p_state = st ; pdata_tactics = ts

--- a/src/core/legacy_lexer.mll
+++ b/src/core/legacy_lexer.mll
@@ -27,7 +27,7 @@ type token =
   | L_SQB | R_SQB | L_PAR | R_PAR | ARROW | LARROW | FARROW | DEFEQ | COMMA
   | COLON | EQUAL | DOT | EOF
   (* Keywords. *)
-  | KW_DEF | KW_INJ | KW_THM | TYPE | KW_PRV
+  | KW_DEF | KW_INJ | KW_THM | TYPE | KW_PRV | KW_SEQ
   (* Identifiers and wildcard. *)
   | WILD
   | ID      of string

--- a/src/core/menhir_parser.mly
+++ b/src/core/menhir_parser.mly
@@ -241,73 +241,66 @@ let build_config : Pos.pos -> string -> string option -> eval_config =
 %%
 
 line:
-  | s=ID ps=param* COLON a=term DOT
+  | ms=modifier* s=ID ps=param* COLON a=term DOT
     {
+      (* Add the "constant" modifier by default. *)
+      let is_prop {elt; _} = match elt with P_prop(_) -> true | _ -> false in
+      let ms =
+        match List.find_opt is_prop ms with
+        | Some(_) -> ms
+        | None -> make_pos Lexing.(dummy_pos, dummy_pos) (P_prop(Const)) :: ms
+      in
+      make_pos $loc (P_symbol(ms, make_pos $loc(s) s, ps, a))
+    }
+  | ms=modifier* KW_DEF s=ID COLON a=term DOT
+    {
+      (* Add the "definable" modifier by default. *)
+      let is_prop {elt; _} = match elt with P_prop(_) -> true | _ -> false in
+      let ms =
+        match List.find_opt is_prop ms with
+        | Some(_) -> ms
+        | None -> make_pos Lexing.(dummy_pos, dummy_pos) (P_prop(Defin)) :: ms
+      in
       let t =
-        P_symbol (Terms.Public, Terms.Const, Terms.Eager,
-                  make_pos $loc(s) s, ps, a)
+        P_symbol (ms, make_pos $loc(s) s, [], a)
       in
       make_pos $loc t
     }
-  | KW_DEF s=ID COLON a=term DOT
+  | ms=modifier* KW_DEF s=ID COLON a=term DEFEQ t=term DOT
     {
       let t =
-        P_symbol (Terms.Public, Terms.Defin, Terms.Eager,
-                  make_pos $loc(s) s, [], a)
+        P_definition (ms, false, make_pos $loc(s) s, [], Some(a), t)
       in
       make_pos $loc t
     }
-  | KW_INJ s=ID COLON a=term DOT
-    {
-      let t =
-        P_symbol (Terms.Public, Terms.Injec, Terms.Eager,
-                  make_pos $loc(s) s, [], a)
-      in
-      make_pos $loc t
-    }
-  | KW_PRV s=ID COLON a=term DOT
-    {
-      let t =
-        P_symbol (Terms.Protec, Terms.Defin, Terms.Eager,
-                  make_pos $loc(s) s, [], a)
-      in
-      make_pos $loc t
-    }
-  | KW_DEF s=ID COLON a=term DEFEQ t=term DOT
-    {
-      let t =
-        P_definition (Terms.Public, false, make_pos $loc(s) s, [], Some(a), t)
-      in
-      make_pos $loc t
-    }
-  | KW_DEF s=ID DEFEQ t=term DOT
+  | ms=modifier* KW_DEF s=ID DEFEQ t=term DOT
     {
       let t = P_definition
-                (Terms.Public, false, make_pos $loc(s) s, [], None, t) in
+                (ms, false, make_pos $loc(s) s, [], None, t) in
       make_pos $loc t
     }
-  | KW_DEF s=ID ps=param+ COLON a=term DEFEQ t=term DOT
+  | ms=modifier* KW_DEF s=ID ps=param+ COLON a=term DEFEQ t=term DOT
     {
       let t = P_definition
-                (Terms.Public, false, make_pos $loc(s) s, ps, Some(a), t) in
+                (ms, false, make_pos $loc(s) s, ps, Some(a), t) in
       make_pos $loc t
     }
-  | KW_DEF s=ID ps=param+ DEFEQ t=term DOT
+  | ms=modifier* KW_DEF s=ID ps=param+ DEFEQ t=term DOT
     {
       let t = P_definition
-                (Terms.Public, false, make_pos $loc(s) s, ps, None, t) in
+                (ms, false, make_pos $loc(s) s, ps, None, t) in
       make_pos $loc t
     }
-  | KW_THM s=ID COLON a=term DEFEQ t=term DOT
+  | ms=modifier* KW_THM s=ID COLON a=term DEFEQ t=term DOT
     {
       let t = P_definition
-                (Terms.Public, true , make_pos $loc(s) s, [], Some(a), t) in
+                (ms, true , make_pos $loc(s) s, [], Some(a), t) in
       make_pos $loc t
     }
-  | KW_THM s=ID ps=param+ COLON a=term DEFEQ t=term DOT
+  | ms=modifier* KW_THM s=ID ps=param+ COLON a=term DEFEQ t=term DOT
     {
       let t = P_definition
-                (Terms.Public, true , make_pos $loc(s) s, ps, Some(a), t) in
+                (ms, true , make_pos $loc(s) s, ps, Some(a), t) in
       make_pos $loc t
     }
   | rs=rule+ DOT {
@@ -356,6 +349,10 @@ param:
   | L_PAR id=ID COLON te=term R_PAR {
       ([Some (make_pos $loc(id) id)], Some(te), false)
     }
+
+modifier:
+  | KW_PRV { make_pos $loc (P_expo(Terms.Privat)) }
+  | KW_INJ { make_pos $loc (P_prop(Terms.Injec)) }
 
 context_item:
   | x=ID ao=option(COLON a=term { a }) { (make_pos $loc(x) x, ao) }

--- a/src/core/menhir_parser.mly
+++ b/src/core/menhir_parser.mly
@@ -243,32 +243,41 @@ let build_config : Pos.pos -> string -> string option -> eval_config =
 line:
   | s=ID ps=param* COLON a=term DOT
     {
-      let t = P_symbol
-                (Terms.Public, Terms.Const, make_pos $loc(s) s, ps, a) in
+      let t =
+        P_symbol (Terms.Public, Terms.Const, Terms.Eager,
+                  make_pos $loc(s) s, ps, a)
+      in
       make_pos $loc t
     }
   | KW_DEF s=ID COLON a=term DOT
     {
-      let t = P_symbol
-                (Terms.Public, Terms.Defin, make_pos $loc(s) s, [], a) in
+      let t =
+        P_symbol (Terms.Public, Terms.Defin, Terms.Eager,
+                  make_pos $loc(s) s, [], a)
+      in
       make_pos $loc t
     }
   | KW_INJ s=ID COLON a=term DOT
     {
-      let t = P_symbol
-                (Terms.Public, Terms.Injec, make_pos $loc(s) s, [], a) in
+      let t =
+        P_symbol (Terms.Public, Terms.Injec, Terms.Eager,
+                  make_pos $loc(s) s, [], a)
+      in
       make_pos $loc t
     }
   | KW_PRV s=ID COLON a=term DOT
     {
-      let t = P_symbol
-                (Terms.Protec, Terms.Defin, make_pos $loc(s) s, [], a) in
+      let t =
+        P_symbol (Terms.Protec, Terms.Defin, Terms.Eager,
+                  make_pos $loc(s) s, [], a)
+      in
       make_pos $loc t
     }
   | KW_DEF s=ID COLON a=term DEFEQ t=term DOT
     {
-      let t = P_definition
-                (Terms.Public, false, make_pos $loc(s) s, [], Some(a), t) in
+      let t =
+        P_definition (Terms.Public, false, make_pos $loc(s) s, [], Some(a), t)
+      in
       make_pos $loc t
     }
   | KW_DEF s=ID DEFEQ t=term DOT

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -190,6 +190,7 @@ let _refl_       = KW.create "reflexivity"
 let _require_    = KW.create "require"
 let _rewrite_    = KW.create "rewrite"
 let _rule_       = KW.create "rule"
+let _sequential_ = KW.create "sequential"
 let _set_        = KW.create "set"
 let _simpl_      = KW.create "simpl"
 let _sym_        = KW.create "symmetry"
@@ -350,6 +351,10 @@ let parser property =
 let parser exposition =
   | _protected_ -> Terms.Protec
   | _private_   -> Terms.Privat
+
+(** [mstrat] parses the matching strategy tag of a symbol. *)
+let parser mstrat =
+  | _sequential_ -> Terms.Sequen
 
 (** [term_ident] parses a qualified identifier and returns a p_term. *)
 let parser term_ident =
@@ -655,9 +660,10 @@ let parser cmd =
   | _open_ ps:path+
       -> List.iter (get_ops _loc) ps;
          P_open(ps)
-  | e:exposition? p:property? _symbol_ s:ident al:arg* ":" a:term
+  | st:mstrat? e:exposition? p:property? _symbol_ s:ident al:arg* ":" a:term
       -> P_symbol(Option.get Terms.Public e,
-                  Option.get Terms.Defin p,s,al,a)
+                  Option.get Terms.Defin p,
+                  Option.get Terms.Eager st, s,al,a)
   | _rule_ r:rule rs:{_:_with_ rule}*
       -> P_rules(r::rs)
   | e:exposition? _definition_ s:ident al:arg* ao:{":" term}? "≔" t:term

--- a/src/core/pos.ml
+++ b/src/core/pos.ml
@@ -70,10 +70,14 @@ let in_pos : pos -> 'a -> 'a loc =
 let none : 'a -> 'a loc =
   fun elt -> { elt ; pos = None }
 
-(** [to_string pos] transforms [pos] into a readable string. *)
-let to_string : pos -> string = fun p ->
+(** [to_string ?print_fname pos] transforms [pos] into a readable string. If
+    [print_fname] is [true] (the default), the filename contained in [pos] is
+    printed. *)
+let to_string : ?print_fname:bool -> pos -> string =
+  fun ?(print_fname=true) p ->
   let {fname; start_line; start_col; end_line; end_col} = Lazy.force p in
   let fname =
+    if not print_fname then "" else
     match fname with
     | None    -> ""
     | Some(n) -> n ^ ", "
@@ -90,3 +94,10 @@ let print : Format.formatter -> pos option -> unit = fun ch p ->
   match p with
   | None    -> Format.pp_print_string ch "unknown location"
   | Some(p) -> Format.pp_print_string ch (to_string p)
+
+(** [print_short oc pos] prints the optional position [pos] to [oc] without
+    the filename. *)
+let print_short : Format.formatter -> pos option -> unit = fun ch p ->
+  match p with
+  | None -> Format.pp_print_string ch "unknown location"
+  | Some(p) -> Format.pp_print_string ch (to_string ~print_fname:false p)

--- a/src/core/pretty.ml
+++ b/src/core/pretty.ml
@@ -44,6 +44,11 @@ let pp_prop : Terms.prop pp = fun oc p ->
   | Const -> Format.pp_print_string oc "constant "
   | Injec -> Format.pp_print_string oc "injective "
 
+let pp_mstrat : Terms.match_strat pp = fun oc s ->
+  match s with
+  | Eager -> ()
+  | Sequen -> Format.pp_print_string oc "sequential"
+
 let rec pp_p_term : p_term pp = fun oc t ->
   let open Parser in (* for PAtom, PAppl and PFunc *)
   let out fmt = Format.fprintf oc fmt in
@@ -220,8 +225,9 @@ let pp_command : p_command pp = fun oc cmd ->
       out "require %a as %a" (pp_path cmd.pos) p (pp_path_elt i.pos) i.elt
   | P_open(ps)                      ->
       List.iter (out "open %a" (pp_path cmd.pos)) ps
-  | P_symbol(e,p,s,args,a)    ->
-      out "@[<hov 2>%a%asymbol %a" pp_expo e pp_prop p pp_ident s;
+  | P_symbol(e,p,st,s,args,a) ->
+      out "@[<hov 2>%a%a%asymbol %a" pp_mstrat st pp_expo e pp_prop p
+        pp_ident s;
       List.iter (out " %a" pp_p_arg) args;
       out " :@ @[<hov>%a@]" pp_p_term a
   | P_rules([])                     -> ()

--- a/src/core/sig_state.ml
+++ b/src/core/sig_state.ml
@@ -79,13 +79,12 @@ let remove_pp_hint_eq :
     if eq_pp_hint h h' then SymMap.remove s pp_hints else pp_hints
   with Not_found -> pp_hints
 
-(** [add_symbol ss e p x a impl] generates a new signature state from [ss] by
-   creating a new symbol with expo [e], property [p], name [x], type [a],
-   implicit arguments [impl] and optional definition [t]. *)
-let add_symbol : sig_state -> expo -> prop -> strloc -> term -> bool list
-                 -> term option -> sig_state =
-  fun ss e p x a impl t ->
-  let s = Sign.add_symbol ss.signature e p x a impl in
+(** [add_symbol ss e p st x a impl] generates a new signature state from [ss]
+   by creating a new symbol with expo [e], property [p], strategy [st], name
+   [x], type [a], implicit arguments [impl] and optional definition [t]. *)
+let add_symbol : sig_state -> expo -> prop -> match_strat -> strloc -> term ->
+  bool list -> term option -> sig_state = fun ss e p st x a impl t ->
+  let s = Sign.add_symbol ss.signature e p st x a impl in
   begin
     match t with
     | Some t -> s.sym_def := Some (cleanup t)

--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -200,6 +200,12 @@ type p_config =
 (** Parser-level representation of a single command. *)
 type p_statement = (ident * p_arg list * p_type) loc
 
+(** Parser-level representation of modifiers. *)
+type p_modifier =
+  | P_mstrat of Terms.match_strat
+  | P_expo of Terms.expo
+  | P_prop of Terms.prop
+
 type p_command_aux =
   | P_require    of bool * p_module_path list
   (** Require statement (require open if the boolean is true). *)
@@ -207,15 +213,15 @@ type p_command_aux =
   (** Require as statement. *)
   | P_open       of p_module_path list
   (** Open statement. *)
-  | P_symbol     of Terms.expo * Terms.prop * Terms.match_strat * ident *
-                    p_arg list * p_type
+  | P_symbol     of p_modifier loc list * ident * p_arg list * p_type
   (** Symbol declaration. *)
   | P_rules      of p_rule list
   (** Rewriting rule declarations. *)
-  | P_definition of Terms.expo * bool * ident * p_arg list * p_type option
-                  * p_term
+  | P_definition of p_modifier loc list * bool * ident * p_arg list *
+                    p_type option * p_term
   (** Definition of a symbol (unfoldable). *)
-  | P_theorem    of Terms.expo * p_statement * p_tactic list * p_proof_end loc
+  | P_theorem    of p_modifier loc list * p_statement * p_tactic list *
+                    p_proof_end loc
   (** Theorem with its proof. *)
   | P_set        of p_config
   (** Set the configuration. *)
@@ -354,8 +360,8 @@ let eq_p_command : p_command eq = fun c1 c2 ->
      List.equal (=) ps1 ps2
   | (P_require_as(p1,id1)  , P_require_as(p2,id2)              ) ->
      p1 = p2 && id1.elt = id2.elt
-  | (P_symbol(e1,l1,t1,s1,al1,a1), P_symbol(e2,l2,t2,s2,al2,a2)) ->
-      t1 = t2 && e1 = e2 && l1 = l2 && eq_ident s1 s2 && eq_p_term a1 a2
+  | (P_symbol(m1,s1,al1,a1), P_symbol(m2,s2,al2,a2)) ->
+      m1 = m2 && eq_ident s1 s2 && eq_p_term a1 a2
       && List.equal eq_p_arg al1 al2
   | (P_rules(rs1)                , P_rules(rs2)                ) ->
       List.equal eq_p_rule rs1 rs2

--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -207,7 +207,8 @@ type p_command_aux =
   (** Require as statement. *)
   | P_open       of p_module_path list
   (** Open statement. *)
-  | P_symbol     of Terms.expo * Terms.prop * ident * p_arg list * p_type
+  | P_symbol     of Terms.expo * Terms.prop * Terms.match_strat * ident *
+                    p_arg list * p_type
   (** Symbol declaration. *)
   | P_rules      of p_rule list
   (** Rewriting rule declarations. *)
@@ -353,8 +354,8 @@ let eq_p_command : p_command eq = fun c1 c2 ->
      List.equal (=) ps1 ps2
   | (P_require_as(p1,id1)  , P_require_as(p2,id2)              ) ->
      p1 = p2 && id1.elt = id2.elt
-  | (P_symbol(e1,l1,s1,al1,a1)   , P_symbol(e2,l2,s2,al2,a2)   ) ->
-      e1 = e2 && l1 = l2 && eq_ident s1 s2 && eq_p_term a1 a2
+  | (P_symbol(e1,l1,t1,s1,al1,a1), P_symbol(e2,l2,t2,s2,al2,a2)) ->
+      t1 = t2 && e1 = e2 && l1 = l2 && eq_ident s1 s2 && eq_p_term a1 a2
       && List.equal eq_p_arg al1 al2
   | (P_rules(rs1)                , P_rules(rs2)                ) ->
       List.equal eq_p_rule rs1 rs2

--- a/src/core/terms.ml
+++ b/src/core/terms.ml
@@ -30,6 +30,15 @@ type expo =
   | Privat
   (** Not visible and thus not usable. *)
 
+(** Pattern-matching strategy modifiers. *)
+type match_strat =
+  | Sequen
+  (** Rules are processed sequentially: a rule can be applied only if the
+      previous ones (in the order of declaration) cannot be. *)
+  | Eager
+    (** Any rule that filters a term can be applied (even if a rule defined
+        earlier filters the term as well). This is the default. *)
+
 (** Representation of a term (or types) in a general sense. Values of the type
     are also used, for example, in the representation of patterns or rewriting
     rules. Specific constructors are included for such applications,  and they
@@ -99,7 +108,9 @@ type term =
   ; sym_prop  : prop
   (** Property of the symbol. *)
   ; sym_expo  : expo
-  (** The visibility of the symbol. *) }
+  (** The visibility of the symbol. *)
+  ; sym_mstrat: match_strat ref
+  (** The reduction strategy modifier. *) }
 
 (** {b NOTE} that {!field:sym_type} holds a (timed) reference for a  technical
     reason related to the writing of signatures as binary files  (in  relation

--- a/src/core/unif_rule.ml
+++ b/src/core/unif_rule.ml
@@ -29,7 +29,9 @@ let sign : Sign.t =
 let equiv : sym =
   let path = List.map (fun s -> (s, false)) path in
   let bo = ("≡", Assoc_none, 1.1, Pos.none (path, "#equiv")) in
-  let sym = Sign.add_symbol sign Public Defin (Pos.none "#equiv") Kind [] in
+  let sym =
+    Sign.add_symbol sign Public Defin Eager (Pos.none "#equiv") Kind []
+  in
   Sign.add_binop sign "≡" (sym, bo);
   sym
 
@@ -40,7 +42,9 @@ let equiv : sym =
 let cons : sym =
   let path = List.map (fun s -> (s, false)) path in
   let bo = (";", Assoc_right, 1.0, Pos.none (path, "#cons")) in
-  let sym = Sign.add_symbol sign Public Defin (Pos.none "#cons") Kind [] in
+  let sym =
+    Sign.add_symbol sign Public Defin Eager (Pos.none "#cons") Kind []
+  in
   Sign.add_binop sign ";" (sym, bo);
   sym
 

--- a/src/core/why3_tactic.ml
+++ b/src/core/why3_tactic.ml
@@ -196,7 +196,8 @@ let handle :
   let trm = !((Proof.Goal.get_meta g).meta_type) in
   (* Add the axiom to the current signature. *)
   let a =
-    Sign.add_symbol ss.signature Privat Const (Pos.none axiom_name) trm []
+    Sign.add_symbol ss.signature Privat Const Eager
+      (Pos.none axiom_name) trm []
   in
   (* Tell the user that the goal is proved (verbose 2). *)
   if !log_enabled then log_why3 "goal proved: axiom [%s] created" axiom_name;

--- a/tests/OK/rule_order.lp
+++ b/tests/OK/rule_order.lp
@@ -1,0 +1,22 @@
+symbol E: TYPE
+symbol e: E
+symbol ListE: TYPE
+symbol nil: ListE
+symbol cons: E → ListE → ListE
+
+symbol Bool: TYPE
+symbol true: Bool
+symbol false: Bool
+
+sequential symbol mem: E → ListE → Bool
+rule mem $e (cons $e _) ↪ true
+rule mem $e (cons _ $l) ↪ mem $e $l
+rule mem _ nil ↪ false
+
+symbol mem2: E → ListE → Bool
+rule mem2 $e (cons $e _) ↪ true
+rule mem2 $e (cons _ $l) ↪ mem $e $l
+rule mem2 _ nil ↪ false
+
+assert mem e (cons e nil) ≡ true
+assert mem2 e (cons e nil) ≡ false


### PR DESCRIPTION
In answer to #331, this pull request allows the user to annotate symbols to change the behaviour of the rewriting engine when it filters terms headed by the symbol.

If the term reduced starts with such an annotated symbol, a rewriting rule defined on this symbol can be applied if and only if the previous rules (in the order of declaration) can not be applied.

A symbol is annotated when it is declared using the `sequential` keyword:
```
sequential symbol mem: ...
```

Remaining to be done
- [x] better variable names (replacing `kro`, find a better name for `keep_rule_order`?)
- [x] documentation
- [x] test files