### PR TITLE
Adding missing dep to lplib

### DIFF
--- a/src/lplib/dune
+++ b/src/lplib/dune
@@ -5,4 +5,4 @@
  (foreign_stubs
   (language c)
   (names realpath))
- (libraries stdlib-shims str))
+ (libraries stdlib-shims str unix))


### PR DESCRIPTION
`Unix` dependency was missing from `dune` of `Lplib`, and resulted in errors when using `Common` as a library from another programme.

It failed with
> File "_none_", line 1:
> Error: No implementations provided for the following modules:
>          Unix referenced from /home/hondet/.opam/4.11.1/lib/lambdapi/lplib/lplib.cmxa(Lplib__Extra),
>            /home/hondet/.opam/4.11.1/lib/lambdapi/common/common.cmxa(Common__Module)