### PR TITLE
delay computation of query results

### DIFF
--- a/src/common/console.ml
+++ b/src/common/console.ml
@@ -23,9 +23,9 @@ let set_default_verbose : int -> unit = fun i ->
     output channel is automatically flushed,  and  the message is displayed in
     magenta (and not default terminal color) if logging modes are enabled. *)
 let out : int -> 'a outfmt -> 'a = fun lvl fmt ->
-  let fmt = if !log_enabled then fmt else fmt ^^ "%!" in
   if lvl > !verbose then Format.ifprintf Stdlib.(!out_fmt) fmt
-  else Format.fprintf Stdlib.(!out_fmt) fmt
+  else Format.fprintf Stdlib.(!out_fmt)
+         (if !log_enabled then fmt else fmt ^^ "%!")
 
 (** List of registered boolean flags, with their default values. *)
 let boolean_flags : (bool * bool ref) StrMap.t Stdlib.ref =

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -468,7 +468,7 @@ let too_long = Stdlib.ref infinity
     are captured, although they should not occur. *)
 let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
    sig_state * proof_data option * Query.result =
- fun compile ss ({pos;_} as cmd) ->
+  fun compile ss ({pos;_} as cmd) ->
   Print.sig_state := ss;
   try
     let (tm, ss) = time (handle compile ss) cmd in

--- a/src/pure/pure.mli
+++ b/src/pure/pure.mli
@@ -4,7 +4,6 @@ open Lplib
 open Core
 open Common
 open Parsing
-open Handle
 
 (** Abstract representation of a command (top-level item). *)
 module Command : sig
@@ -51,7 +50,7 @@ val current_goals : proof_state -> goal list
 
 (** Result type of the [handle_command] function. *)
 type command_result =
-  | Cmd_OK    of state * Query.result
+  | Cmd_OK    of state * string option
   (** Command is done. *)
   | Cmd_Proof of proof_state * Tactic.t list * Pos.popt * Pos.popt
   (** Enter proof mode (positions are for statement and qed). *)
@@ -60,7 +59,7 @@ type command_result =
 
 (** Result type of the [handle_tactic] function. *)
 type tactic_result =
-  | Tac_OK    of proof_state * Query.result
+  | Tac_OK    of proof_state * string option
   | Tac_Error of Pos.popt option * string
 
 (** [initial_state fname] gives an initial state for working with the (source)


### PR DESCRIPTION
The computation of query results as strings added in #518 slowed down performances in a very significant way.
Delay these computations whose results are required in the LSP server only allows to recover the lost efficiency.