### PR TITLE
Setting filename in ocamllex

### DIFF
--- a/src/core/dkLexer.mll
+++ b/src/core/dkLexer.mll
@@ -3,13 +3,15 @@ open Console
 open Lexing
 open Pos
 
-let filename = Stdlib.ref ""
+let filename = ref ""
 
 let to_module_path : string -> Syntax.p_module_path = fun mp ->
   List.map (fun s -> (s, false)) (String.split_on_char '.' mp)
 
 let make_pos : Lexing.position * Lexing.position -> 'a -> 'a loc =
-  fun lps elt -> {pos = Some(locate lps); elt}
+  fun lps elt ->
+    let fname = !filename in
+    make (Some (locate ~fname lps)) elt
 
 let locate_lexbuf : Lexing.lexbuf -> Pos.pos = fun lexbuf ->
   locate (lexbuf.lex_start_p, lexbuf.lex_curr_p)

--- a/src/core/parser.ml
+++ b/src/core/parser.ml
@@ -84,8 +84,8 @@ let parse_qident : string ->
     try Ok(parse lexer)
     with LpLexer.SyntaxError(s) -> Error(s.pos)
        | LpParser.Error ->
-         let loc = Pos.locate (Sedlexing.lexing_positions lexbuf) in
-         Error(Some(loc))
+           let loc = Pos.locate (Sedlexing.lexing_positions lexbuf) in
+           Error(Some(loc))
   in
   (* We get individual identifiers. *)
   let ids = String.split_on_char '.' s in
@@ -119,10 +119,10 @@ module Dk : PARSER = struct
         with
         | End_of_file -> Option.iter close_in inchan; None
         | DkParser.Error ->
-          let loc =
-            Lexing.(lexbuf.lex_start_p, lexbuf.lex_curr_p) in
-          let loc = Pos.locate loc in
-          parser_fatal loc "Unexpected token [%s]." (Lexing.lexeme lexbuf)
+            let loc =
+              Lexing.(lexbuf.lex_start_p, lexbuf.lex_curr_p) in
+            let loc = Pos.locate loc in
+            parser_fatal loc "Unexpected token [%s]." (Lexing.lexeme lexbuf)
       in
       Stream.from generator
 

--- a/src/core/pos.ml
+++ b/src/core/pos.ml
@@ -96,10 +96,11 @@ let print_short : Format.formatter -> popt -> unit = fun ch p ->
 let map : ('a -> 'b) -> 'a loc -> 'b loc = fun f loc ->
   {loc with elt = f loc.elt}
 
-(** [locate loc] converts the pair of position [loc] of the Lexing library
-    into a {!type:pos}. *)
-let locate : Lexing.position * Lexing.position -> pos = fun (p1, p2) ->
-  let fname = Some(p1.pos_fname) in
+(** [locate ?fname loc] converts the pair of position [loc] and filename
+    [fname] of the Lexing library into a {!type:pos}. *)
+let locate : ?fname:string -> Lexing.position * Lexing.position -> pos =
+  fun ?fname (p1, p2) ->
+  let fname = if p1.pos_fname = "" then fname else Some(p1.pos_fname) in
   let start_line = p1.pos_lnum in
   let start_col = p1.pos_cnum - p1.pos_bol in
   let end_line = p2.pos_lnum in


### PR DESCRIPTION
Makes file name appear in errors and warning (in positions in general) when parsing Dedukti 2 files.