### PR TITLE
add missing qidents_of function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,12 +1,17 @@
-Contributors (in alphabetical order)
-====================================
+Active Contributors (in alphabetical order)
+===========================================
 
+- Ashish Kumar Barnawal (2020-)
 - Frédéric Blanqui (coordinator)
-- Yacine El Haddad (2019)
 - Emilio Gallego (2018-)
-- Guillaume Genestier (2019)
 - Gabriel Hondet (2019-)
-- Amélie Ledein (2020)
+- Amélie Ledein (2020-)
+
+Past Contributors (in alphabetical order)
+=========================================
+
+- Yacine El Haddad (2019)
+- Guillaume Genestier (2019)
 - François Lefoulon (2020)
 - Rodolphe Lepigre (2017-2020)
 - Rehan Malak (2019-2020)
@@ -15,3 +20,4 @@ Contributors (in alphabetical order)
 - Christophe Raffalli (2017-2018)
 - Diego Riverio (2020)
 - Franck Slama (2019)
+- Jui-Hsuan Wu (2019)

--- a/src/pure/cmd_analysis.ml
+++ b/src/pure/cmd_analysis.ml
@@ -18,6 +18,9 @@ let concat_map = List.concat_map
 
 type t = Syntax.p_command
 
+let ident_to_qident : Syntax.ident -> Syntax.qident = fun p ->
+  {elt=([], p.elt); pos=p.pos}
+
 (*Messy pattern matching to get the qidents throughout the document*)
 let rec qidents_of_bound_p_args (args : Syntax.p_args) :
     Syntax.qident list * Pos.strloc list =
@@ -51,6 +54,46 @@ and qidents_of_p_term (term : Syntax.p_term) =
   | Syntax.P_BinO (t1, _, t2) -> qidents_of_p_term t1 @ qidents_of_p_term t2
   | Syntax.P_Wrap term -> qidents_of_p_term term
   | Syntax.P_Expl term -> qidents_of_p_term term
+
+and qidents_of_rw_patt (rwpat : Syntax.p_rw_patt) =
+  match rwpat with
+  | Syntax.P_rw_Term pt -> qidents_of_p_term pt
+  | Syntax.P_rw_InTerm pt -> qidents_of_p_term pt
+  | Syntax.P_rw_InIdInTerm (_, pt) -> qidents_of_p_term pt
+  | Syntax.P_rw_IdInTerm (_, pt) -> qidents_of_p_term pt
+  | Syntax.P_rw_TermInIdInTerm (pt1, _, pt2) -> (qidents_of_p_term pt1) @ (qidents_of_p_term pt2)
+  | Syntax.P_rw_TermAsIdInTerm (pt1, _, pt2) -> (qidents_of_p_term pt1) @ (qidents_of_p_term pt2)
+
+and qidents_of_p_assertion (pasrtn : Syntax.p_assertion) =
+  match pasrtn with
+  | Syntax.P_assert_typing (pt, _) -> qidents_of_p_term pt
+  | Syntax.P_assert_conv (pt1, pt2) ->
+    qidents_of_p_term pt1 @ qidents_of_p_term pt2
+
+and qidents_of_p_query (pq : Syntax.p_query) =
+  match pq.elt with
+  | Syntax.P_query_assert (_, pasrt)-> qidents_of_p_assertion pasrt
+  | Syntax.P_query_infer (pt, _) -> qidents_of_p_term pt
+  | Syntax.P_query_normalize (pt, _) -> qidents_of_p_term pt
+  | Syntax.P_query_print qidnt_opt ->
+    (match qidnt_opt with Some qidnt -> [qidnt] | None -> [])
+  | _ -> []
+
+
+and qidents_of_p_tactic (term: Syntax.p_tactic) =
+  match term.elt with
+  | Syntax.P_tac_refine pt -> qidents_of_p_term pt
+  | Syntax.P_tac_apply pt -> qidents_of_p_term pt
+  | Syntax.P_tac_rewrite (_, rwpat_lo, pt) ->
+    let rwqids =
+      match rwpat_lo with
+      | Some rwpat -> qidents_of_rw_patt rwpat.elt
+      | None -> []
+    in
+    let ptqids = qidents_of_p_term pt in
+    rwqids @ ptqids
+  | Syntax.P_tac_query pq -> qidents_of_p_query pq
+  | _ -> []
 
 and filter_bound_qidents (args : Syntax.p_args list)
     (terms_list : Syntax.p_term list) =
@@ -92,10 +135,18 @@ let qidents_of_cmd (cmd : t) =
   | Syntax.P_require_as (_, _) -> []
   | Syntax.P_open _ -> []
   | Syntax.P_rules rules -> concat_map qidents_of_p_rule rules
-  | Syntax.P_symbol {p_sym_arg;p_sym_typ;p_sym_trm;_} ->
+  | Syntax.P_symbol {p_sym_nam;p_sym_arg;p_sym_typ;p_sym_trm;p_sym_prf;_} ->
     let some_or_empty = function Some arg -> [arg] | None -> [] in
+    let symqidlist = [ident_to_qident p_sym_nam] in
+    let prfqidlist = begin
+      match p_sym_prf with
+      | Some (ptac_list, _) -> List.concat_map qidents_of_p_tactic ptac_list
+      | None -> []
+    end in
     let terms_list = some_or_empty p_sym_typ @ some_or_empty p_sym_trm in
-    filter_bound_qidents p_sym_arg terms_list
+    let res =  (filter_bound_qidents p_sym_arg terms_list) in
+    res @ symqidlist @ prfqidlist
+
   | Syntax.P_set set -> qidents_of_p_config set
   | Syntax.P_query q ->
     let f (q : Syntax.p_query_aux) =


### PR DESCRIPTION
`qidents_of_*` functions were not implemented in `pure/cmd_analysis.ml` causing goto defintions to not work.
This fixes #479 