### PR TITLE
fix and improve inverse image computation and unification rules handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,18 @@
 
 #### Fix and improve inverse image computation (2021-03-16)
 
-- fix and improve the computation of the inverse image of a term wrt an injective function (no unification rule is needed in tests anymore)
-- fix management of initial constraints in unification (initial is now a global variable fixed when solve is called)
+- fix and improve in `inverse.ml` the computation of the inverse image of a term wrt an injective function (no unification rule is needed anymore in common examples)
+- fix management of "initial" constraints in unification (initial is now a global variable updated whenever a new constraint is added)
+- when applying a unification rule, add constraints on types too (fix #466)
 - turn `Infer.make_prod` into `Infer.set_to_prod`
-- when applying a unification rule, add constraints on types too
 - add pp_constrs for printing lists of constraints
+- make time printing optional
+- improve visualization of debugging data using colors:
+  . blue: top-level type inference/checking
+  . magenta: new constraint
+  . green: constraint to solve
+  . yellow: data from signature or context
+  . red: instantiations (and handled commands)
 
 #### Add tactic admit (2021-03-12)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ### Unreleased
 
+#### Fix and improve inverse image computation (2021-03-16)
+
+- fix and improve the computation of the inverse image of a term wrt an injective function (no unification rule is needed in tests anymore)
+- fix management of initial constraints in unification (initial is now a global variable fixed when solve is called)
+- when applying a unification rule, add constraints on types too
+- add pp_constrs for printing lists of constraints
+
 #### Add tactic admit (2021-03-12)
 
 - rename command `admit` into `admitted`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - fix and improve the computation of the inverse image of a term wrt an injective function (no unification rule is needed in tests anymore)
 - fix management of initial constraints in unification (initial is now a global variable fixed when solve is called)
+- turn `Infer.make_prod` into `Infer.set_to_prod`
 - when applying a unification rule, add constraints on types too
 - add pp_constrs for printing lists of constraints
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 #### Fix and improve inverse image computation (2021-03-16)
 
-- fix and improve in `inverse.ml` the computation of the inverse image of a term wrt an injective function (no unification rule is needed anymore in common examples)
+- fix and improve in `inverse.ml` the computation of the inverse image of a term wrt an injective function (no unification rule is needed anymore in common examples, fix #342)
 - fix management of "initial" constraints in unification (initial is now a global variable updated whenever a new constraint is added)
 - when applying a unification rule, add constraints on types too (fix #466)
 - turn `Infer.make_prod` into `Infer.set_to_prod`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,3 +79,13 @@ following files:
 - the User Manual files in the `docs/` repository
 
 and do `make doc` for generating BNF grammars.
+
+Debugging
+---------
+
+Color codes:
+- blue: top-level type inference/checking
+- magenta: new constraint
+- green: constraint to solve
+- yellow: data from signature or context
+- red: instantiations and user commands

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -77,14 +77,14 @@ let logger_hndl = new_logger 'h' "hndl" "command handling"
 let log_hndl = logger_hndl.logger
 
 (** To print time data. *)
-let print_time = ref false
+let print_time = ref true
 
 (** [time_of f x] computes [f x] and the time for computing it. *)
-let time_of : logger -> (unit -> 'b) -> 'b = fun lg f ->
+let time_of : (unit -> 'b) -> 'b = fun f ->
   if !print_time && !log_enabled then
       let t0 = Sys.time() in
-      try let y = f () in lg.logger "%f" (Sys.time() -. t0); y
-      with e -> lg.logger "%f" (Sys.time() -. t0); raise e
+      try let y = f () in log_hndl "%f" (Sys.time() -. t0); y
+      with e -> log_hndl "%f" (Sys.time() -. t0); raise e
   else f ()
 
 (** Printing functions. *)

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -76,9 +76,12 @@ let new_logger : char -> string -> string -> logger = fun key name desc ->
 let logger_hndl = new_logger 'h' "hndl" "command handling"
 let log_hndl = logger_hndl.logger
 
+(** To print time data. *)
+let print_time = ref false
+
 (** [time_of f x] computes [f x] and the time for computing it. *)
 let time_of : logger -> (unit -> 'b) -> 'b = fun lg f ->
-  if !log_enabled then
+  if !print_time && !log_enabled then
       let t0 = Sys.time() in
       try let y = f () in lg.logger "%f" (Sys.time() -. t0); y
       with e -> lg.logger "%f" (Sys.time() -. t0); raise e

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -176,16 +176,15 @@ and check : ctxt -> term -> term -> unit = fun ctx t a ->
    and constraints [cs] cannot be infered, or [Some(a,cs')] where [a] is some
    type of [t] in the context [ctx] if the constraints [cs'] are satisfiable
    (which may not be the case). [ctx] must well sorted. *)
-let infer_noexn :
-    ?lg:logger -> constr list -> ctxt -> term -> (term * constr list) option =
-  fun ?(lg=logger_hndl) cs ctx t ->
+let infer_noexn : constr list -> ctxt -> term -> (term * constr list) option =
+  fun cs ctx t ->
   Stdlib.(constraints := cs);
   let res =
     try
-      if !log_enabled then lg.logger (blu "infer %a%a") pp_ctxt ctx pp_term t;
-      let a = time_of lg (fun () -> infer ctx t) in
+      if !log_enabled then log_hndl (blu "infer %a%a") pp_ctxt ctx pp_term t;
+      let a = time_of (fun () -> infer ctx t) in
       let cs = List.rev Stdlib.(!constraints) in
-      if !log_enabled then lg.logger (blu "%a%a") pp_term a pp_constrs cs;
+      if !log_enabled then log_hndl (blu "%a%a") pp_term a pp_constrs cs;
       Some (a, cs)
     with NotTypable -> None
   in Stdlib.(constraints := []); res
@@ -194,16 +193,15 @@ let infer_noexn :
    context [ctx] and constraints [cs], and [Some(cs')] where [cs'] is a list
    of constraints under which [t] may have type [a] (but constraints may be
    unsatisfiable). The context [ctx] and the type [a] must be well sorted. *)
-let check_noexn :
-    ?lg:logger -> constr list -> ctxt -> term -> term -> constr list option =
-  fun ?(lg=logger_hndl) cs ctx t a ->
+let check_noexn : constr list -> ctxt -> term -> term -> constr list option =
+  fun cs ctx t a ->
   Stdlib.(constraints := cs);
   let res =
     try
-      if !log_enabled then lg.logger (blu "check %a") pp_typing (ctx,t,a);
-      time_of lg (fun () -> check ctx t a);
+      if !log_enabled then log_hndl (blu "check %a") pp_typing (ctx,t,a);
+      time_of (fun () -> check ctx t a);
       let cs = List.rev Stdlib.(!constraints) in
-      if !log_enabled && cs <> [] then lg.logger (blu "%a") pp_constrs cs;
+      if !log_enabled && cs <> [] then log_hndl (blu "%a") pp_constrs cs;
       Some cs
     with NotTypable -> None
   in Stdlib.(constraints := []); res

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -45,7 +45,7 @@ let conv ctx a b =
     begin
       let c = (ctx,a,b) in
       Stdlib.(constraints := c::!constraints);
-      if !log_enabled then log_infr (yel "add %a") pp_constr c
+      if !log_enabled then log_infr (mag "%a") pp_constr c
     end
 
 (** Exception that may be raised by type inference. *)
@@ -182,10 +182,10 @@ let infer_noexn :
   Stdlib.(constraints := cs);
   let res =
     try
-      if !log_enabled then lg.logger "infer %a%a" pp_ctxt ctx pp_term t;
+      if !log_enabled then lg.logger (blu "infer %a%a") pp_ctxt ctx pp_term t;
       let a = time_of lg (fun () -> infer ctx t) in
       let cs = List.rev Stdlib.(!constraints) in
-      if !log_enabled then lg.logger (gre "%a%a") pp_term a pp_constrs cs;
+      if !log_enabled then lg.logger (blu "%a%a") pp_term a pp_constrs cs;
       Some (a, cs)
     with NotTypable -> None
   in Stdlib.(constraints := []); res
@@ -200,10 +200,10 @@ let check_noexn :
   Stdlib.(constraints := cs);
   let res =
     try
-      if !log_enabled then lg.logger "check %a" pp_typing (ctx,t,a);
+      if !log_enabled then lg.logger (blu "check %a") pp_typing (ctx,t,a);
       time_of lg (fun () -> check ctx t a);
       let cs = List.rev Stdlib.(!constraints) in
-      if !log_enabled && cs <> [] then lg.logger (gre "%a") pp_constrs cs;
+      if !log_enabled && cs <> [] then lg.logger (blu "%a") pp_constrs cs;
       Some cs
     with NotTypable -> None
   in Stdlib.(constraints := []); res

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -183,7 +183,7 @@ let infer_noexn : constr list -> ctxt -> term -> (term * constr list) option =
     try
       if !log_enabled then log_hndl (blu "infer %a%a") pp_ctxt ctx pp_term t;
       let a = time_of (fun () -> infer ctx t) in
-      let cs = List.rev Stdlib.(!constraints) in
+      let cs = Stdlib.(!constraints) in
       if !log_enabled then log_hndl (blu "%a%a") pp_term a pp_constrs cs;
       Some (a, cs)
     with NotTypable -> None
@@ -200,7 +200,7 @@ let check_noexn : constr list -> ctxt -> term -> term -> constr list option =
     try
       if !log_enabled then log_hndl (blu "check %a") pp_typing (ctx,t,a);
       time_of (fun () -> check ctx t a);
-      let cs = List.rev Stdlib.(!constraints) in
+      let cs = Stdlib.(!constraints) in
       if !log_enabled && cs <> [] then log_hndl (blu "%a") pp_constrs cs;
       Some cs
     with NotTypable -> None
@@ -217,6 +217,7 @@ let infer : solver -> Pos.popt -> ctxt -> term -> term =
   match infer_noexn [] ctx t with
   | None -> fatal pos "[%a] is not typable." pp_term t
   | Some(a, to_solve) ->
+      let to_solve = List.rev to_solve in
       match solve_noexn {empty_problem with to_solve} with
       | None -> fatal pos "[%a] is not typable." pp_term t
       | Some [] -> a
@@ -232,6 +233,7 @@ let check : solver -> Pos.popt -> ctxt -> term -> term -> unit =
   match check_noexn [] ctx t a with
   | None -> fatal pos "[%a] does not have type [%a]." pp_term t pp_term a
   | Some(to_solve) ->
+      let to_solve = List.rev to_solve in
       match solve_noexn {empty_problem with to_solve} with
       | None -> fatal pos "[%a] does not have type [%a]." pp_term t pp_term a
       | Some [] -> ()
@@ -247,6 +249,7 @@ let check_sort : solver -> Pos.popt -> ctxt -> term -> unit
   match infer_noexn [] ctx t with
   | None -> fatal pos "[%a] is not typable." pp_term t
   | Some(a, to_solve) ->
+      let to_solve = List.rev to_solve in
       match solve_noexn {empty_problem with to_solve} with
       | None -> fatal pos "[%a] is not typable." pp_term t
       | Some ((_::_) as cs) ->

--- a/src/core/inverse.ml
+++ b/src/core/inverse.ml
@@ -5,6 +5,7 @@ open Timed
 open Common
 open Debug
 open Print
+open Lplib.Extra
 
 (** Logging function for unification. *)
 let logger_inv = new_logger 'v' "invr" "inverse"
@@ -26,7 +27,7 @@ let const_graph : sym -> (sym * sym) list = fun s ->
   if !log_enabled then log_inv "check rules of %a" pp_sym s;
   let add s0 s1 l =
     if !log_enabled then
-      log_inv "rule %a %a ↪ %a" pp_sym s pp_sym s0 pp_sym s1;
+      log_inv (yel "%a %a ↪ %a") pp_sym s pp_sym s0 pp_sym s1;
     (s0,s1)::l
   in
   let f l rule =
@@ -64,9 +65,9 @@ let prod_graph : sym -> (sym * sym * sym * bool) list = fun s ->
   if !log_enabled then log_inv "check rules of %a" pp_sym s;
   let add (s0,s1,s2,b) l =
     if !log_enabled then
-      if b then log_inv "rule %a (%a _ _) ↪ Π x:%a _, %a _[x]"
+      if b then log_inv (yel "%a (%a _ _) ↪ Π x:%a _, %a _[x]")
                   pp_sym s pp_sym s0 pp_sym s1 pp_sym s2
-      else log_inv "rule %a (%a _ _) ↪ %a _ → %a _"
+      else log_inv (yel "%a (%a _ _) ↪ %a _ → %a _")
              pp_sym s pp_sym s0 pp_sym s1 pp_sym s2;
     (s0,s1,s2,b)::l
   in
@@ -120,7 +121,7 @@ let inverse_prod : sym -> sym -> sym * sym * sym * bool = fun s s' ->
 (** [inverse s v] tries to compute a term [u] such that [s(u)] reduces to [v].
 @raise [Not_found] otherwise. *)
 let rec inverse : sym -> term -> term = fun s v ->
-  if !log_enabled then log_inv "try to compute %a⁻¹(%a)" pp_sym s pp_term v;
+  if !log_enabled then log_inv "compute %a⁻¹(%a)" pp_sym s pp_term v;
   match LibTerm.get_args v with
   | Symb s', [t] when s' == s -> t
   | Symb s', ts -> LibTerm.add_args (Symb (inverse_const s s')) ts

--- a/src/core/inverse.ml
+++ b/src/core/inverse.ml
@@ -1,0 +1,142 @@
+(** Compute the inverse image of a term wrt an injective function. *)
+
+open Term
+open Timed
+open Common
+open Debug
+open Print
+
+(** Logging function for unification. *)
+let logger_inv = new_logger 'v' "invr" "inverse"
+let log_inv = logger_inv.logger
+
+(** [cache f s] is equivalent to [f s] but [f s] is computed only once unless
+   the rules of [s] are changed. *)
+let cache : (sym -> 'a) -> (sym -> 'a) = fun f ->
+  let cache = ref [] in
+  fun s ->
+  let srs = !(s.sym_rules) in
+  try let rs, x = List.assq s !cache in
+      if rs == srs then x else raise Not_found
+  with Not_found -> let x = f s in cache := (s, (srs, x))::!cache; x
+
+(** [const_graph s] returns the list of pairs [(s0,s1)] such that [s]
+   has a rule of the form [s (s0 ...) ↪ s1 ...]. *)
+let const_graph : sym -> (sym * sym) list = fun s ->
+  if !log_enabled then log_inv "check rules of %a" pp_sym s;
+  let add s0 s1 l =
+    if !log_enabled then
+      log_inv "rule %a %a ↪ %a" pp_sym s pp_sym s0 pp_sym s1;
+    (s0,s1)::l
+  in
+  let f l rule =
+    match rule.lhs with
+    | [l1] ->
+        begin
+          match LibTerm.get_args l1 with
+          | Symb s0, _ ->
+              let n = Bindlib.mbinder_arity rule.rhs in
+              let r = Bindlib.msubst rule.rhs (Array.make n TE_None) in
+              begin
+                match LibTerm.get_args r with
+                | Symb s1, _ -> add s0 s1 l
+                | _ -> l
+              end
+          | _ -> l
+        end
+    | _ -> l
+  in
+  List.fold_left f [] !(s.sym_rules)
+
+(** cached version of [const_rules]. *)
+let const_graph : sym -> (sym * sym) list = cache const_graph
+
+(** [inverse_const s s'] returns [s0] if [s] has a rule of the form [s (s0
+   ...) ↪ s' ...].
+@raise [Not_found] otherwise. *)
+let inverse_const : sym -> sym -> sym = fun s s' ->
+  fst (List.find (fun (_,s1) -> s1 == s') (const_graph s))
+
+(** [prod_graph s] returns the list of tuples [(s0,s1,s2,b)] such that [s] has
+   a rule of the form [s (s0 _ _) ↪ Π x:s1 _, s2 r] with [b=true] iff [x]
+   occurs in [r]. *)
+let prod_graph : sym -> (sym * sym * sym * bool) list = fun s ->
+  if !log_enabled then log_inv "check rules of %a" pp_sym s;
+  let add (s0,s1,s2,b) l =
+    if !log_enabled then
+      if b then log_inv "rule %a (%a _ _) ↪ Π x:%a _, %a _[x]"
+                  pp_sym s pp_sym s0 pp_sym s1 pp_sym s2
+      else log_inv "rule %a (%a _ _) ↪ %a _ → %a _"
+             pp_sym s pp_sym s0 pp_sym s1 pp_sym s2;
+    (s0,s1,s2,b)::l
+  in
+  let f l rule =
+    match rule.lhs with
+    | [l1] ->
+        begin
+          match LibTerm.get_args l1 with
+          | Symb s0, [_;_] ->
+              let n = Bindlib.mbinder_arity rule.rhs in
+              let r = Bindlib.msubst rule.rhs (Array.make n TE_None) in
+              begin
+                match r with
+                | Prod(a,b) ->
+                    begin
+                      match LibTerm.get_args a with
+                      | Symb s1, [_] ->
+                          begin
+                            match LibTerm.get_args (Bindlib.subst b Kind) with
+                            | Symb(s2), [_] ->
+                                add (s0,s1,s2,Bindlib.binder_occur b) l
+                            | _ -> l
+                          end
+                      | _ -> l
+                    end
+                | _ -> l
+              end
+          | _ -> l
+        end
+    | _ -> l
+  in
+  List.fold_left f [] !(s.sym_rules)
+
+(** cached version of [prod_graph]. *)
+let prod_graph : sym -> (sym * sym * sym * bool) list = cache prod_graph
+
+(** [inverse_prod s s'] returns [(s0,s1,s2,b)] if [s] has a rule of the form
+   [s (s0 _ _) ↪ Π x:s1 _, s2 r] with [b=true] iff [x] occurs in [r], and
+   either [s1] has a rule of the form [s1 (s3 ...) ↪ s' ...] or [s1 == s'].
+@raise [Not_found] otherwise. *)
+let inverse_prod : sym -> sym -> sym * sym * sym * bool = fun s s' ->
+  match prod_graph s with
+  | [] -> raise Not_found
+  | [x] -> x
+  | graph ->
+  let f (_,s1,_,_) =
+    try let _ = inverse_const s1 s' in true with Not_found -> false in
+  try List.find f graph
+  with Not_found -> List.find (fun (_,s1,_,_) -> s1 == s') graph
+
+(** [inverse s v] tries to compute a term [u] such that [s(u)] reduces to [v].
+@raise [Not_found] otherwise. *)
+let rec inverse : sym -> term -> term = fun s v ->
+  if !log_enabled then log_inv "try to compute %a⁻¹(%a)" pp_sym s pp_term v;
+  match LibTerm.get_args v with
+  | Symb s', [t] when s' == s -> t
+  | Symb s', ts -> LibTerm.add_args (Symb (inverse_const s s')) ts
+  | Prod(a,b), _ ->
+      let s0,s1,s2,occ =
+        match LibTerm.get_args a with
+        | Symb s', _ -> inverse_prod s s'
+        | _ -> raise Not_found
+      in
+      let t1 = inverse s1 a in
+      let t2 =
+        let x, b = Bindlib.unbind b in
+        let b = inverse s2 b in
+        if occ then
+          Bindlib.unbox (_Abst (lift a) (Bindlib.bind_var x (lift b)))
+        else b
+      in
+      LibTerm.add_args (Symb s0) [t1;t2]
+  | _ -> raise Not_found

--- a/src/core/inverse.ml
+++ b/src/core/inverse.ml
@@ -141,3 +141,6 @@ let rec inverse : sym -> term -> term = fun s v ->
       in
       LibTerm.add_args (Symb s0) [t1;t2]
   | _ -> raise Not_found
+
+let inverse : sym -> term -> term = fun s v ->
+  let t = inverse s v in assert (Eval.eq_modulo [] (Appl(Symb s,t)) v); t

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -266,8 +266,10 @@ let pp_typing : constr pp = fun ppf (ctx, t, u) ->
 let pp_constr : constr pp = fun ppf (ctx, t, u) ->
   out ppf "%a%a\n  ≡ %a" pp_ctxt ctx pp_term t pp_term u
 
+let pp_constrs : constr list pp = fun ppf ->
+  List.iter (fprintf ppf "\n  ; %a" pp_constr)
+
 (* for debug only *)
 let pp_problem : problem pp = fun ppf p ->
-  let constr ppf c = out ppf "\n  ; %a" pp_constr c in
   out ppf "{ recompute = %b; to_solve = [%a];\nunsolved = [%a] }"
-    p.recompute (List.pp constr "") p.to_solve (List.pp constr "") p.unsolved
+    p.recompute pp_constrs p.to_solve pp_constrs p.unsolved

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -261,15 +261,15 @@ let pp_ctxt : ctxt pp = fun ppf ctx ->
     end
 
 let pp_typing : constr pp = fun ppf (ctx, t, u) ->
-  out ppf "%a%a\n: %a" pp_ctxt ctx pp_term t pp_term u
+  out ppf "%a%a : %a" pp_ctxt ctx pp_term t pp_term u
 
 let pp_constr : constr pp = fun ppf (ctx, t, u) ->
-  out ppf "%a%a\n  ≡ %a" pp_ctxt ctx pp_term t pp_term u
+  out ppf "%a%a ≡ %a" pp_ctxt ctx pp_term t pp_term u
 
 let pp_constrs : constr list pp = fun ppf ->
   List.iter (fprintf ppf "\n  ; %a" pp_constr)
 
 (* for debug only *)
 let pp_problem : problem pp = fun ppf p ->
-  out ppf "{ recompute = %b; to_solve = [%a];\nunsolved = [%a] }"
+  out ppf "{ recompute = %b; to_solve = [%a];\n  unsolved = [%a] }"
     p.recompute pp_constrs p.to_solve pp_constrs p.unsolved

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -472,7 +472,7 @@ let solve : ?type_check:bool -> problem -> constr list =
   fun ?(type_check=true) p ->
   if !log_enabled then log_hndl "solve %a" pp_problem p;
   Stdlib.(do_type_check := type_check; initial := p.to_solve);
-  time_of logger_hndl (fun () -> solve p)
+  time_of (fun () -> solve p)
 
 (** [solve_noexn problem] attempts to solve [problem]. If there is
    no solution, the value [None] is returned. Otherwise [Some(cs)] is

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -67,8 +67,6 @@ let instantiation : ctxt -> meta -> term array -> term ->
     match nl_distinct_vars ctx ts with
     | None -> None
     | Some(vs, map) ->
-        (*if !log_enabled then
-          log_unif "variables: %a" (Array.pp pp_var " ") vs;*)
         let u = Eval.simplify (sym_to_var map u) in
         Some (Bindlib.bind_mvar vs (lift u))
   else None

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -198,7 +198,8 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
     sig_state * proof_data option * Query.result =
   fun compile ss ({elt; pos} as cmd) ->
   if !log_enabled then
-    log_hndl (blu "%f %a\n%a") (Sys.time()) Pos.pp pos Pretty.command cmd;
+      (if !print_time then log_hndl "%f" (Sys.time());
+       log_hndl "%a" Pos.pp pos; log_hndl (red "%a") Pretty.command cmd);
   let scope expo = Scope.scope_term expo ss Env.empty IntMap.empty in
   match elt with
   | P_query(q) -> (ss, None, Query.handle ss None q)

--- a/src/handle/proof.ml
+++ b/src/handle/proof.ml
@@ -235,7 +235,7 @@ let goals_of_typ : term loc option -> term loc option -> goal list * term =
         end
     | None, None -> assert false (* already rejected by parser *)
   in
-  (List.rev_map (fun c -> Unif c) to_solve, typ)
+  (List.map (fun c -> Unif c) to_solve, typ)
 
 (** [goals_of_typ typ ter] returns a list of goals for [typ] to be typable by
    by a sort and [ter] to have type [typ] in the empty context. [ter] and

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -119,7 +119,7 @@ let tac_refine : popt -> proof_state -> goal_typ -> goal list -> term
 (** [ind_data t] returns the [ind_data] structure of [s] if [t] is of the
    form [s t1 .. tn] with [s] an inductive type. Fails otherwise. *)
 let ind_data : popt -> Env.t -> term -> Sign.ind_data = fun pos env a ->
-  let h, ts = LibTerm.get_args a in
+  let h, ts = LibTerm.get_args (Eval.whnf (Env.to_ctxt env) a) in
   match h with
   | Symb s ->
       let sign = Path.Map.find s.sym_path Sign.(!loaded) in

--- a/src/tool/sr.ml
+++ b/src/tool/sr.ml
@@ -149,7 +149,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
          only used for printing. *)
       let rhs = Bindlib.(unbox (bind_mvar vars pr_rhs)) in
       let naive_rule = {lhs; rhs; arity; arities; vars; xvars_nb = 0} in
-      log_subj (mag "check %a") pp_rule (s, naive_rule);
+      log_subj (red "%a") pp_rule (s, naive_rule);
     end;
   (* Replace [Patt] nodes of LHS with corresponding elements of [vars]. *)
   let lhs_vars =
@@ -195,8 +195,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
   | Some lhs_constrs ->
   if !log_enabled then
     begin
-      log_subj (gre "LHS has type: %a") pp_term ty_lhs;
-      List.iter (log_subj (gre "  if %a") pp_constr) lhs_constrs;
+      log_subj "LHS has type: %a%a" pp_term ty_lhs pp_constrs lhs_constrs;
       log_subj "LHS is now: %a" pp_term lhs_typing;
       log_subj "RHS is now: %a" pp_term rhs_typing;
       log_subj "check that the RHS has the same type as the LHS"

--- a/src/tool/sr.ml
+++ b/src/tool/sr.ml
@@ -188,6 +188,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
   match Infer.infer_noexn [] [] lhs_typing with
   | None -> fatal pos "The LHS is not typable."
   | Some(ty_lhs, to_solve) ->
+  let to_solve = List.rev to_solve in
   (* Try to simplify constraints. *)
   let type_check = false in (* Don't check typing when instantiating metas. *)
   match Unif.(solve_noexn ~type_check {empty_problem with to_solve}) with

--- a/src/tool/xtc.ml
+++ b/src/tool/xtc.ml
@@ -172,7 +172,7 @@ let get_vars : sym -> rule -> (string * Term.term) list = fun s r ->
   match Infer.infer_noexn [] ctx lhs with
   | None -> assert false (*FIXME?*)
   | Some (_,cs) ->
-  let cs = List.map (fun (_,t,u) -> (t,u)) cs in
+  let cs = List.rev_map (fun (_,t,u) -> (t,u)) cs in
   let ctx = List.map (fun (x,a,_) -> (x,a)) ctx in
   List.map (fun (v,ty) -> Bindlib.name_of v, List.assoc ty cs(*FIXME?*)) ctx
 

--- a/tests/OK/admit.lp
+++ b/tests/OK/admit.lp
@@ -13,10 +13,9 @@ constant symbol ι: Type;
 
 // A simple independant axiom
 symbol prop1: Prop;
-symbol f: Prf prop1 → El ι;
+symbol f: Prf prop1 → Prop;
 symbol π_f: Prf (f _)
 begin
-  focus 1;
   admit;
   // Adds an axiom [ax_?]
 admitted;

--- a/tests/OK/inductive.lp
+++ b/tests/OK/inductive.lp
@@ -664,9 +664,6 @@ builtin "eqind" ≔ eq_ind;
 // Some proofs
 /////////////////////////////
 
-unif_rule τ $x ≡ N ↪ [ $x ≡ nat ];
-//FIXME: should be infered from injectivity of τ
-
 opaque symbol plus_0_n n : π(0 + n = n) ≔
 begin
   assume n;

--- a/tests/OK/natproofs.lp
+++ b/tests/OK/natproofs.lp
@@ -3,7 +3,6 @@ require open tests.OK.bool;
 require open tests.OK.nat;
 
 rule T nat ↪ N;
-unif_rule T $x ≡ N ↪ [ $x ≡ nat ]; //FIXME should be infered automatically
 
 // Symmetry of the equality (first option, rewrite).
 opaque symbol eq_sym a (x y:T a) : P (x = y) → P (y = x)

--- a/tests/OK/tautologies.lp
+++ b/tests/OK/tautologies.lp
@@ -2,7 +2,6 @@ require open tests.OK.logic;
 require open tests.OK.bool;
 
 rule T bool ↪ B;
-unif_rule T $x ≡ B ↪ [ $x ≡ bool ]; //FIXME should be infered automatically
 
 opaque symbol and_idempotent (a:B) : P (bool_and a a = a)
 ≔ begin

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -8,7 +8,7 @@ rule T bool ↪ Bool;
 //   &x ≡ bool
 // --------------
 //  T &x ≡ Bool
-unif_rule (T $x) ≡ Bool ↪ [ $x ≡ bool ];
+//unif_rule (T $x) ≡ Bool ↪ [ $x ≡ bool ];
 
 symbol f : (Bool → Bool) → U;
 
@@ -21,7 +21,7 @@ rule T nat ↪ Nat;
 //   &x ≡ nat
 // -------------
 //  T &x ≡ Nat
-unif_rule T $x ≡ Nat ↪ [ $x ≡ nat ];
+//unif_rule T $x ≡ Nat ↪ [ $x ≡ nat ];
 
 symbol G: Bool → Nat → TYPE;
 type λ x: T _, λ y: T _, G x y;

--- a/tests/ok_ko.ml
+++ b/tests/ok_ko.ml
@@ -15,8 +15,6 @@ let _ =
   Common.Library.set_lib_root None;
   let open Alcotest in
   let files = Lplib.Extra.files Common.Library.is_valid_src_extension "OK" in
-  (* TODO put back OK/unif_hint.lp when it is fixed *)
-  let files = List.filter (fun f -> f <> "OK/unif_hint.lp") files in
   let tests_ok = List.map (fun f -> test_case f `Quick (test_ok f)) files in
   let files = Lplib.Extra.files Common.Library.is_valid_src_extension "KO" in
   let tests_ko = List.map (fun f -> test_case f `Quick (test_ko f)) files in


### PR DESCRIPTION
- fix and improve in `inverse.ml` the computation of the inverse image of a term wrt an injective function (no unification rule is needed anymore in common examples, fix #342)
- fix management of "initial" constraints in unification (initial is now a global variable updated whenever a new constraint is added)
- when applying a unification rule, add constraints on types too (fix #466)
- turn `Infer.make_prod` into `Infer.set_to_prod`
- add pp_constrs for printing lists of constraints
- make time printing optional
- improve visualization of debugging data using colors:
  . blue: top-level type inference/checking
  . magenta: new constraint
  . green: constraint to solve
  . yellow: data from signature or context
  . red: instantiations (and handled commands)
