### PR TITLE
Dune 2 + Package management in test suite

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 1.11)
+(lang dune 2.1)
 (name lambdapi)
 
 (using menhir 1.0)

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -21,7 +21,7 @@ doc: "https://deducteam.github.io/lambdapi/"
 
 depends: [
   "ocaml"        { >= "4.05.0" }
-  "dune"         { >= "1.3.0"  }
+  "dune"         { >= "2.1.0"  }
   "menhir"
   "bindlib"      { >= "5.0.1" }
   "earley"       { >= "3.0.0" }

--- a/src/core/dune
+++ b/src/core/dune
@@ -10,7 +10,9 @@
  (public_name lambdapi.core)
  (synopsis "LambdaPi interactive theorem prover [core]")
  (modules :standard)
- (c_names stubs)
+ (foreign_stubs
+  (language c)
+  (names stubs))
  (preprocess (per_module ((action (run pa_ocaml %{input-file})) parser)))
  (flags (:standard -w -27))
  (libraries unix stdlib-shims timed bindlib earley.core why3))

--- a/src/core/files.ml
+++ b/src/core/files.ml
@@ -223,12 +223,12 @@ let current_path : unit -> string = fun _ ->
 let current_mappings : unit -> ModMap.t = fun _ -> !lib_mappings
 
 (** [module_to_file mp] converts module path [mp] into the corresponding "file
-    path" (with no attached extension). It is assumed that [init_lib_root] was
-    called prior to any call to this function. *)
+    path" (with no attached extension). It is assumed that [lib_root] has been
+    set, possibly with [set_lib_root]. *)
 let module_to_file : Path.t -> file_path = fun mp ->
   let path =
     try ModMap.get mp !lib_mappings with ModMap.Root_not_set ->
-      assert false (* Unreachable after [init_lib_root] is called. *)
+      fatal_no_pos "Library root not set."
   in
   log_file "[%a] points to base name [%s]." Path.pp mp path; path
 

--- a/src/core/files.ml
+++ b/src/core/files.ml
@@ -287,7 +287,6 @@ let file_to_module : string -> Path.t = fun fname ->
         fatal_msg "Consider adding a package file under your source tree, ";
         fatal_no_pos "or use the [--map-dir] option."
   in
-  ignore (mp, path);
   (* Build the module path. *)
   let rest =
     let len_path = String.length path in

--- a/src/core/files.ml
+++ b/src/core/files.ml
@@ -211,7 +211,7 @@ let new_lib_mapping : string -> unit = fun s ->
   let new_mapping =
     try ModMap.add module_path file_path !lib_mappings
     with ModMap.Already_mapped ->
-    fatal_no_pos "Module path [%a] is already mapped." Path.pp module_path
+      fatal_no_pos "Module path [%a] is already mapped." Path.pp module_path
   in
   lib_mappings := new_mapping
 

--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,4 @@
 (tests
  (names utils ok_ko)
- (deps (glob_files OK/*.lp) (glob_files KO/*.lp))
+ (deps (glob_files OK/*.lp) (glob_files KO/*.lp) lambdapi.pkg)
  (libraries lambdapi.core alcotest))

--- a/tests/ok_ko.ml
+++ b/tests/ok_ko.ml
@@ -1,8 +1,6 @@
 (** Compile files in "OK" and "KO". *)
 open Core
 
-let _ = Files.set_lib_root (Some(".."));;
-
 let test_ok f () =
   (* Simply assert that there is no exception raised. *)
   Alcotest.(check unit) f (ignore (Compile.compile_file f)) ()
@@ -13,6 +11,7 @@ let test_ko f () =
   Alcotest.(check bool) f r false
 
 let _ =
+  Files.set_lib_root None;
   let open Alcotest in
   let files = Sys.readdir "OK" |> Array.map (fun f -> "OK/" ^ f) in
   let tests_ok = Array.map (fun f -> test_case f `Quick (test_ok f)) files in

--- a/tests/ok_ko.ml
+++ b/tests/ok_ko.ml
@@ -1,17 +1,22 @@
 (** Compile files in "OK" and "KO". *)
 open Core
 
+let compile fname = Compile.compile false (Files.file_to_module fname)
+
 let test_ok f () =
   (* Simply assert that there is no exception raised. *)
-  Alcotest.(check unit) f (ignore (Compile.compile_file f)) ()
+  Alcotest.(check unit) f (ignore (compile f)) ()
 
 let test_ko f () =
   (* Succeed if compilation fails. *)
-  let r = try (ignore (Compile.compile_file f)); true with _ -> false in
+  let r = try (ignore (compile f)); true with _ -> false in
   Alcotest.(check bool) f r false
 
 let _ =
   Files.set_lib_root None;
+  match Package.find_config "." with
+  | None -> assert false
+  | Some(f) -> Package.apply_config f;
   let open Alcotest in
   let files = Sys.readdir "OK" |> Array.map (fun f -> "OK/" ^ f) in
   let tests_ok = Array.map (fun f -> test_case f `Quick (test_ok f)) files in

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -4,7 +4,8 @@
 open Core (* Lambdapi core *)
 open Extra
 
-let _ = Files.set_lib_root (Some(".."));;
+let _ = Files.set_lib_root None
+
 let bool_file = "OK/bool.lp"
 let bool_sign = Compile.compile_file bool_file
 let bool_ss = Sig_state.of_sign bool_sign

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -4,10 +4,17 @@
 open Core (* Lambdapi core *)
 open Extra
 
-let _ = Files.set_lib_root None
+let _ =
+  Files.set_lib_root None;
+  match Package.find_config "." with
+  | None -> assert false
+  | Some(f) -> Package.apply_config f
+
+let compile (fname: string): Sign.t =
+  Compile.compile false (Files.file_to_module fname)
 
 let bool_file = "OK/bool.lp"
-let bool_sign = Compile.compile_file bool_file
+let bool_sign = compile bool_file
 let bool_ss = Sig_state.of_sign bool_sign
 
 (** HRS file generation. *)
@@ -39,7 +46,7 @@ let test_dtree () =
 (** Decision tree of ghost symbols. *)
 let test_dtree_ghost () =
   let file = "OK/unif_hint.lp" in
-  ignore (Compile.compile_file file);
+  ignore (compile file);
   let sym = fst (StrMap.find "#equiv" Timed.(!(Unif_rule.sign.sign_symbols))) in
   let buf = Buffer.create 16 in
   let fmt = Format.formatter_of_buffer buf in


### PR DESCRIPTION
Upping to dune2.

Test suite now relies on the package files (`lambdapi.pkg`) for requirements, which is cleaner.

The behaviour of `new_lib_mappings` is slightly changed: when the module path is already mapped, we silently do nothing, rather than raising an exception. This will be necessary in the context of interoperability, where we want to compile several files, which will potentially re import several times the same files.