### PR TITLE
Fixing let printing

### DIFF
--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -218,6 +218,7 @@ and pp_term : term pp = fun oc t ->
         if wrap then out oc ")"
     | LLet(a,t,b) ->
         if wrap then out oc "(";
+        out oc "let ";
         let (x,u) = Bindlib.unbind b in
         pp_bvar oc (b,x);
         if !print_domains then out oc ": %a" (pp `Atom) a;


### PR DESCRIPTION
This pull request fixes the way `let ... in ` are printed, because the `let` wasn't printed.