### PR TITLE
Fix type inference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           opam pin add alt-ergo 2.3.1
           opam install alt-ergo
+          opam pin add why3 1.3.3
+          opam install why3
           opam pin add -n -k path lambdapi .
           opam install --deps-only -d -t lambdapi
           opam update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,6 @@ jobs:
         run: |
           opam pin add alt-ergo 2.3.1
           opam install alt-ergo
-          opam pin add why3 1.3.3
-          opam install why3
           opam pin add -n -k path lambdapi .
           opam install --deps-only -d -t lambdapi
           opam update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ### Unreleased
 
+#### Bug fixes (2021-03-22)
+
+- fix type inference in the case of an application (t u) where the type of t is not a product yet (uncomment code commented in #596)
+- fix the order in which emacs prints hypotheses
+- fix opam dependencies: add constraint why3 <= 1.3.3
+
 #### Fix and improve inverse image computation (2021-03-16)
 
 - fix and improve in `inverse.ml` the computation of the inverse image of a term wrt an injective function (no unification rule is needed anymore in common examples, fix #342)

--- a/editors/emacs/lambdapi-proofs.el
+++ b/editors/emacs/lambdapi-proofs.el
@@ -116,7 +116,7 @@ bold if goalNo is 0"
                 (let ((name (plist-get hyp :hname))
                       (type (plist-get hyp :htype)))
                   (format "%s: %s\n" name type)))
-              (reverse hs)))))
+              hs))))
 
 (defun lp-format-string-goal (goal goalNo proofbuf proofpos)
   "Return the string associated to a single goal. Adds text-properties to

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -27,7 +27,7 @@ depends: [
   "sedlex"
   "bindlib"      { >= "5.0.1" }
   "timed"        { = "1.0"   }
-  "why3"         { >= "1.3.1" }
+  "why3"         { >= "1.3.1" & <= "1.3.3" }
   "yojson"       { >= "1.6.0" }
   "cmdliner"     { >= "1.0.3" }
   "stdlib-shims"

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -134,7 +134,7 @@ let rec infer : ctxt -> term -> term = fun ctx t ->
         | Meta(m,_) -> set_to_prod m; get_prod f typ
         | _ -> f typ
       in
-      let get_prod_whnf = (* assume that its argument is in whnf *)
+      let get_prod_whnf = (* assumes that its argument is in whnf *)
         get_prod (fun typ ->
             let a = LibTerm.Meta.make ctx Type in
             (* We force [b] to be of type [Type] as there is little (no?)

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -124,19 +124,25 @@ let rec infer : ctxt -> term -> term = fun ctx t ->
      ------------------------------------
          ctx ⊢ Appl(t,u) ⇒ subst b u      *)
   | Appl(t,u)   ->
+      (* [get_prod f typ] returns the domain and codomain of [t] if [t] is a
+         product. If [t] is a metavariable, then it instantiates it with a
+         product calls [get_prod f typ] again. Otherwise, it calls [f typ]. *)
       let rec get_prod f typ =
+        if !log_enabled then log_infr "get_prod %a" pp_term typ;
         match unfold typ with
         | Prod(a,b) -> (a,b)
         | Meta(m,_) -> set_to_prod m; get_prod f typ
         | _ -> f typ
       in
-      let get_prod_whnf = get_prod (fun _ -> raise NotTypable) in
-        (*let a = LibTerm.Meta.make ctx Type in
-        (* Here, we force [b] to be of type [Type] as there is little
-           (no?) chance that it can be a kind. FIXME? *)
-        let b = LibTerm.Meta.make_codomain ctx a in
-        conv ctx t (Prod(a,b)); (a,b)*)
-      let get_prod = get_prod (fun t -> get_prod_whnf (Eval.whnf ctx t)) in
+      let get_prod_whnf = (* assume that its argument is in whnf *)
+        get_prod (fun typ ->
+            let a = LibTerm.Meta.make ctx Type in
+            (* We force [b] to be of type [Type] as there is little (no?)
+               chance that it can be a kind. *)
+            let b = LibTerm.Meta.make_codomain ctx a in
+            conv ctx typ (Prod(a,b)); (a,b)) in
+      let get_prod =
+        get_prod (fun typ -> get_prod_whnf (Eval.whnf ctx typ)) in
       let (a,b) = get_prod (infer ctx t) in
       check ctx u a;
       Bindlib.subst b u

--- a/tests/OK/infer.lp
+++ b/tests/OK/infer.lp
@@ -1,0 +1,24 @@
+// test type inference in the case of an application (t u)
+// where the type of t is not a product (yet)
+
+constant symbol Prop : TYPE;
+injective symbol π : Prop → TYPE;
+
+constant symbol ∧ : Prop → Prop → Prop;
+notation ∧ infix left 5;
+rule π ($A ∧ $B) ↪ Π P, (π $A → π $B → π P) → π P;
+
+constant symbol and_i A B : π A → π B → π (A ∧ B);
+constant symbol and_eg A B : π (A ∧ B) → π A;
+constant symbol and_ed A B : π (A ∧ B) → π B;
+
+constant symbol ⇒ : Prop → Prop → Prop;
+notation ⇒ infix right 6;
+rule π ($A ⇒ $B) ↪ π $A → π $B;
+
+constant symbol imp_e A B : π (A ⇒ B) → π A → π B;
+
+symbol P : Prop;
+symbol R : Prop;
+
+type λ H: π((P ⇒ R) ∧ (R ⇒ P)), λ Hr: π R, and_ed _ _ H Hr;


### PR DESCRIPTION
- fix type inference in the case of an application (t u) where the type of t is not a product yet: uncomment code commented in #596 
- fix the order in which emacs prints hypotheses
- opam dependencies: add constraint why3 <= 1.3.3
