### PR TITLE
bug in PR#504

### DIFF
--- a/src/core/files.ml
+++ b/src/core/files.ml
@@ -266,16 +266,7 @@ let file_to_module : string -> Path.t = fun fname ->
       fatal_no_pos "Expected any of: %a." pp_exp valid_extensions
     end;
   (* Normalizing the file path. *)
-  let fname =
-    let rec normalize fname =
-      if Sys.file_exists fname then
-        Filename.realpath fname
-      else
-        let dirnm = Filename.dirname fname in
-        let basenm = Filename.basename fname in
-        Filename.concat (normalize dirnm) basenm
-    in
-    normalize fname
+  let fname = Filename.normalize fname
   in
   let base = Filename.chop_extension fname in
   (* Finding the best mapping under the root. *)

--- a/src/core/files.ml
+++ b/src/core/files.ml
@@ -266,8 +266,7 @@ let file_to_module : string -> Path.t = fun fname ->
       fatal_no_pos "Expected any of: %a." pp_exp valid_extensions
     end;
   (* Normalizing the file path. *)
-  let fname = Filename.normalize fname
-  in
+  let fname = Filename.normalize fname in
   let base = Filename.chop_extension fname in
   (* Finding the best mapping under the root. *)
   let mapping = ref None in

--- a/src/core/package.ml
+++ b/src/core/package.ml
@@ -75,6 +75,15 @@ let read : file_path -> config_data = fun fname ->
     [Sys_error] is raised. Note that [fname] is first normalized with a call
     to [Filename.realpath]. *)
 let find_config : file_path -> file_path option = fun fname ->
+  let rec normalize fname =
+    if Sys.file_exists fname then
+      Filename.realpath fname
+    else
+      let dirnm = Filename.dirname fname in
+      let basenm = Filename.basename fname in
+      Filename.concat (normalize dirnm) basenm
+  in
+  let fname = normalize fname in
   let rec find dir =
     let file = Filename.concat dir pkg_file in
     match Sys.file_exists file with

--- a/src/core/package.ml
+++ b/src/core/package.ml
@@ -75,15 +75,7 @@ let read : file_path -> config_data = fun fname ->
     [Sys_error] is raised. Note that [fname] is first normalized with a call
     to [Filename.realpath]. *)
 let find_config : file_path -> file_path option = fun fname ->
-  let rec normalize fname =
-    if Sys.file_exists fname then
-      Filename.realpath fname
-    else
-      let dirnm = Filename.dirname fname in
-      let basenm = Filename.basename fname in
-      Filename.concat (normalize dirnm) basenm
-  in
-  let fname = normalize fname in
+  let fname = Filename.normalize fname in
   let rec find dir =
     let file = Filename.concat dir pkg_file in
     match Sys.file_exists file with

--- a/src/lplib/filename.ml
+++ b/src/lplib/filename.ml
@@ -4,3 +4,11 @@ include Stdlib.Filename
     [path] is invalid (i.e., it does not describe an existing file), then the
     exception [Invalid_argument] is raised. *)
 external realpath : string -> string = "c_realpath"
+
+let rec normalize fname =
+  if Sys.file_exists fname then
+    realpath fname
+  else
+    let dirnm = dirname fname in
+    let basenm = basename fname in
+    concat (normalize dirnm) basenm


### PR DESCRIPTION
The file path should've been expanded in package.ml in #504. This caused `lambdapi check natproofs.lp` to get stuck.