### PR TITLE
Various bug fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 ### Unreleased
 
+#### Various bug fixes (2021-03-02)
+
+- allow matching on abstraction/product type annotation (fix #573)
+- Infer: do not check constraint duplication and return them in the order they have been added (fix #579)
+- inductive type symbols are now declared as constants (fix #580)
+- fix parsing and printing of unification rules
+- Extra.files returns only the files that satisfy some user-defined condition
+- tests/ok_ko.ml: test only .dk and .lp files
+- Pretty: checking that identifiers are LP keywords in now optional (useful for debug)
+
 #### Fix notation declarations (2021-02-19)
 
 - `set infix ... "<string>" := <qid>` is replaced by `set notation <qid> infix ...`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,13 @@
 
 #### Various bug fixes (2021-03-02)
 
-- allow matching on abstraction/product type annotation (fix #573)
-- Infer: do not check constraint duplication and return them in the order they have been added (fix #579)
-- inductive type symbols are now declared as constants (fix #580)
+- allow matching on abstraction/product type annotations (fix #573)
+- Infer: do not check constraint duplication and return constraints in the order they have been added (fix #579)
+- inductive type symbols are now declared as constant (fix #580)
 - fix parsing and printing of unification rules
 - Extra.files returns only the files that satisfy some user-defined condition
 - tests/ok_ko.ml: test only .dk and .lp files
-- Pretty: checking that identifiers are LP keywords in now optional (useful for debug)
+- Pretty: checking that identifiers are LP keywords is now optional (useful for debug)
 
 #### Fix notation declarations (2021-02-19)
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -378,9 +378,9 @@ is equivalent to:
 ￼
 ::
    
-   ￼injective symbol ℕ : TYPE;
-   ￼constant  symbol zero : ℕ;
-   ￼constant  symbol succ : ℕ → ℕ;
+   ￼constant symbol ℕ : TYPE;
+   ￼constant symbol zero : ℕ;
+   ￼constant symbol succ : ℕ → ℕ;
    ￼symbol ind_ℕ p :
       π(p zero) → (Π x, π(p x) → π(p(succ x))) → Π x, π(p x);
    ￼rule ind_ℕ _ $pz _ zero ↪ $pz

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -66,7 +66,8 @@ let parse_cmd : Config.t -> string list -> unit = fun cfg files ->
 (** Running the pretty-printing mode. *)
 let beautify_cmd : Config.t -> string -> unit = fun cfg file ->
   let run _ =
-    Config.init cfg; Pretty.beautify (Compile.parse_file file) in
+    Config.init cfg; Pretty.check_keywords := true;
+    Pretty.beautify (Compile.parse_file file) in
   Error.handle_exceptions run
 
 (** Running the LSP server. *)

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -66,9 +66,11 @@ let parse_cmd : Config.t -> string list -> unit = fun cfg files ->
 (** Running the pretty-printing mode. *)
 let beautify_cmd : Config.t -> string -> unit = fun cfg file ->
   let run _ =
-    Config.init cfg; Pretty.check_keywords := true;
-    Pretty.beautify (Compile.parse_file file) in
-  Error.handle_exceptions run
+    Config.init cfg;
+    let cmds = Compile.parse_file file in
+    Pretty.check_keywords := true;
+    Pretty.beautify cmds
+  in Error.handle_exceptions run
 
 (** Running the LSP server. *)
 let lsp_server_cmd : Config.t -> bool -> string -> unit =

--- a/src/common/escape.ml
+++ b/src/common/escape.ml
@@ -1,22 +1,22 @@
-(** Escaped identifiers "{|...|}". *)
+(** Escaped identifiers ["{|...|}"]. *)
 
 (*open Debug*)
 
-(** [is_beg_escaped s] tells if [s] starts with "{|". *)
+(** [is_beg_escaped s] tells if [s] starts with ["{|"]. *)
 let is_beg_escaped : string -> bool = fun s ->
   let n = String.length s in n > 1 && s.[0] = '{' && s.[1] = '|'
 
-(** [is_end_escaped s] tells if [s] ends with "|}". *)
+(** [is_end_escaped s] tells if [s] ends with ["|}"]. *)
 let is_end_escaped : string -> bool = fun s ->
   let n = String.length s in n > 1 && s.[n-2] = '|' && s.[n-1] = '}'
 
-(** [is_escaped s] tells if [s] begins with "{|" and ends with "|}" without
-   overlapping. *)
+(** [is_escaped s] tells if [s] begins with ["{|"] and ends with ["|}"]
+   without overlapping. *)
 let is_escaped : string -> bool = fun s ->
   let n = String.length s in
   n > 3 && s.[0] = '{' && s.[1] = '|' && s.[n-2] = '|' && s.[n-1] = '}'
 
-(** [unescape s] removes "{|" and "|}" if [s] is an escaped identifier. *)
+(** [unescape s] removes ["{|"] and ["|}"] if [s] is an escaped identifier. *)
 let unescape : string -> string = fun s ->
   if is_escaped s then String.(sub s 2 (length s - 4)) else s
 

--- a/src/common/library.ml
+++ b/src/common/library.ml
@@ -196,11 +196,17 @@ let file_of_path : Path.t -> string = fun mp ->
 (** [src_extension] is the expected extension for source files. *)
 let src_extension : string = ".lp"
 
-(** [obj_extension] is the expected extension for binary (object) files. *)
-let obj_extension : string = ".lpo"
-
 (** [legacy_src_extension] is the extension for legacy source files. *)
 let legacy_src_extension : string = ".dk"
+
+(** [is_valid_src_extension s] returns [true] iff [s] ends with
+   [src_extension] or [legacy_src_extension]. *)
+let is_valid_src_extension : string -> bool = fun s ->
+  Filename.check_suffix s src_extension
+  || Filename.check_suffix s legacy_src_extension
+
+(** [obj_extension] is the expected extension for binary (object) files. *)
+let obj_extension : string = ".lpo"
 
 (** [valids_extensions] is the list of valid file extensions. *)
 let valid_extensions : string list =

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -27,13 +27,13 @@ let constraints = Stdlib.ref []
 
 (** Function adding a constraint. *)
 let conv ctx a b =
-  if not (List.mem_sorted LibTerm.cmp_constr (ctx,a,b)
-            Stdlib.(!constraints)) && not (Eval.eq_modulo ctx a b) then
-    begin
-      if !log_enabled then log_infr (yel "add %a") pp_constr (ctx,a,b);
-      Stdlib.(constraints :=
-                Lplib.List.insert LibTerm.cmp_constr (ctx,a,b) !constraints)
-    end
+  if not (Eval.eq_modulo ctx a b) then
+    let c = (ctx,a,b) in
+    let cs =
+      Lplib.List.insert LibTerm.cmp_constr c Stdlib.(!constraints) in
+    if cs != Stdlib.(!constraints) then
+      (Stdlib.(constraints := cs);
+       if !log_enabled then log_infr (yel "add %a") pp_constr c)
 
 (** Exception that may be raised by type inference. *)
 exception NotTypable

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -30,9 +30,7 @@ let conv ctx a b =
   if not (Eval.eq_modulo ctx a b) then
     begin
       let c = (ctx,a,b) in
-      let cs = c::Stdlib.(!constraints) in
-      (*Lplib.List.insert_uniq LibTerm.cmp_constr c Stdlib.(!constraints) in*)
-      (*if cs != Stdlib.(!constraints) then*) Stdlib.(constraints := cs);
+      Stdlib.(constraints := c::!constraints);
       if !log_enabled then log_infr (yel "add %a") pp_constr c
     end
 
@@ -176,7 +174,7 @@ let infer_noexn : constr list -> ctxt -> term -> (term * constr list) option =
         let cond oc c = Format.fprintf oc "\n  if %a" pp_constr c in
         log_infr (gre "infer %a : %a%a")
           pp_term t pp_term a (List.pp cond "") cs);
-      Some (a,cs)
+      Some (a, List.rev cs)
     with NotTypable -> None
   in Stdlib.(constraints := []); res
 
@@ -195,7 +193,7 @@ let check_noexn : constr list -> ctxt -> term -> term -> constr list option =
         let cond oc c = Format.fprintf oc "\n  if %a" pp_constr c in
         log_infr (gre "check %a\n: %a%a")
           pp_term t pp_term a (List.pp cond "") cs);
-      Some cs
+      Some (List.rev cs)
     with NotTypable -> None
   in Stdlib.(constraints := []); res
 

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -28,12 +28,13 @@ let constraints = Stdlib.ref []
 (** Function adding a constraint. *)
 let conv ctx a b =
   if not (Eval.eq_modulo ctx a b) then
-    let c = (ctx,a,b) in
-    let cs =
-      Lplib.List.insert LibTerm.cmp_constr c Stdlib.(!constraints) in
-    if cs != Stdlib.(!constraints) then
-      (Stdlib.(constraints := cs);
-       if !log_enabled then log_infr (yel "add %a") pp_constr c)
+    begin
+      let c = (ctx,a,b) in
+      let cs = c::Stdlib.(!constraints) in
+      (*Lplib.List.insert_uniq LibTerm.cmp_constr c Stdlib.(!constraints) in*)
+      (*if cs != Stdlib.(!constraints) then*) Stdlib.(constraints := cs);
+      if !log_enabled then log_infr (yel "add %a") pp_constr c
+    end
 
 (** Exception that may be raised by type inference. *)
 exception NotTypable

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -63,7 +63,9 @@ let pp_path : Path.t pp = List.pp pp_uid "."
 
 let pp_sym : sym pp = fun ppf s ->
   if !print_implicits && s.sym_impl <> [] then out ppf "@";
-  if StrMap.mem s.sym_name !sig_state.in_scope then pp_uid ppf s.sym_name
+  if StrMap.mem s.sym_name !sig_state.in_scope then
+    if s == Unif_rule.cons then out ppf "%s" s.sym_name
+    else pp_uid ppf s.sym_name
   else
     match Path.Map.find_opt s.sym_path (!sig_state).path_alias with
     | None -> out ppf "%a.%a" pp_path s.sym_path pp_uid s.sym_name
@@ -230,6 +232,11 @@ let pp_rule : (sym * rule) pp = fun ppf (s,r) ->
   let lhs = LibTerm.add_args (Symb s) r.lhs in
   let (_, rhs) = Bindlib.unmbind r.rhs in
   out ppf "%a ↪ %a" pp_term lhs pp_term rhs
+
+let pp_unif_rule : (sym * rule) pp = fun ppf (s,r) ->
+  let lhs = LibTerm.add_args (Symb s) r.lhs in
+  let (_, rhs) = Bindlib.unmbind r.rhs in
+  out ppf "%a ↪ [ %a ]" pp_term lhs pp_term rhs
 
 (* ends with a space if [!print_contexts = true] *)
 let pp_ctxt : ctxt pp = fun ppf ctx ->

--- a/src/core/scope.ml
+++ b/src/core/scope.ml
@@ -159,6 +159,7 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
   in
   (* Toplevel scoping function, with handling of implicit arguments. *)
   let rec scope : env -> p_term -> tbox = fun env t ->
+    if Timed.(!log_enabled) then log_scop "%a" Pretty.term t;
     (* Extract the spine. *)
     let (p_head, args) = get_pratt_args ss env t in
     (* Check that LHS pattern variables are applied to no argument. *)
@@ -219,8 +220,6 @@ let scope : mode -> sig_state -> env -> p_term -> tbox = fun md ss env t ->
   (* Scoping function for the domain of functions or products. *)
   and scope_domain : env -> p_term option -> tbox = fun env a ->
     match (a, md) with
-    | (Some(a), M_LHS(_)    ) ->
-        fatal a.pos "Annotation not allowed in a LHS."
     | (None   , M_LHS(_)    ) -> fresh_patt md None (Env.to_tbox env)
     | ((Some({elt=P_Wild;_})|None), _           ) -> _Meta_Type env
     | (Some(a)   , _           ) -> scope env a

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -156,8 +156,9 @@ let instantiate : ctxt -> meta -> term array -> term -> constr list -> bool =
                 Meta.set m (Bindlib.unbox bu); true
             | true, true ->
                 if !log_enabled then
-                  (log_unif "cannot instantiate because of new constraints:";
-                   List.iter (log_unif "%a" pp_constr) cs);
+                  (let constr ppf = Format.fprintf ppf "\n; %a" pp_constr in
+                   log_unif "cannot instantiate because of new constraints:%a"
+                     (List.pp constr "") cs);
                 false
       end
   | _ ->

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -156,7 +156,8 @@ let instantiate : ctxt -> meta -> term array -> term -> constr list -> bool =
                 Meta.set m (Bindlib.unbox bu); true
             | true, true ->
                 if !log_enabled then
-                  log_unif "cannot instantiate (new constraints)";
+                  (log_unif "cannot instantiate because of new constraints:";
+                   List.iter (log_unif "%a" pp_constr) cs);
                 false
       end
   | _ ->

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -229,7 +229,7 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
       (* Add inductive types in the signature. *)
       let add_ind_sym (ss, ind_sym_list) {elt=(id,pt,_); _} =
         let (ss, ind_sym) =
-          handle_inductive_symbol ss expo Injec Eager id params pt in
+          handle_inductive_symbol ss expo Const Eager id params pt in
         (ss, ind_sym::ind_sym_list)
       in
       let (ss, ind_sym_list_rev) =

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -202,7 +202,7 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
     sig_state * proof_data option * Query.result =
   fun compile ss ({elt; pos} as cmd) ->
   if !log_enabled then
-    log_hndl (blu "%a\n%a") Pos.pp pos Pretty.command cmd;
+    log_hndl (blu "%f %a\n%a") (Sys.time()) Pos.pp pos Pretty.command cmd;
   let scope expo = Scope.scope_term expo ss Env.empty IntMap.empty in
   match elt with
   | P_query(q) ->

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -470,7 +470,7 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
             in
             Sign.add_rule ss.signature Unif_rule.equiv urule;
             Tree.update_dtree Unif_rule.equiv;
-            Console.out 3 "(hint) [%a]\n" pp_rule (Unif_rule.equiv, urule);
+            Console.out 3 "(hint) %a\n" pp_unif_rule (Unif_rule.equiv, urule);
             ss
       in
       (ss, None, None)

--- a/src/lplib/extra.ml
+++ b/src/lplib/extra.ml
@@ -109,9 +109,10 @@ let file_time : string -> float = fun fname ->
 let more_recent : string -> string -> bool = fun source target ->
   file_time source > file_time target
 
-(** [files d] returns all the files in [d] and its sub-directories
-   recursively, assuming that [d] is a directory. *)
-let files : string -> string list =
+(** [files f d] returns all the filenames in [d] and its sub-directories
+   recursively satisfying the function [f], assuming that [d] is a
+   directory. *)
+let files : (string -> bool) -> string -> string list = fun chk ->
   let rec files acc dirs =
     match dirs with
     | [] -> acc
@@ -119,7 +120,7 @@ let files : string -> string list =
         let f (fnames, dnames) s =
           let s = Filename.concat d s in
           if Sys.is_directory s then (fnames, s::dnames)
-          else (s::fnames, dnames)
+          else if chk s then (s::fnames, dnames) else (fnames, dnames)
         in
         let acc, dirs = Array.fold_left f (acc, dirs) (Sys.readdir d) in
         files acc dirs

--- a/src/lplib/list.ml
+++ b/src/lplib/list.ml
@@ -205,7 +205,7 @@ let _ =
      && insert_uniq Stdlib.compare 7 l = [2;4;6;7]
      && insert_uniq Stdlib.compare 4 l == l)
 
-(** [split_last l] returns [(l',x)] if |l = append l' [x]], and
+(** [split_last l] returns [(l',x)] if [l = append l' [x]], and
 @raise Invalid_argument otherwise. *)
 let split_last : 'a list -> 'a list * 'a = fun l ->
   match rev l with

--- a/src/lplib/list.ml
+++ b/src/lplib/list.ml
@@ -87,7 +87,6 @@ let equal : 'a eq -> 'a list eq =
 
 (** [max ?cmp l] finds the max of list [l] with compare function [?cmp]
     defaulting to [Stdlib.compare].
-
     @raise Invalid_argument if [l] is empty. *)
 let max : ?cmp:('a -> 'a -> int) -> 'a list -> 'a =
  fun ?(cmp = Stdlib.compare) li ->
@@ -98,7 +97,6 @@ let max : ?cmp:('a -> 'a -> int) -> 'a list -> 'a =
     L.fold_left max h t
 
 (** [assoc_eq e k l] is [List.assoc k l] with equality function [e].
-
     @raise Not_found if [k] is not a key of [l]. *)
 let assoc_eq : 'a eq -> 'a -> ('a * 'b) list -> 'b =
  fun eq k l ->
@@ -124,7 +122,6 @@ let rec remove_phys_dups : 'a list -> 'a list =
     [i]-th element of [l], [left_rev] is the reversed prefix of [l] up to its
     [i]-th element (excluded), and [right] is the remaining suffix of [l]
     (starting at its [i+1]-th element).
-
     @raise Invalid_argument when [i < 0].
     @raise Not_found when [i ≥ length v]. *)
 let destruct : 'a list -> int -> 'a list * 'a * 'a list =
@@ -207,16 +204,6 @@ let _ =
      && insert_uniq Stdlib.compare 3 l = [2;3;4;6]
      && insert_uniq Stdlib.compare 7 l = [2;4;6;7]
      && insert_uniq Stdlib.compare 4 l == l)
-
-(** Map and filter missing elements *)
-let rec pmap (f : 'a -> 'b option) (l : 'a list) : 'b list =
-  match l with
-  | [] -> []
-  | x :: xs -> ( match f x with None -> pmap f xs | Some x -> x :: pmap f xs )
-
-(** Concat the result of a map *)
-let concat_map (f : 'a -> 'b list) (l : 'a list) : 'b list =
-  L.concat (L.map f l)
 
 (** [split_last l] returns [(l',x)] if |l = append l' [x]], and
 @raise Invalid_argument otherwise. *)

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -165,8 +165,8 @@ end = struct
   let non_user_id = ""
   let ghost_path s = [non_user_id; s]
   let unif_rule_path = ghost_path "unif_rule"
-  let equiv = "equiv"
-  let cons = "cons"
+  let equiv = "≡"
+  let cons = ";"
 
   let uid = [%sedlex.regexp? regid | escid]
   let qid = [%sedlex.regexp? uid, Plus ('.', uid)]

--- a/src/parsing/lpParser.mly
+++ b/src/parsing/lpParser.mly
@@ -343,17 +343,17 @@ rule: l=term HOOK_ARROW r=term { make_pos $sloc (l, r) }
 
 equation: l=term EQUIV r=term { (l, r) }
 
-unif_rule: l=equation HOOK_ARROW
-  L_SQ_BRACKET rs=separated_nonempty_list(SEMICOLON, equation) R_SQ_BRACKET
+unif_rule: e=equation HOOK_ARROW
+  L_SQ_BRACKET es=separated_nonempty_list(SEMICOLON, equation) R_SQ_BRACKET
     { (* FIXME: give sensible positions instead of Pos.none and P.appl. *)
       let equiv = P.qiden LpLexer.unif_rule_path LpLexer.equiv in
       let cons = P.qiden LpLexer.unif_rule_path LpLexer.cons in
-      let mk_equiv (l, r) = P.appl (P.appl equiv l) r in
-      let lhs = mk_equiv l in
-      let rs = List.map mk_equiv rs in
-      let (r, rs) = List.(hd rs, tl rs) in
-      let cat eqlst eq = P.appl (P.appl cons eq) eqlst in
-      let rhs = List.fold_left cat r rs in
+      let mk_equiv (t, u) = P.appl (P.appl equiv t) u in
+      let lhs = mk_equiv e in
+      let es = List.rev_map mk_equiv es in
+      let (en, es) = List.(hd es, tl es) in
+      let cat e es = P.appl (P.appl cons e) es in
+      let rhs = List.fold_right cat es en in
       make_pos $sloc (lhs, rhs) }
 
 %%

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -15,8 +15,11 @@ open Format
 
 let out = fprintf
 
+(** check whether identifiers are Lambdapi keywords. *)
+let check_keywords = ref false
+
 let raw_ident : popt -> string pp = fun pos ppf s ->
-  if LpLexer.is_keyword s then
+  if !check_keywords && LpLexer.is_keyword s then
     fatal pos "Identifier [%s] is a Lambdapi keyword." s
   else LpLexer.pp_uid ppf s
 

--- a/tests/OK/330.lp
+++ b/tests/OK/330.lp
@@ -2,8 +2,4 @@ constant symbol Term : TYPE;
 constant symbol Prop : TYPE;
 symbol prf : Prop → TYPE;
 symbol equals : Term → Term → Prop;
-
-//set flag "print_implicits" on
-//set debug +siu
-
-rule prf (equals $x $y) ↪ Π P, prf (P $x) → prf (P $y);
+rule prf (equals $x $y) ↪ Π p, prf (p $x) → prf (p $y);

--- a/tests/OK/573.lp
+++ b/tests/OK/573.lp
@@ -1,0 +1,13 @@
+// test matching on type annotations in abstractions/products
+
+constant symbol Set : TYPE;
+injective symbol τ : Set → TYPE;
+
+constant symbol prop : Set;
+symbol Prop ≔ τ prop;
+injective symbol π : Prop → TYPE;
+
+constant symbol ∀ {a} : (τ a → Prop) → Prop;
+set notation ∀ quantifier;
+
+set unif_rule π $p ≡ Π x:$t, π $q[x] ↪ [ $p ≡ `∀ x:$t, $q[x] ];

--- a/tests/OK/579_long_no_duplicate.lp
+++ b/tests/OK/579_long_no_duplicate.lp
@@ -1,0 +1,102 @@
+// Encoding taken from OK test firstOrder.dk
+
+constant symbol Prop : TYPE;
+symbol prf  : Prop → TYPE;
+
+symbol False     : Prop;
+symbol False_elim: Π (A : Prop), prf False → prf A;
+
+symbol ∧         : Prop → Prop → Prop;
+set notation ∧ infix right 18;
+symbol and_intro : Π (A B:Prop), prf A → prf B → prf (A ∧ B);
+symbol and_elim1 : Π (A B:Prop), prf (A ∧ B) → prf A;
+symbol and_elim2 : Π (A B:Prop), prf (A ∧ B) → prf B;
+
+symbol ↝         : Prop → Prop → Prop;
+set notation ↝ infix right 14;
+symbol imp_elim  : Π (A B:Prop), prf (A ↝  B) → prf A → prf B;
+symbol imp_intro : Π (A B:Prop), (prf A → prf B) → prf (A ↝  B);
+
+symbol ∨         : Prop → Prop → Prop;
+set notation ∨ infix right 16;
+symbol or_elim   : Π (A B C:Prop), prf (A ∨ B) → prf (A ↝  C) → prf (B ↝  C) → prf C;
+symbol or_intro1 : Π (A B:Prop), prf A → prf (A ∨ B);
+symbol or_intro2 : Π (A B:Prop), prf B → prf (A ∨ B);
+
+symbol ¬       : Prop → Prop ≔  λ (P:Prop), P ↝  False;
+set notation ¬ prefix 20;
+
+
+symbol long_to_verify : Π a : Prop, Π b1: Prop, Π b2: Prop, Π b3: Prop, Π b4: Prop, Π b5: Prop, Π b6: Prop, Π b7: Prop, Π b8: Prop, Π b9: Prop, Π b10: Prop, Π b11: Prop, Π b12: Prop, Π b13: Prop, Π b14: Prop, Π b15: Prop, Π b16: Prop, Π b17: Prop, Π b18: Prop, Π b19: Prop, Π b20: Prop,
+      (prf b1 →
+      prf b2 →
+      prf b3 →
+      prf b4 →
+      prf b5 →
+      prf b6 →
+      prf b7 →
+      prf b8 →
+      prf b9 →
+      prf b10 →
+      prf b11 →
+      prf b12 →
+      prf b13 →
+      prf b14 →
+      prf b15 →
+      prf b16 →
+      prf b17 →
+      prf b18 →
+      prf b19 →
+      prf b20 →
+      prf a →
+      prf False) →
+
+      (prf b1 →
+      prf b2 →
+      prf b3 →
+      prf b4 →
+      prf b5 →
+      prf b6 →
+      prf b7 →
+      prf b8 →
+      prf b9 →
+      prf b10 →
+      prf b11 →
+      prf b12 →
+      prf b13 →
+      prf b14 →
+      prf b15 →
+      prf b16 →
+      prf b17 →
+      prf b18 →
+      prf b19 →
+      prf b20 →
+      prf (¬ a) →
+      prf False) →
+
+      prf (a ∨ ¬ a) →
+      prf b1 →
+      prf b2 →
+      prf b3 →
+      prf b4 →
+      prf b5 →
+      prf b6 →
+      prf b7 →
+      prf b8 →
+      prf b9 →
+      prf b10 →
+      prf b11 →
+      prf b12 →
+      prf b13 →
+      prf b14 →
+      prf b15 →
+      prf b16 →
+      prf b17 →
+      prf b18 →
+      prf b19 →
+      prf b20 →
+      prf False
+≔  λ a b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 s1 s2 H h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 H0 H1 H2 H3 H4 H5 H6 H7 H8 H9,
+   or_elim a (¬ a) False H
+   (imp_intro a False (s1 h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 H0 H1 H2 H3 H4 H5 H6 H7 H8 H9))
+   (imp_intro (¬ a) False (s2 h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 H0 H1 H2 H3 H4 H5 H6 H7 H8 H9));

--- a/tests/OK/579_or_elim_long.lp
+++ b/tests/OK/579_or_elim_long.lp
@@ -1,0 +1,102 @@
+// Encoding taken from OK test firstOrder.dk
+
+constant symbol Prop : TYPE;
+symbol prf  : Prop → TYPE;
+
+symbol False     : Prop;
+symbol False_elim: Π (A : Prop), prf False → prf A;
+
+symbol ∧       : Prop → Prop → Prop;
+set notation ∧ infix right 18;
+symbol and_intro : Π (A B:Prop), prf A → prf B → prf (A ∧ B);
+symbol and_elim1 : Π (A B:Prop), prf (A ∧ B) → prf A;
+symbol and_elim2 : Π (A B:Prop), prf (A ∧ B) → prf B;
+
+symbol ↝       : Prop → Prop → Prop;
+set notation ↝ infix right 14;
+symbol imp_elim  : Π (A B:Prop), prf (A ↝  B) → prf A → prf B;
+symbol imp_intro : Π (A B:Prop), (prf A → prf B) → prf (A ↝  B);
+
+symbol ∨        : Prop → Prop → Prop;
+set notation ∨ infix right 16;
+symbol or_elim   : Π (A B C:Prop), prf (A ∨ B) → prf (A ↝  C) → prf (B ↝  C) → prf C;
+symbol or_intro1 : Π (A B:Prop), prf A → prf (A ∨ B);
+symbol or_intro2 : Π (A B:Prop), prf B → prf (A ∨ B);
+
+symbol ¬       : Prop → Prop ≔  λ (P:Prop), P ↝  False;
+set notation ¬ prefix 20;
+
+set debug +i;
+symbol long_to_verify : Π a : Prop, Π b: Prop,
+      (prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf a →
+      prf False) →
+
+      (prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf (¬ a) →
+      prf False) →
+
+      prf (a ∨ ¬ a) →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf b →
+      prf False
+≔  λ a b s1 s2 H h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 H0 H1 H2 H3 H4 H5 H6 H7 H8 H9,
+   or_elim a (¬ a) False H
+   (imp_intro a False (s1 h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 H0 H1 H2 H3 H4 H5 H6 H7 H8 H9))
+   (imp_intro (¬ a) False (s2 h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 H0 H1 H2 H3 H4 H5 H6 H7 H8 H9));

--- a/tests/OK/inductive.lp
+++ b/tests/OK/inductive.lp
@@ -77,7 +77,7 @@ assert p ptrue pfalse ⊢ ind_B p ptrue pfalse true ≡ ptrue;
 assert p ptrue pfalse ⊢ ind_B p ptrue pfalse false ≡ pfalse;
 
 constant symbol bool : Set;
-rule B ↪ τ bool;
+rule τ bool ↪ B;
 
 ////////////////// False (empty type)
 
@@ -103,7 +103,7 @@ assert p pz psucc ⊢ ind_N p pz psucc z ≡ pz;
 assert p pz psucc n ⊢ ind_N p pz psucc (succ n) ≡ psucc n (ind_N p pz psucc n);
 
 constant symbol nat : Set;
-rule N ↪ τ nat;
+rule τ nat ↪ N;
 
 set builtin "0"  ≔ z;
 set builtin "+1" ≔ succ;
@@ -386,7 +386,7 @@ assert p pnil pcons n l
 ⊢ ind_List p pnil pcons (cons n l) ≡ pcons n l (ind_List p pnil pcons l);
 
 constant symbol list : Set;
-rule List ↪ τ list;
+rule τ list ↪ List;
 
 ///////////////// Pairs of natural numbers
 
@@ -434,7 +434,7 @@ inductive L : TYPE ≔
 assert ⊢ L : Set → TYPE;
 assert ⊢ @nilL : Π a, L a;
 assert ⊢ @consL : Π a, τ a → L a → L a;
-assert ⊢ ind_L : Π a p,
+assert ⊢ ind_L : Π a (p:L a → Prop),
   π(p nilL) → (Π x l, π(p l) → π(p (consL x l))) → Π l, π(p l);
 
 assert a p pnil pcons ⊢ ind_L a p pnil pcons nilL ≡ pnil;
@@ -641,31 +641,6 @@ assert p pnil pcons a n x v
 ⊢ ind_Vec p pnil pcons _ _ (Vcons a n x v)
 ≡ pcons a n x v (ind_Vec p pnil pcons a n v);
 
-////////////////// Type Bush (nested inductive type)
-
-symbol bush : Set →  Set;
-
-inductive Bush : Π(_:Set), TYPE ≔
- | bush_nil : Π a, Bush a
- | bush_cons : Π a, τ a → Bush (bush a) → Bush a;
-
-rule Bush $a ↪ τ (bush $a);
-
-assert ⊢ Bush : Π(_:Set), TYPE;
-assert ⊢ bush_nil : Π a, Bush a;
-assert ⊢ bush_cons : Π a, τ a → Bush (bush a) → Bush a;
-
-assert ⊢ ind_Bush : Π p,
-  (Π a, π(p a (bush_nil a))) →
-  (Π a x l, π(p (bush a) l) → π(p a (bush_cons a x l))) →
-  Π a l, π(p a l);
-
-assert p pempty pcons a ⊢ ind_Bush p pempty pcons a (bush_nil a) ≡ pempty a;
-
-assert p pempty pcons a x t
-⊢ ind_Bush p pempty pcons a (bush_cons a x t)
-≡ pcons a x t (ind_Bush p pempty pcons (bush a) t);
-
 /////////////////////////////
 // Equality
 /////////////////////////////
@@ -685,7 +660,10 @@ set builtin "eqind" ≔ eq_ind;
 // Some proofs
 /////////////////////////////
 
-opaque symbol plus_0_n : Π n, π(0 + n = n) ≔
+set unif_rule τ $x ≡ N ↪ [ $x ≡ nat ];
+//FIXME: should be infered from injectivity of τ
+
+opaque symbol plus_0_n n : π(0 + n = n) ≔
 begin
   assume n;
   reflexivity;

--- a/tests/ok_ko.ml
+++ b/tests/ok_ko.ml
@@ -14,10 +14,10 @@ let test_ko f () =
 let _ =
   Common.Library.set_lib_root None;
   let open Alcotest in
-  let files = Lplib.Extra.files "OK" in
+  let files = Lplib.Extra.files Common.Library.is_valid_src_extension "OK" in
   (* TODO put back OK/unif_hint.lp when it is fixed *)
   let files = List.filter (fun f -> f <> "OK/unif_hint.lp") files in
   let tests_ok = List.map (fun f -> test_case f `Quick (test_ok f)) files in
-  let files = Lplib.Extra.files "KO" in
+  let files = Lplib.Extra.files Common.Library.is_valid_src_extension "KO" in
   let tests_ko = List.map (fun f -> test_case f `Quick (test_ko f)) files in
   run "Std" [("OK", tests_ok); ("KO", tests_ko)]


### PR DESCRIPTION
- allow matching on abstraction/product type annotations (fix #573)
- Infer: do not check constraint duplication and return constraints in the order they have been added (fix #579)
- inductive type symbols are now declared as constant (fix #580)
- fix parsing and printing of unification rules
- Extra.files returns only the files that satisfy some user-defined condition
- tests/ok_ko.ml: test only .dk and .lp files
- Pretty: checking that identifiers are LP keywords is now optional (useful for debug)