### PR TITLE
[debug] Install toplevel printers for use with Pure

### DIFF
--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -154,7 +154,7 @@ let check_text ~doc =
   let uri, version = doc.uri, doc.version in
   try
     let cmds =
-      let (cmds, root) = Pure.parse_text doc.root uri doc.text in
+      let (cmds, root) = Pure.parse_text doc.root ~fname:uri doc.text in
       (* One shot state update after parsing. *)
       doc.root <- root; doc.final <- root; cmds
     in

--- a/src/pure/pure.mli
+++ b/src/pure/pure.mli
@@ -9,6 +9,7 @@ module Command : sig
   type t
   val equal : t -> t -> bool
   val get_pos : t -> Pos.popt
+  val print : t Base.pp [@@ocaml.toplevel_printer]
 end
 
 val rangemap : Command.t list -> Syntax.qident_aux RangeMap.t
@@ -18,6 +19,7 @@ module Tactic : sig
   type t
   val equal : t -> t -> bool
   val get_pos : t -> Pos.popt
+  val print : t Base.pp [@@ocaml.toplevel_printer]
 end
 
 (** Representation of the state when at the toplevel. *)
@@ -29,10 +31,10 @@ type proof_state
 (** Exception raised by [parse_text]. *)
 exception Parse_error of Pos.pos * string
 
-(** [parse_text st fname contents] runs the parser on the string [contents] as
+(** [parse_text st ~fname contents] runs the parser on the string [contents] as
     if it were a file named [fname]. The action takes place in the state [st],
     and an updated state is returned. The function may raise [Parse_error]. *)
-val parse_text : state -> string -> string -> Command.t list * state
+val parse_text : state -> fname:string -> string -> Command.t list * state
 
 (** A goal is given by a list of assumptions and a conclusion. Each assumption
    has a name and a type. *)


### PR DESCRIPTION
This is convenient as to interact with the library, example of use:

```ocaml
$ dune utop src/pure

utop # let txt = "constant symbol A : TYPE;

constant symbol Nat : TYPE;
constant symbol zero : Nat;
constant symbol succ : Nat → Nat;

symbol plus : Nat → Nat → Nat;
rule plus zero      $m ↪ $m;
rule plus (succ $n) $m ↪ succ (plus $n $m);

constant symbol Vec : Nat → TYPE;
constant symbol nil : Vec zero;
constant symbol cns : Π (n:Nat), A → Vec n → Vec (succ n);
";;

utop # let st = Pure.initial_state "tests/OK/apply.lp";;
val st : Pure.state = <abstr>
utop # let cmd, st1 = Pure.parse_text st ~fname:"tests/OK/apply.lp" txt;;
val cmd : Pure.Command.t list =
  [[tests/OK/apply.lp, 0:0-25] constant symbol A : TYPE;;
   [tests/OK/apply.lp, 0:0-27] constant symbol Nat : TYPE;;
   [tests/OK/apply.lp, 0:0-27] constant symbol zero : Nat;;
   [tests/OK/apply.lp, 0:0-33] constant symbol succ : Nat → Nat;;
   [1:0-0:30] symbol plus : Nat → Nat → Nat;;
   [tests/OK/apply.lp, 0:0-28] rule plus zero $m ↪ $m;;
   [tests/OK/apply.lp, 0:0-43] rule plus (succ $n) $m ↪ succ (plus $n $m);;
   [tests/OK/apply.lp, 0:0-33] constant symbol Vec : Nat → TYPE;;
   [tests/OK/apply.lp, 0:0-31] constant symbol nil : Vec zero;;
   [tests/OK/apply.lp, 0:0-58] constant symbol cns : Π (n : Nat), A → Vec n → Vec (succ n);]
val st1 : Pure.state = <abstr>
```