### PR TITLE
[build] Generate a byte version for lambdapi

### DIFF
--- a/src/cli/dune
+++ b/src/cli/dune
@@ -1,5 +1,6 @@
 (executable
  (name lambdapi)
  (public_name lambdapi)
+ (modes byte native)
  (modules :standard)
  (libraries cmdliner lambdapi.lsp lambdapi.tool lambdapi.handle))


### PR DESCRIPTION
Fixes #568 , file name is by convention `lambdapi.bc`

```
$ dune build src/cli/lambdapi.bc`
$ ls -l _build/default/src/cli/lambdapi.*
-r-xr-xr-x 2 egallego egallego 78199578 févr. 15 17:08 _build/default/src/cli/lambdapi.bc
-rwxrwxr-x 1 egallego egallego 40699080 févr.  9 17:36 _build/default/src/cli/lambdapi.exe
```