### PR TITLE
Ensure protected numeric suffix truly is a suffix

### DIFF
--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -153,7 +153,7 @@ end = struct
   let regid = [%sedlex.regexp? Plus (Compl forbidden_letter)]
 
   (* Identifiers not compatible with Bindlib. *)
-  let invalid_bindlib_id = [%sedlex.regexp? Star any, Plus '0', nat]
+  let invalid_bindlib_id = [%sedlex.regexp? Star any, Plus '0', nat, eof]
 
   (* Once unescaped, escaped identifiers must not be empty, as the empty
      string is used in the path of ghost signatures. *)


### PR DESCRIPTION
Not sure if this is the right way to fix #625 but it works on my side at least.