### PR TITLE
[package] Workaround realpath failing with non-existing files

### DIFF
--- a/src/core/package.ml
+++ b/src/core/package.ml
@@ -75,7 +75,12 @@ let read : file_path -> config_data = fun fname ->
     [Sys_error] is raised. Note that [fname] is first normalized with a call
     to [Filename.realpath]. *)
 let find_config : file_path -> file_path option = fun fname ->
-  let fname = Filename.realpath fname in
+  (* workaround #432 , this whole code should be reworked tho *)
+  let fname =
+    if Sys.file_exists fname
+    then Filename.realpath fname
+    else fname
+  in
   let fname =
     if Sys.is_directory fname then fname else Filename.dirname fname
   in


### PR DESCRIPTION
Fixes #432 , introduced in #289

This whole code needs more investigation as the logic seems quite
strange, in particular I think the core of LP should not mess with
filesystem low-level details, but hoping for a quick fix.

Please test in emacs as I don't happen to have the setup right now.

Note that Vscode won't actually initialize the server until the file is saved, we should check what the lsp protocol says, maybe it is a bug that emacs is sending `didOpen` for a non-existing file?