### PR TITLE
XTC export fix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,6 +32,8 @@ tests: bin
 	@dune exec -- tests/commands.sh \
 && printf '\033[32mOK\033[0m commands.sh\n' \
 || { printf '\033[31mKO\033[0m commands.sh\n'; exit 1; }
+	@printf "## XTC tests ##\n"
+	@dune exec -- tests/xtc.sh
 	@printf "## KO tests ##\n"
 	@for file in $(KO_TESTFILES) ; do \
 		$(LAMBDAPI) --verbose 0 $$file 2> /dev/null \
@@ -51,6 +53,8 @@ real_tests: bin
 	@dune exec -- tests/commands.sh \
 && printf '\033[32mOK\033[0m commands.sh\n' \
 || { printf '\033[31mKO\033[0m commands.sh\n'; exit 1; }
+	@printf "## XTC tests ##\n"
+	@dune exec -- tests/xtc.sh
 	@printf "## KO tests ##\n"
 	@for file in $(KO_TESTFILES) ; do \
 		$(LAMBDAPI) --verbose 0 $$file 2> /dev/null \

--- a/src/core/unif_rule.ml
+++ b/src/core/unif_rule.ml
@@ -8,6 +8,7 @@ open Timed
 open Files
 open Terms
 open Syntax
+open Extra
 
 (** Path of the module. *)
 let path = Path.ghost "unif_rule"
@@ -76,3 +77,6 @@ let rec p_unpack : p_term -> (p_term * p_term) list = fun eqs ->
       else if id s = "#equiv" then [(v, w)] else
       assert false (* Ill-formed term. *)
   | _                               -> assert false (* Ill-formed term. *)
+
+(** [is_ghost s] is true iff [s] is a symbol of the ghost signature. *)
+let is_ghost : sym -> bool = fun s -> s == equiv || s == cons

--- a/src/core/xtc.ml
+++ b/src/core/xtc.ml
@@ -178,8 +178,12 @@ let to_XTC : Format.formatter -> Sign.t -> unit = fun oc sign ->
   let deps = Sign.dependencies sign in
   (* Function to iterate over every symbols. *)
   let iter_symbols : (sym -> unit) -> unit = fun fn ->
+    (* Iterate on all symbols of a signature, excluding ghost symbols. *)
     let iter_symbols sign =
-      StrMap.iter (fun _ (s,_) -> fn s) Sign.(!(sign.sign_symbols))
+      let not_on_ghosts _ (s, _) =
+        if not (Unif_rule.is_ghost s) then fn s
+      in
+      StrMap.iter not_on_ghosts Sign.(!(sign.sign_symbols))
     in
     List.iter (fun (_, sign) -> iter_symbols sign) deps
   in

--- a/tests/xtc.sh
+++ b/tests/xtc.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# xtc.sh         Test XTC export
+set -euf
+
+ko() {
+    printf '\033[31mKO\033[0m %s\n' "$1"
+    exit 1
+}
+
+ok() {
+    printf '\033[32mOK\033[0m %s\n' "$1"
+    exit 0
+}
+
+LAMBDAPI="lambdapi check --termination 'cat > /dev/null; printf YES' \
+--verbose 0 --lib-root=lib"
+
+if ${LAMBDAPI} tests/OK/nat.lp 2>/dev/null; then
+    ko "XTC"
+else
+    ok "XTC"
+fi
+exit 0


### PR DESCRIPTION
Before this pull request, the XTC export processed ghost symbols, which raised an exception. This pull request filters symbols to avoid processing symbols of ghost signatures.

An XTC export unit test has been added as well.

Fixes #438.