### PR TITLE
add commutative and associative-commutative symbols

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,20 @@
 
 #### Add commutative and associative-commutative symbols (2021-04-07)
 
-- by privatizing the type `term` and adding `term.mli`
+- Add `term.mli` and turn the `term` type into a *private* type so that
+  term constructors are not exported anymore (they are available for
+  pattern-matching though). For constructing terms, one now needs to
+  use the provided construction functions `mk_Vari` for `Vari`,
+  `mk_Appl` for `Appl`, etc.
+
+- Move some functions `LibTerm` to `Term`, in particular `get_args`,
+  `add_args` and `cmp_term`.
+
+- Rename the field `sym_tree` into `sym_dtree`.
+
+- Redefine the type `rhs` as `(term_env, term) Bindlib.mbinder`
+  instead of `(term_env, term) Bindlib.mbinder * int` so that the old
+  `rhs` needs to be replaced by `rhs * int` in a few places.
 
 #### Improvements in some tactics (2021-04-05)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+#### Add commutative and associative-commutative symbols (2021-04-07)
+
+- by privatizing the type `term` and adding `term.mli`
+
 #### Improvements in some tactics (2021-04-05)
 
 - fix `have`

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -34,9 +34,11 @@ syntax.bnf:
 	-e 's/AS/as/g' \
 	-e 's/asSERT/assert/g' \
 	-e 's/assertNOT/assertnot/g' \
+	-e 's/<assoc>IATIVE/associative/g' \
 	-e 's/asSUME/assume/g' \
 	-e 's/BEGIN/begin/g' \
 	-e 's/BUILTIN/builtin/g' \
+	-e 's/COMMUTATIVE/commutative/g' \
 	-e 's/COMPUTE/compute/g' \
 	-e 's/CONSTANT/constant/g' \
 	-e 's/DEBUG/debug/g' \

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -102,32 +102,37 @@ Examples:
 **Modifiers:**
 
 Modifiers are keywords that precede a symbol declaration to provide
-the system with additional information on its properties or behavior.
+the system with additional information on its properties and behavior.
 
-- Modifiers for the unification engine:
+- Property modifiers (used by the unification engine or the conversion):
 
-  - ``constant``: no rule can be added to the symbol
-  - ``injective``: the symbol can be considered as injective, that is, if ``f t1 .. tn`` ≡ ``f u1 .. un``, then ``t1``\ ≡\ ``u1``, …, ``tn``\ ≡\ ``un``. For the moment, the verification is left to the user.
+  - ``constant``: No rule or definition can be given to the symbol
+  - ``injective``: The symbol can be considered as injective, that is, if ``f t1 .. tn`` ≡ ``f u1 .. un``, then ``t1``\ ≡\ ``u1``, …, ``tn``\ ≡\ ``un``. For the moment, the verification is left to the user.
+  - ``commutative``: Adds in the conversion the equation ``f t u ≡ f u t``.
+  - ``associative``: Adds in the conversion the equation ``f (f t u) v ≡ f t (f u v)`` (in conjonction with ``commutative`` only)
 
--  Exposition markers define how a symbol can be used outside the module
-   where it is defined.
+    
+- Exposition modifiers define how a symbol can be used outside the
+   module where it is defined. By default, the symbol can be used
+   without restriction.
 
-   -  by default, the symbol can be used without restriction
-   -  ``private``: the symbol cannot be used
-   -  ``protected``: the symbol can only be used in left-hand side of
+  -  ``private``: The symbol cannot be used.
+  -  ``protected``: The symbol can only be used in left-hand side of
       rewrite rules.
 
-   Exposition markers obey the following rules: inside a module,
+  Exposition modifiers obey the following rules: inside a module,
 
-   -  private symbols cannot appear in the type of public symbols;
-   -  private symbols cannot appear in the right-hand side of a
-      rewriting rule defining a public symbol
-   -  externally defined protected symbols cannot appear at the head of
-      a left-hand side
-   -  externally defined protected symbols cannot appear in the right
-      hand side of a rewriting rule
+  -  Private symbols cannot appear in the type of public symbols.
+  -  Private symbols cannot appear in the right-hand side of a
+     rewriting rule defining a public symbol.
+  -  Externally defined protected symbols cannot appear at the head of
+     a left-hand side.
+  -  Externally defined protected symbols cannot appear in the right
+     hand side of a rewriting rule.
 
--  ``sequential``: modifies the pattern matching algorithm. By default,
+-  Matching strategy modifiers:
+
+  - ``sequential``: modifies the pattern matching algorithm. By default,
    the order of rule declarations is not taken into account. This
    modifier tells Lambdapi to apply rules defining a sequential symbol
    in the order they have been declared (note that the order of the

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -104,7 +104,7 @@ Examples:
 Modifiers are keywords that precede a symbol declaration to provide
 the system with additional information on its properties and behavior.
 
-- Property modifiers (used by the unification engine or the conversion):
+- **Property modifiers** (used by the unification engine or the conversion):
 
   - ``constant``: No rule or definition can be given to the symbol
   - ``injective``: The symbol can be considered as injective, that is, if ``f t1 .. tn`` ≡ ``f u1 .. un``, then ``t1``\ ≡\ ``u1``, …, ``tn``\ ≡\ ``un``. For the moment, the verification is left to the user.
@@ -112,9 +112,9 @@ the system with additional information on its properties and behavior.
   - ``associative``: Adds in the conversion the equation ``f (f t u) v ≡ f t (f u v)`` (in conjonction with ``commutative`` only)
 
     
-- Exposition modifiers define how a symbol can be used outside the
-   module where it is defined. By default, the symbol can be used
-   without restriction.
+- **Exposition modifiers** define how a symbol can be used outside the
+  module where it is defined. By default, the symbol can be used
+  without restriction.
 
   - ``private``: The symbol cannot be used.
   - ``protected``: The symbol can only be used in left-hand side of
@@ -130,7 +130,7 @@ the system with additional information on its properties and behavior.
   - Externally defined protected symbols cannot appear in the right
     hand side of a rewriting rule.
 
--  Matching strategy modifiers:
+- **Matching strategy modifiers:**
 
   - ``sequential``: modifies the pattern matching algorithm. By default,
     the order of rule declarations is not taken into account. This

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -116,29 +116,29 @@ the system with additional information on its properties and behavior.
    module where it is defined. By default, the symbol can be used
    without restriction.
 
-  -  ``private``: The symbol cannot be used.
-  -  ``protected``: The symbol can only be used in left-hand side of
-      rewrite rules.
+  - ``private``: The symbol cannot be used.
+  - ``protected``: The symbol can only be used in left-hand side of
+    rewrite rules.
 
   Exposition modifiers obey the following rules: inside a module,
 
-  -  Private symbols cannot appear in the type of public symbols.
-  -  Private symbols cannot appear in the right-hand side of a
-     rewriting rule defining a public symbol.
-  -  Externally defined protected symbols cannot appear at the head of
-     a left-hand side.
-  -  Externally defined protected symbols cannot appear in the right
-     hand side of a rewriting rule.
+  - Private symbols cannot appear in the type of public symbols.
+  - Private symbols cannot appear in the right-hand side of a
+    rewriting rule defining a public symbol.
+  - Externally defined protected symbols cannot appear at the head of
+    a left-hand side.
+  - Externally defined protected symbols cannot appear in the right
+    hand side of a rewriting rule.
 
 -  Matching strategy modifiers:
 
   - ``sequential``: modifies the pattern matching algorithm. By default,
-   the order of rule declarations is not taken into account. This
-   modifier tells Lambdapi to apply rules defining a sequential symbol
-   in the order they have been declared (note that the order of the
-   rules may depend on the order of the ``require`` commands). An
-   example can be seen in ``tests/OK/rule_order.lp``.
-   *WARNING:* using this modifier can break important properties.
+    the order of rule declarations is not taken into account. This
+    modifier tells Lambdapi to apply rules defining a sequential symbol
+    in the order they have been declared (note that the order of the
+    rules may depend on the order of the ``require`` commands). An
+    example can be seen in ``tests/OK/rule_order.lp``.
+    *WARNING:* using this modifier can break important properties.
 
 Examples:
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -110,7 +110,6 @@ the system with additional information on its properties and behavior.
   - ``injective``: The symbol can be considered as injective, that is, if ``f t1 .. tn`` ≡ ``f u1 .. un``, then ``t1``\ ≡\ ``u1``, …, ``tn``\ ≡\ ``un``. For the moment, the verification is left to the user.
   - ``commutative``: Adds in the conversion the equation ``f t u ≡ f u t``.
   - ``associative``: Adds in the conversion the equation ``f (f t u) v ≡ f t (f u v)`` (in conjonction with ``commutative`` only)
-
     
 - **Exposition modifiers** define how a symbol can be used outside the
   module where it is defined. By default, the symbol can be used

--- a/docs/syntax.bnf
+++ b/docs/syntax.bnf
@@ -48,7 +48,9 @@
            | symmetry
            | why3 ["<string>"]
 
-<modifier> ::= constant
+<modifier> ::= [<assoc>] associative
+             | commutative
+             | constant
              | injective
              | opaque
              | private

--- a/editors/emacs/lambdapi-smie.el
+++ b/editors/emacs/lambdapi-smie.el
@@ -134,6 +134,8 @@ Indent by `lambdapi-indent-basic' in proofs, and 0 otherwise."
                ("flag" ident "on")
                ("injective" "inductive" inddec ";")
                ("injective" symdec ";")
+               ("associative" symdec ";")
+               ("commutative" symdec ";")
                ("notation" ident "infix" "left" sterm ";")
                ("notation" ident "infix" "right" sterm ";")
                ("notation" ident "infix" sterm ";")
@@ -215,8 +217,10 @@ The default lexer is used because the syntax is primarily made of sexps."
      lambdapi-indent-basic)
 
     ;; Toplevel
+    (`(:before . "associative") '(column . 0))
     (`(:before . "begin") '(column . 0))
     (`(:before . "builtin") '(column . 0))
+    (`(:before . "commutative") '(column . 0))
     (`(:before . "constant") '(column . 0))
     (`(:before . "debug") '(column . 0))
     (`(:before . "flag") '(column . 0))

--- a/editors/emacs/lambdapi-vars.el
+++ b/editors/emacs/lambdapi-vars.el
@@ -61,7 +61,9 @@
   "Commands producing side-effects.")
 
 (defconst lambdapi-misc-keywords
-  '("constant"
+  '("associative"
+    "commutative"
+    "constant"
     "left"
     "right"
     "infix"
@@ -93,7 +95,6 @@
     (modify-syntax-entry ?? "." table)
     (modify-syntax-entry ?: "." table)
     (modify-syntax-entry ?, "." table)
-    ;; (modify-syntax-entry ?| "\\" table) ; | instead of {| |} for simplicity
     (modify-syntax-entry ?\n "> " table)
     (modify-syntax-entry ?. "w" table)
     (modify-syntax-entry ?_ "w" table)

--- a/editors/vim/syntax/lambdapi.vim
+++ b/editors/vim/syntax/lambdapi.vim
@@ -33,9 +33,11 @@ syntax keyword KeywordOK contained apply
 syntax keyword KeywordOK contained as
 syntax keyword KeywordOK contained assert
 syntax keyword KeywordOK contained assertnot
+syntax keyword KeywordOK contained associative
 syntax keyword KeywordOK contained assume
 syntax keyword KeywordOK contained begin
 syntax keyword KeywordOK contained builtin
+syntax keyword KeywordOK contained commutative
 syntax keyword KeywordOK contained compute
 syntax keyword KeywordOK contained constant
 syntax keyword KeywordOK contained debug
@@ -92,9 +94,11 @@ syntax keyword KeywordKO contained apply
 syntax keyword KeywordKO contained as
 syntax keyword KeywordKO contained assert
 syntax keyword KeywordKO contained assertnot
+syntax keyword KeywordKO contained associative
 syntax keyword KeywordKO contained assume
 syntax keyword KeywordKO contained begin
 syntax keyword KeywordKO contained builtin
+syntax keyword KeywordKO contained commutative
 syntax keyword KeywordKO contained compute
 syntax keyword KeywordKO contained constant
 syntax keyword KeywordKO contained debug

--- a/editors/vscode/syntaxes/lp.tmLanguage.json
+++ b/editors/vscode/syntaxes/lp.tmLanguage.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "commands": {
-      "match": "\\b(abort|admit|admitted|apply|as|assert|assertnot|assume|begin|builtin|compute|constant|debug|end|fail|flag|focus|generalize|have|in|induction|inductive|infix|injective|left|let|notation|off|on|open|opaque|prefix|print|private|proofterm|protected|prover|prover_timeout|quantifier|refine|reflexivity|require|rewrite|rule|sequential|simplify|symbol|symmetry|type|TYPE|unif_rule|why3|with)\\b",
+      "match": "\\b(abort|admit|admitted|apply|as|assert|assertnot|associative|assume|begin|builtin|commutative|compute|constant|debug|end|fail|flag|focus|generalize|have|in|induction|inductive|infix|injective|left|let|notation|off|on|open|opaque|prefix|print|private|proofterm|protected|prover|prover_timeout|quantifier|refine|reflexivity|require|rewrite|rule|sequential|simplify|symbol|symmetry|type|TYPE|unif_rule|why3|with)\\b",
       "name": "keyword.control.lp"
     },
     "comments": {
@@ -75,7 +75,7 @@
     },
 
     "keywords": {
-      "match": "\\b(as|begin|builtin|constant|debug|end|flag|in|infix|injective|left|off|notation|on|opaque|prover|prover_timeout|prefix|private|protected|quantifier|right|sequential|TYPE|unif_rule)\\b",
+      "match": "\\b(as|associative|begin|builtin|commutative|constant|debug|end|flag|in|infix|injective|left|off|notation|on|opaque|prover|prover_timeout|prefix|private|protected|quantifier|right|sequential|TYPE|unif_rule)\\b",
       "name": "storage.modifier.lp"
     }    
   }

--- a/misc/lambdapi.tex
+++ b/misc/lambdapi.tex
@@ -15,7 +15,7 @@
   tabsize=2,
   basicstyle={\ttfamily\small\upshape},
   backgroundcolor=\color{lightgrey},
-  keywords={abort,admit,admitted,apply,as,assert,assertnot,assume,begin,builtin,compute,constant,debug,end,fail,flag,focus,generalize,have,in,induction,inductive,infix,injective,left,let,notation,off,on,opaque,open,prefix,print,private,proofterm,protected,prover,prover_timeout,quantifier,refine,reflexivity,require,rewrite,right,rule,sequential,simplify,solve,symbol,symmetry,type,TYPE,unif_rule,verbose,why3,with},
+  keywords={abort,admit,admitted,apply,as,assert,assertnot,associative,assume,begin,builtin,commutative,compute,constant,debug,end,fail,flag,focus,generalize,have,in,induction,inductive,infix,injective,left,let,notation,off,on,opaque,open,prefix,print,private,proofterm,protected,prover,prover_timeout,quantifier,refine,reflexivity,require,rewrite,right,rule,sequential,simplify,solve,symbol,symmetry,type,TYPE,unif_rule,verbose,why3,with},
   sensitive=true,
   keywordstyle=\color{blue},
   morecomment=[l]{//},

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -131,7 +131,7 @@ let of_prod_using : ctxt -> tvar array -> term -> env * term = fun c xs t ->
     if i >= n then env, t
     else match_prod c t (fun a b ->
              let env = add xs.(i) (lift a) None env in
-             build_env (i+1) env (Bindlib.subst b (Vari(xs.(i)))))
+             build_env (i+1) env (Bindlib.subst b (mk_Vari(xs.(i)))))
   in build_env 0 [] t
 
 (** [fresh_meta_Type env] creates a fresh metavariable of type [Type] in
@@ -160,5 +160,6 @@ let fresh_meta : env -> term = fun env -> Bindlib.unbox (fresh_meta_tbox env)
 (** [add_fresh_metas env t n] returns the application of [t] to [n] fresh meta
    terms. *)
 let add_fresh_metas : env -> term -> int -> term = fun env ->
-  let rec add t n = if n <= 0 then t else add (Appl(t, fresh_meta env)) (n-1)
+  let rec add t n =
+    if n <= 0 then t else add (mk_Appl(t, fresh_meta env)) (n-1)
   in add

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -65,22 +65,27 @@ let pp_uid = Format.pp_print_string
 
 let pp_path : Path.t pp = List.pp pp_uid "."
 
-let pp_prop : prop pp = fun oc p ->
+let pp_prop : prop pp = fun ppf p ->
   match p with
+  | AC true -> out ppf "left associative commutative "
+  | AC false -> out ppf "associative commutative "
+  | Assoc true -> out ppf "left associative "
+  | Assoc false -> out ppf "associative "
+  | Const -> out ppf "constant "
+  | Commu -> out ppf "commutative "
   | Defin -> ()
-  | Const -> Format.fprintf oc "constant "
-  | Injec -> Format.fprintf oc "injective "
+  | Injec -> out ppf "injective "
 
-let pp_expo : expo pp = fun oc e ->
+let pp_expo : expo pp = fun ppf e ->
   match e with
+  | Privat -> out ppf "private "
+  | Protec -> out ppf "protected "
   | Public -> ()
-  | Protec -> Format.fprintf oc "protected "
-  | Privat -> Format.fprintf oc "private "
 
-let pp_match_strat : match_strat pp = fun oc s ->
+let pp_match_strat : match_strat pp = fun ppf s ->
   match s with
-  | Sequen -> Format.fprintf oc "sequential "
   | Eager -> ()
+  | Sequen -> out ppf "sequential "
 
 let pp_sym : sym pp = fun ppf s ->
   if !print_implicits && s.sym_impl <> [] then out ppf "@";
@@ -112,7 +117,7 @@ let nat_of_term : term -> int = fun t ->
   let zero = get_builtin "0" in
   let succ = get_builtin "+1" in
   let rec nat acc = fun t ->
-    match LibTerm.get_args t with
+    match get_args t with
     | (Symb s, [u]) when s == succ -> nat (acc+1) u
     | (Symb s,  []) when s == zero -> acc
     | _ -> raise Not_a_nat
@@ -140,7 +145,7 @@ and pp_term : term pp = fun ppf t ->
   and appl ppf t = pp `Appl ppf t
   and func ppf t = pp `Func ppf t
   and pp p ppf t =
-    let (h, args) = LibTerm.get_args t in
+    let (h, args) = get_args t in
     let pp_appl h args =
       match args with
       | []   -> pp_head (p <> `Func) ppf h
@@ -266,12 +271,12 @@ let rec pp_prod : (term * bool list) pp = fun ppf (t, impl) ->
   | _ -> pp_term ppf t
 
 let pp_rule : (sym * rule) pp = fun ppf (s,r) ->
-  let lhs = LibTerm.add_args (Symb s) r.lhs in
+  let lhs = add_args (mk_Symb s) r.lhs in
   let (_, rhs) = Bindlib.unmbind r.rhs in
   out ppf "%a ↪ %a" pp_term lhs pp_term rhs
 
 let pp_unif_rule : (sym * rule) pp = fun ppf (s,r) ->
-  let lhs = LibTerm.add_args (Symb s) r.lhs in
+  let lhs = add_args (mk_Symb s) r.lhs in
   let (_, rhs) = Bindlib.unmbind r.rhs in
   out ppf "%a ↪ [ %a ]" pp_term lhs pp_term rhs
 

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -9,10 +9,6 @@
 
 open Timed
 open Lplib.Base
-open Common.Debug
-
-let log_term = new_logger 'm' "term" "term building"
-let log_term = log_term.logger
 
 (** {3 Term (and symbol) representation} *)
 
@@ -47,7 +43,7 @@ type prop =
     are also used, for example, in the representation of patterns or rewriting
     rules. Specific constructors are included for such applications,  and they
     are considered invalid in unrelated code. *)
-type term =
+type term = private
   | Vari of tvar (** Free variable. *)
   | Type (** "TYPE" constant. *)
   | Kind (** "KIND" constant. *)
@@ -193,8 +189,7 @@ and sym =
   (** Free "term with environment" variable (used to build a RHS). *)
   | TE_Some of tmbinder
   (** Actual "term with environment" (used to instantiate a RHS). *)
-  | TE_None
-  (** Dummy term environment (used during matching). *)
+  | TE_None (** Dummy term environment (used during matching). *)
 
 (** The {!constructor:TEnv}[(te,env)] constructor intuitively corresponds to a
     term [te] with free variables together with an explicit environment [env].
@@ -243,39 +238,6 @@ type tbox = term Bindlib.box
 
 type tebox = term_env Bindlib.box
 
-(** Printing functions for debug. *)
-let rec pp_term : term pp = let out = Format.fprintf in fun ppf t ->
-  match t with
-  | Vari v -> pp_var ppf v
-  | Type -> out ppf "TYPE"
-  | Kind -> out ppf "KIND"
-  | Symb s -> pp_sym ppf s
-  | Prod(a,b) ->
-      if Bindlib.binder_constant b then
-        let _, b = Bindlib.unbind b in out ppf "(%a → %a)" pp_term a pp_term b
-      else out ppf "(Π %a)" pp_binder (a,b)
-  | Abst(a,b) -> out ppf "(λ %a)" pp_binder (a,b)
-  | Appl(a,b) -> out ppf "(%a %a)" pp_term a pp_term b
-  | Meta(m,ts) -> out ppf "?%a[%a]" pp_meta m pp_terms ts
-  | Patt _ -> out ppf "<Patt>"
-  | TEnv _ -> out ppf "<TEnv>"
-  | Wild -> out ppf "_"
-  | TRef _ -> out ppf "<TRef>"
-  | LLet(a,t,u) ->
-      let x, u = Bindlib.unbind u in
-      out ppf "let %a : %a ≔ %a in %a" pp_var x pp_term a pp_term t pp_term u
-and pp_var : tvar pp = fun ppf v ->
-  Format.fprintf ppf "%s" (Bindlib.name_of v)
-and pp_binder : (term * tbinder) pp = fun ppf (a,b) ->
-  let x, b = Bindlib.unbind b in
-  Format.fprintf ppf "%a : %a, %a" pp_var x pp_term a pp_term b
-and pp_terms : term array pp = fun ppf ts -> Array.iter (pp_term ppf) ts
-and pp_meta : meta pp = let out = Format.fprintf in fun ppf m ->
-  match m.meta_name with
-  | None -> out ppf "%d" m.meta_key
-  | Some s -> out ppf "%s" s
-and pp_sym : sym pp = fun ppf s -> Format.fprintf ppf "%s" s.sym_name
-
 (** Typing context associating a [Bindlib] variable to a type and possibly a
    definition. The typing environment [x1:A1,..,xn:An] is represented by the
    list [xn:An;..;x1:A1] in reverse order (last added variable comes
@@ -307,46 +269,50 @@ type problem =
   (** Indicates whether unsolved problems should be rechecked. *) }
 
 (** Empty problem. *)
-let empty_problem : problem =
-  {to_solve  = []; unsolved = []; recompute = false}
+val empty_problem : problem
 
 (** Sets and maps of term variables. *)
-module Var = struct
-  type t = tvar
-  let compare = Bindlib.compare_vars
-end
+module Var : Map.OrderedType with type t = tvar
 
-module VarSet = Set.Make(Var)
-module VarMap = Map.Make(Var)
+module VarSet : Set.S with type elt = tvar
+module VarMap : Map.S with type key = tvar
 
 (** [of_tvar x] injects the [Bindlib] variable [x] in a term. *)
-let of_tvar : tvar -> term = fun x -> Vari(x)
+val of_tvar : tvar -> term
 
 (** [new_tvar s] creates a new [tvar] of name [s]. *)
-let new_tvar : string -> tvar = Bindlib.new_var of_tvar
+val new_tvar : string -> tvar
 
 (** [new_tvar_ind s i] creates a new [tvar] of name [s ^ string_of_int i]. *)
-let new_tvar_ind : string -> int -> tvar = fun s i ->
-  new_tvar (Common.Escape.add_prefix s (string_of_int i))
+val new_tvar_ind : string -> int -> tvar
 
 (** [of_tevar x] injects the [Bindlib] variable [x] in a {!type:term_env}. *)
-let of_tevar : tevar -> term_env = fun x -> TE_Vari(x)
+val of_tevar : tevar -> term_env
 
 (** [new_tevar s] creates a new [tevar] with name [s]. *)
-let new_tevar : string -> tevar = Bindlib.new_var of_tevar
+val new_tevar : string -> tevar
 
 (** Sets and maps of symbols. *)
-module Sym = struct
-  type t = sym
-  let compare s1 s2 =
-    if s1 == s2 then 0 else
-    match Stdlib.compare s1.sym_name s2.sym_name with
-    | 0 -> Stdlib.compare s1.sym_path s2.sym_path
-    | n -> n
-end
+module Sym : Map.OrderedType with type t = sym
 
-module SymSet = Set.Make(Sym)
-module SymMap = Map.Make(Sym)
+module SymSet : Set.S with type elt = sym
+module SymMap : Map.S with type key = sym
+
+(** [create_sym path expo prop opaq name typ impl] creates a new symbol with
+   path [path], exposition [expo], property [prop], opacity [opaq], matching
+   strategy [mstrat], name [name], type [typ], implicit arguments [impl], no
+   definition and no rules. *)
+val create_sym : Common.Path.t -> expo -> prop -> match_strat -> bool ->
+  string -> term -> bool list -> sym
+
+(** [is_injective s] tells whether the symbol is injective. *)
+val is_injective : sym -> bool
+
+(** [is_constant s] tells whether the symbol is a constant. *)
+val is_constant : sym -> bool
+
+(** [is_private s] tells whether the symbol [s] is private. *)
+val is_private : sym -> bool
 
 (** Basic management of meta variables. *)
 module Meta : sig
@@ -379,436 +345,155 @@ module Meta : sig
 
   val reset_meta_counter : unit -> unit
   (** [reset_counter ()] resets the counter used to produce meta keys. *)
-end = struct
-  type t = meta
-  let compare m1 m2 = m1.meta_key - m2.meta_key
-  let meta_counter : int Stdlib.ref = Stdlib.ref (-1)
-  let reset_meta_counter () = Stdlib.(meta_counter := -1)
-
-  let fresh : ?name:string -> term -> int -> t = fun ?name a n ->
-      { meta_key = Stdlib.(incr meta_counter; !meta_counter); meta_name = name
-      ; meta_type = ref a; meta_arity = n; meta_value = ref None }
-
-  let set : t -> tmbinder -> unit = fun m v ->
-    m.meta_type := Kind; (* to save memory *) m.meta_value := Some(v)
-
-  let name : t -> string = fun m ->
-    match m.meta_name with
-    | Some(n) -> n
-    | None    -> string_of_int m.meta_key
-
-  let fresh_box : ?name:string -> tbox -> int -> t Bindlib.box =
-    fun ?name a n ->
-    let m = fresh ?name Kind n in
-    Bindlib.box_apply (fun a -> m.meta_type := a; m) a
-
 end
 
 (** Sets and maps of metavariables. *)
-module MetaSet = Set.Make(Meta)
-module MetaMap = Map.Make(Meta)
-
-(** [create_sym path expo prop opaq name typ impl] creates a new symbol with
-   path [path], exposition [expo], property [prop], opacity [opaq], matching
-   strategy [mstrat], name [name], type [typ], implicit arguments [impl], no
-   definition and no rules. *)
-let create_sym : Common.Path.t -> expo -> prop -> match_strat -> bool ->
-  string -> term -> bool list -> sym =
-  fun sym_path sym_expo sym_prop sym_mstrat sym_opaq sym_name typ sym_impl ->
-  {sym_path; sym_name; sym_type = ref typ; sym_impl; sym_def = ref None;
-   sym_opaq; sym_rules = ref []; sym_dtree = ref Tree_type.empty_dtree;
-   sym_mstrat; sym_prop; sym_expo }
-
-(** [is_injective s] tells whether the symbol is injective. *)
-let is_injective : sym -> bool = fun s -> s.sym_prop = Injec
-
-(** [is_constant s] tells whether the symbol is a constant. *)
-let is_constant : sym -> bool = fun s -> s.sym_prop = Const
-
-(** [is_private s] tells whether the symbol [s] is private. *)
-let is_private : sym -> bool = fun s -> s.sym_expo = Privat
+module MetaSet : Set.S with type elt = Meta.t
+module MetaMap : Map.S with type key = Meta.t
 
 (** [unfold t] repeatedly unfolds the definition of the surface constructor of
     [t], until a significant {!type:term} constructor is found.  The term that
     is returned cannot be an instantiated metavariable or term environment nor
     a reference cell ({!constructor:TRef} constructor). Note that the returned
     value is physically equal to [t] if no unfolding was performed. *)
-let rec unfold : term -> term = fun t ->
-  match t with
-  | Meta(m, ts) ->
-      begin
-        match !(m.meta_value) with
-        | None    -> t
-        | Some(b) -> unfold (Bindlib.msubst b ts)
-      end
-  | TEnv(TE_Some(b), ts) -> unfold (Bindlib.msubst b ts)
-  | TRef(r) ->
-      begin
-        match !r with
-        | None    -> t
-        | Some(v) -> unfold v
-      end
-  | _ -> t
+val unfold : term -> term
 
 (** {b NOTE} that {!val:unfold} must (almost) always be called before matching
     over a value of type {!type:term}. *)
 
-(** [is_abst t] returns [true] iff [t] is of the form [Abst(_)]. *)
-let is_abst : term -> bool = fun t ->
-  match unfold t with Abst(_) -> true | _ -> false
-
-(** [is_prod t] returns [true] iff [t] is of the form [Prod(_)]. *)
-let is_prod : term -> bool = fun t ->
-  match unfold t with Prod(_) -> true | _ -> false
-
-(** [is_unset m] returns [true] if [m] is not instantiated. *)
-let is_unset : meta -> bool = fun m -> !(m.meta_value) = None
-
-(** [is_symb s t] tests whether [t] is of the form [Symb(s)]. *)
-let is_symb : sym -> term -> bool = fun s t ->
-  match unfold t with Symb(r) -> r == s | _ -> false
-
-(** Total order on alpha-equivalence classes of terms not containing [Patt],
+(** Total orders terms, contexts and constraints not containing [Patt],
    [TEnv] or [TRef].
 @raise Invalid_argument otherwise. *)
-let cmp_term : term cmp =
-  let pos = __MODULE__ ^ ".cmp_term: " ^ __LOC__ in
-  (* Total precedence on term constructors (must be injective). *)
-  let prec t =
-    match unfold t with
-    | Vari _ -> 0
-    | Type -> 1
-    | Kind -> 2
-    | Symb _ -> 3
-    | Prod _ -> 4
-    | Abst _ -> 5
-    | Appl _ -> 6
-    | Meta _ -> 7
-    | Patt _ -> 8
-    | TEnv _ -> 9
-    | Wild -> 10
-    | TRef _ -> 11
-    | LLet _ -> 12
-  in
-  let rec cmp t t' =
-    match unfold t, unfold t' with
-    | Vari x, Vari x' -> Bindlib.compare_vars x x'
-    | Type, Type
-    | Kind, Kind
-    | Wild, Wild -> 0
-    | Symb f, Symb f' -> Sym.compare f f'
-    | Prod(t,u), Prod(t',u')
-    | Abst(t,u), Abst(t',u') ->
-        let c = cmp t t' in if c <> 0 then c else cmp_binder u u'
-    | Appl(t,u), Appl(t',u') ->
-        let c = cmp t t' in if c <> 0 then c else cmp u u'
-    | Meta(m,ts), Meta(m',ts') ->
-        let c = Meta.compare m m' in
-        if c <> 0 then c
-        else Lplib.List.cmp_list cmp (Array.to_list ts) (Array.to_list ts')
-    | Patt _, _ | _, Patt _
-    | TEnv _, _ | _, TEnv _ -> invalid_arg pos
-    | TRef r, TRef r' ->
-        if r == r' then 0 else
-          begin
-            match !r, !r' with
-            | None, None -> invalid_arg pos
-            | Some t, Some t' -> cmp t t'
-            | None, Some _ -> -1
-            | Some _, None -> 1
-          end
-    | LLet(a,t,u), LLet(a',t',u') ->
-        let c = cmp a a' in
-        if c <> 0 then c
-        else let c = cmp t t' in if c <> 0 then c else cmp_binder u u'
-    | t, t' -> Stdlib.compare (prec t) (prec t')
-  and cmp_binder u u' = let (_,u,u') = Bindlib.unbind2 u u' in cmp u u'
-  in cmp
+val cmp_term : term cmp
+val cmp_ctxt : ctxt cmp
+val cmp_constr : constr cmp
+val eq_constr : constr eq
 
-(** Total order on contexts not containing [Patt], [TEnv] or [TRef].
-@raise Invalid_argument otherwise. *)
-let cmp_ctxt : ctxt cmp =
-  let cmp_decl (x,t,a) (x',t',a') =
-    let c = Bindlib.compare_vars x x' in
-    if c <> 0 then c
-    else let c = cmp_term t t' in
-         if c <> 0 then c else Lplib.Option.cmp_option cmp_term a a'
-  in Lplib.List.cmp_list cmp_decl
+(** [is_abst t] returns [true] iff [t] is of the form [Abst(_)]. *)
+val is_abst : term -> bool
 
-(** Total order on constraints not containing [Patt], [TEnv] or [TRef].
-@raise Invalid_argument otherwise. *)
-let cmp_constr : constr cmp = fun (c,t,u) (c',t',u') ->
-  let r = cmp_ctxt c c' in
-  if r <> 0 then r
-  else let r = cmp_term t t' in if r <> 0 then r else cmp_term u u'
+(** [is_prod t] returns [true] iff [t] is of the form [Prod(_)]. *)
+val is_prod : term -> bool
 
-let eq_constr : constr eq = fun c c' -> cmp_constr c c' = 0
+(** [is_unset m] returns [true] if [m] is not instantiated. *)
+val is_unset : meta -> bool
+
+(** [is_symb s t] tests whether [t] is of the form [Symb(s)]. *)
+val is_symb : sym -> term -> bool
 
 (** [get_args t] decomposes the {!type:term} [t] into a pair [(h,args)], where
     [h] is the head term of [t] and [args] is the list of arguments applied to
     [h] in [t]. The returned [h] cannot be an [Appl] node. *)
-let get_args : term -> term * term list = fun t ->
-  let rec get_args acc t =
-    match unfold t with
-    | Appl(t,u) -> get_args (u::acc) t
-    | t         -> (t, acc)
-  in get_args [] t
+val get_args : term -> term * term list
 
 (** [get_args_len t] is similar to [get_args t] but it also returns the length
     of the list of arguments. *)
-let get_args_len : term -> term * term list * int = fun t ->
-  let rec get_args_len acc len t =
-    match unfold t with
-    | Appl(t, u) -> get_args_len (u::acc) (len + 1) t
-    | t          -> (t, acc, len)
-  in
-  get_args_len [] 0 t
+val get_args_len : term -> term * term list * int
 
 (** Construction functions of the private type [term]. *)
-let mk_Vari x = Vari x
-let mk_Type = Type
-let mk_Kind = Kind
-let mk_Symb x = Symb x
-let mk_Prod (a,b) = Prod (a,b)
-let mk_Abst (a,b) = Abst (a,b)
-let mk_Meta (m,ts) = Meta (m,ts)
-let mk_Patt (i,s,ts) = Patt (i,s,ts)
-let mk_TEnv (te,ts) = TEnv (te,ts)
-let mk_Wild = Wild
-let mk_TRef x = TRef x
-let mk_LLet (a,t,u) = LLet (a,t,u)
-
-(* We make the equality of terms modulo commutative and
-   associative-commutative symbols syntactic by always ordering arguments in
-   increasing order and by putting them in a comb form.
-
-   The term [t1 + t2 + t3] is represented by the left comb [(t1 + t2) + t3] if
-   + is left associative and [t1 + (t2 + t3)] if + is right associative. *)
-
-let mk_bin s t1 t2 = Appl(Appl(Symb s, t1), t2)
-
-(** [mk_left_comb s t ts] builds a left comb of applications of [s] from
-   [t::ts] so that [mk_left_comb s t1 [t2; t3] = mk_bin s (mk_bin s t1 t2)
-   t3]. *)
-let mk_left_comb : sym -> term -> term list -> term = fun s ->
-  List.fold_left (mk_bin s)
-
-(** [mk_right_comb s ts t] builds a right comb of applications of [s] to
-   [ts@[p]] so that [mk_right_comb s [t1; t2] t3 = mk_bin s t1 (mk_bin s t2
-   t3)]. *)
-let mk_right_comb : sym -> term list -> term -> term = fun s ->
-  List.fold_right (mk_bin s)
-
-(** [left_aliens s t] returns the list of the biggest subterms of [t] not
-   headed by [s], assuming that [s] is left associative and [t] is in
-   canonical form. This is the reverse of [mk_left_comb]. *)
-let left_aliens : sym -> term -> term list = fun s ->
-  let rec aliens acc = function
-    | [] -> acc
-    | u::us ->
-        let h, ts = get_args u in
-        if is_symb s h then
-          match ts with
-          | t1 :: t2 :: _ -> aliens (t2 :: acc) (t1 :: us)
-          | _ -> aliens (u :: acc) us
-        else aliens (u :: acc) us
-  in fun t -> aliens [] [t]
-
-(** [right_aliens s t] returns the list of the biggest subterms of [t] not
-   headed by [s], assuming that [s] is right associative and [t] is in
-   canonical form. This is the reverse of [mk_right_comb]. *)
-let right_aliens : sym -> term -> term list = fun s ->
-  let rec aliens acc = function
-    | [] -> acc
-    | u::us ->
-        let h, ts = get_args u in
-        if is_symb s h then
-          match ts with
-          | t1 :: t2 :: _ -> aliens (t1 :: acc) (t2 :: us)
-          | _ -> aliens (u :: acc) us
-        else aliens (u :: acc) us
-  in fun t -> let r = aliens [] [t] in
-  if !log_enabled then
-    log_term "right_aliens %a %a = %a" pp_sym s pp_term t (D.list pp_term) r;
-  r
-
-(* unit test *)
-let _ =
-  let s = create_sym [] Privat (AC true) Eager false "+" Kind [] in
-  let t1 = Vari (new_tvar "x1") in
-  let t2 = Vari (new_tvar "x2") in
-  let t3 = Vari (new_tvar "x3") in
-  let left = mk_bin s (mk_bin s t1 t2) t3 in
-  let right = mk_bin s t1 (mk_bin s t2 t3) in
-  let eq t1 t2 = cmp_term t1 t2 = 0 in
-  assert (eq (mk_left_comb s t1 [t2; t3]) left);
-  assert (eq (mk_right_comb s [t1; t2] t3) right);
-  let eq l1 l2 = Lplib.List.compare cmp_term l1 l2 = 0 in
-  assert (eq (left_aliens s left) [t1; t2; t3]);
-  assert (eq (right_aliens s right) [t3; t2; t1])
-
-(** [mk_Appl t u] puts the application of [t] to [u] in canonical form. *)
-let mk_Appl : term * term -> term = fun (t, u) ->
-  (*if !log_enabled then log_term "mk_Appl(%a, %a)" pp_term t pp_term u;
-  let r =*)
-  match get_args t with
-  | Symb s, [t1] ->
-      begin
-        match s.sym_prop with
-        | Commu when cmp_term t1 u > 0 -> mk_bin s u t1
-        | AC true -> (* left associative symbol *)
-            let ts = left_aliens s t1 and us = left_aliens s u in
-            begin
-              match List.sort cmp_term (ts @ us) with
-              | v::vs -> mk_left_comb s v vs
-              | _ -> assert false
-            end
-        | AC false -> (* right associative symbol *)
-            let ts = right_aliens s t1 and us = right_aliens s u in
-            let vs, v = Lplib.List.split_last (List.sort cmp_term (ts @ us))
-            in mk_right_comb s vs v
-        | _ -> Appl (t, u)
-      end
-  | _ -> Appl (t, u)
-  (*in if !log_enabled then
-    log_term "mk_Appl(%a, %a) = %a" pp_term t pp_term u pp_term r; r*)
+val mk_Vari : tvar -> term
+val mk_Type : term
+val mk_Kind : term
+val mk_Symb : sym -> term
+val mk_Prod : term * tbinder -> term
+val mk_Abst : term * tbinder -> term
+val mk_Appl : term * term -> term
+val mk_Meta : meta * term array -> term
+val mk_Patt : int option * string * term array -> term
+val mk_TEnv : term_env * term array -> term
+val mk_Wild : term
+val mk_TRef : term option ref -> term
+val mk_LLet : term * term * tbinder -> term
 
 (** [add_args t args] builds the application of the {!type:term} [t] to a list
     arguments [args]. When [args] is empty, the returned value is (physically)
     equal to [t]. *)
-let add_args : term -> term list -> term = fun t ts ->
-  List.fold_left (fun t u -> mk_Appl(t,u)) t ts
+val add_args : term -> term list -> term
 
 (** [add_args_map f t ts] is equivalent to [add_args t (List.map f ts)] but
    more efficient. *)
-let add_args_map : term -> (term -> term) -> term list -> term = fun t f ts ->
-  List.fold_left (fun t u -> mk_Appl(t, f u)) t ts
+val add_args_map : term -> (term -> term) -> term list -> term
 
 (** {3 Smart constructors and lifting (related to [Bindlib])} *)
 
 (** [_Vari x] injects the free variable [x] into the {!type:tbox} type so that
     it may be available for binding. *)
-let _Vari : tvar -> tbox = Bindlib.box_var
+val _Vari : tvar -> tbox
 
 (** [_Type] injects the constructor [Type] into the {!type:tbox} type. *)
-let _Type : tbox = Bindlib.box Type
+val _Type : tbox
 
 (** [_Kind] injects the constructor [Kind] into the {!type:tbox} type. *)
-let _Kind : tbox = Bindlib.box Kind
+val _Kind : tbox
 
 (** [_Symb s] injects the constructor [Symb(s)] into the {!type:tbox} type. As
     symbols are closed object they do not require lifting. *)
-let _Symb : sym -> tbox = fun s -> Bindlib.box (Symb s)
+val _Symb : sym -> tbox
 
 (** [_Appl t u] lifts an application node to the {!type:tbox} type given boxed
     terms [t] and [u]. *)
-let _Appl : tbox -> tbox -> tbox =
-  Bindlib.box_apply2 (fun t u -> mk_Appl(t,u))
+val _Appl : tbox -> tbox -> tbox
 
 (** [_Appl_list a [b1;...;bn]] returns (... ((a b1) b2) ...) bn. *)
-let _Appl_list : tbox -> tbox list -> tbox = List.fold_left _Appl
+val _Appl_list : tbox -> tbox list -> tbox
 
 (** [_Appl_Symb f ts] returns the same result that
     _Appl_l ist (_Symb [f]) [ts]. *)
-let _Appl_Symb : sym -> tbox list -> tbox = fun f ts ->
-  _Appl_list (_Symb f) ts
+val _Appl_Symb : sym -> tbox list -> tbox
 
 (** [_Prod a b] lifts a dependent product node to the {!type:tbox} type, given
     a boxed term [a] for the domain of the product, and a boxed binder [b] for
     its codomain. *)
-let _Prod : tbox -> tbinder Bindlib.box -> tbox =
-  Bindlib.box_apply2 (fun a b -> Prod(a,b))
+val _Prod : tbox -> tbinder Bindlib.box -> tbox
 
-let _Impl : tbox -> tbox -> tbox =
-  let v = new_tvar "_" in fun a b -> _Prod a (Bindlib.bind_var v b)
+val _Impl : tbox -> tbox -> tbox
 
 (** [_Abst a t] lifts an abstraction node to the {!type:tbox}  type,  given  a
     boxed term [a] for the domain type, and a boxed binder [t]. *)
-let _Abst : tbox -> tbinder Bindlib.box -> tbox =
-  Bindlib.box_apply2 (fun a t -> Abst(a,t))
+val _Abst : tbox -> tbinder Bindlib.box -> tbox
 
-(** [_Meta m ts] lifts the metavariable [m] to the {!type:tbox} type given its
-    environment [ts]. As for symbols in {!val:_Symb}, metavariables are closed
+(** [_Meta m ar] lifts the metavariable [m] to the {!type:tbox} type given its
+    environment [ar]. As for symbols in {!val:_Symb}, metavariables are closed
     objects so they do not require lifting. *)
-let _Meta : meta -> tbox array -> tbox = fun m ts ->
-  Bindlib.box_apply (fun ts -> Meta(m,ts)) (Bindlib.box_array ts)
+val _Meta : meta -> tbox array -> tbox
 
-(** [_Meta_full m ts] is similar to [_Meta m ts] but works with a metavariable
+(** [_Meta_full m ar] is similar to [_Meta m ar] but works with a metavariable
     that is boxed. This is useful in very rare cases,  when metavariables need
     to be able to contain free term environment variables. Using this function
     in bad places is harmful for efficiency but not unsound. *)
-let _Meta_full : meta Bindlib.box -> tbox array -> tbox = fun m ts ->
-  Bindlib.box_apply2 (fun m ts -> Meta(m,ts)) m (Bindlib.box_array ts)
+val _Meta_full : meta Bindlib.box -> tbox array -> tbox
 
-(** [_Patt i n ts] lifts a pattern variable to the {!type:tbox} type. *)
-let _Patt : int option -> string -> tbox array -> tbox = fun i n ts ->
-  Bindlib.box_apply (fun ts -> Patt(i,n,ts)) (Bindlib.box_array ts)
+(** [_Patt i n ar] lifts a pattern variable to the {!type:tbox} type. *)
+val _Patt : int option -> string -> tbox array -> tbox
 
-(** [_TEnv te ts] lifts a term environment to the {!type:tbox} type. *)
-let _TEnv : tebox -> tbox array -> tbox = fun te ts ->
-  Bindlib.box_apply2 (fun te ts -> TEnv(te,ts)) te (Bindlib.box_array ts)
+(** [_TEnv te ar] lifts a term environment to the {!type:tbox} type. *)
+val _TEnv : tebox -> tbox array -> tbox
 
 (** [_Wild] injects the constructor [Wild] into the {!type:tbox} type. *)
-let _Wild : tbox = Bindlib.box Wild
+val _Wild : tbox
 
 (** [_TRef r] injects the constructor [TRef(r)] into the {!type:tbox} type. It
     should be the case that [!r] is [None]. *)
-let _TRef : term option ref -> tbox = fun r ->
-  Bindlib.box (TRef(r))
+val _TRef : term option ref -> tbox
 
-(** [_LLet t a u] lifts let binding [let x := t : a in u<x>]. *)
-let _LLet : tbox -> tbox -> tbinder Bindlib.box -> tbox =
-  Bindlib.box_apply3 (fun a t u -> LLet(a, t, u))
+(** [_LVal t a u] lifts val binding [val x := t : a in u<x>]. *)
+val _LLet : tbox -> tbox -> tbinder Bindlib.box -> tbox
 
 (** [_TE_Vari x] injects a term environment variable [x] into the {!type:tbox}
     type so that it may be available for binding. *)
-let _TE_Vari : tevar -> tebox = Bindlib.box_var
+val _TE_Vari : tevar -> tebox
 
 (** [_TE_None] injects the constructor [TE_None] into the {!type:tbox} type.*)
-let _TE_None : tebox = Bindlib.box TE_None
+val _TE_None : tebox
 
-(** [lift mk_appl t] lifts the {!type:term} [t] to the type {!type:tbox},
-   using the function [mk_appl] in the case of an application. This has the
-   effect of gathering its free variables, making them available for binding.
-   Bound variable names are automatically updated in the process. *)
-let lift : (tbox -> tbox -> tbox) -> term -> tbox = fun mk_appl ->
-  let rec lift t =
-  match unfold t with
-  | Vari x      -> _Vari x
-  | Type        -> _Type
-  | Kind        -> _Kind
-  | Symb _      -> Bindlib.box t
-  | Prod(a,b)   -> _Prod (lift a) (lift_binder b)
-  | Abst(a,t)   -> _Abst (lift a) (lift_binder t)
-  | Appl(t,u)   -> mk_appl (lift t) (lift u)
-  | Meta(r,m)   -> _Meta r (Array.map lift m)
-  | Patt(i,n,m) -> _Patt i n (Array.map lift m)
-  | TEnv(te,m)  -> _TEnv (lift_term_env te) (Array.map lift m)
-  | Wild        -> _Wild
-  | TRef r      -> _TRef r
-  | LLet(a,t,u) -> _LLet (lift a) (lift t) (lift_binder u)
-  (* We do not use [Bindlib.box_binder] here because it is possible for a free
-     variable to disappear from a term through metavariable instantiation. As
-     a consequence we must traverse the whole term, even when we find a closed
-     binder, so that the metadata on nested binders is also updated. *)
-  and lift_binder b =
-    let x, t = Bindlib.unbind b in Bindlib.bind_var x (lift t)
-  and lift_term_env : term_env -> tebox = function
-  | TE_Vari x -> _TE_Vari x
-  | TE_None   -> _TE_None
-  | TE_Some _ -> assert false (* Unreachable. *)
-  in lift
+(** [lift t] lifts the {!type:term} [t] to the {!type:tbox} type. This has the
+    effect of gathering its free variables, making them available for binding.
+    Bound variable names are automatically updated in the process. *)
+val lift : term -> tbox
 
 (** [cleanup t] builds a copy of the {!type:term} [t] where every instantiated
    metavariable, instantiated term environment, and reference cell has been
    eliminated using {!val:unfold}. Another effect of the function is that the
    the names of bound variables are updated. This is useful to avoid any form
    of "visual capture" while printing terms. *)
-let cleanup : term -> term =
-  let mk_appl = Bindlib.box_apply2 (fun t u -> Appl(t,u)) in
-  fun t -> Bindlib.unbox (lift mk_appl t)
-
-(** [lift t] lifts the {!type:term} [t] to the type {!type:tbox}. This has the
-   effect of gathering its free variables, making them available for binding.
-   Bound variable names are automatically updated in the process. *)
-let lift = lift _Appl
+val cleanup : term -> term

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -38,7 +38,7 @@ open Tree_type
     portion [S─∘─Z] is made possible by a swap. *)
 
 (** Representation of a tree (see {!type:Term.tree}). *)
-type tree = rhs Tree_type.tree
+type tree = (rhs * int) Tree_type.tree
 
 (** {1 Conditions for decision trees}
 
@@ -238,7 +238,7 @@ module CM = struct
   type clause =
     { c_lhs       : term array
     (** Left hand side of a rule. *)
-    ; c_rhs       : rhs
+    ; c_rhs       : rhs * int
     (** Right hand side of a rule. *)
     ; env_builder : env_builder
     (** Data required to apply the rule. *)
@@ -515,7 +515,7 @@ module CM = struct
           else None
       | _      , Patt(_) ->
           let arity = List.length pargs in
-          let e = Array.make arity (Patt(None, "", [||])) in
+          let e = Array.make arity (mk_Patt(None, "", [||])) in
           Some({ r with c_lhs = insert e })
       | Symb(_), Vari(_)
       | Vari(_), Symb(_)
@@ -570,14 +570,15 @@ module CM = struct
     let transf (r:clause) =
       let ph, pargs = get_args r.c_lhs.(col) in
       match ph with
-      | Patt(_)  -> Some{r with c_lhs = insert r [|Patt(None, "", [||]); ph|]}
+      | Patt(_)  ->
+          Some{r with c_lhs = insert r [|mk_Patt(None, "", [||]); ph|]}
       | Symb(_)
       | Vari(_)  -> None
       | t        ->
       match get t with
       | Some(a,b) ->
           assert (pargs = []) ; (* Patterns in β-normal form *)
-          let b = Bindlib.subst b (Vari v) in
+          let b = Bindlib.subst b (mk_Vari v) in
           Some({r with c_lhs = insert r [|a; b|]})
       | None      -> assert false (* Term is ill formed *)
 
@@ -621,8 +622,9 @@ end
     composed only  of pattern variables with  no constraints, to yield  a leaf
     with RHS [rhs]  and the environment builder  [env_builder] completed. [vi]
     contains the indexes of variables. *)
-let harvest : term array -> rhs -> CM.env_builder -> int VarMap.t -> int ->
-  tree = fun lhs rhs env_builder vi slot ->
+let harvest :
+    term array -> rhs * int -> CM.env_builder -> int VarMap.t -> int -> tree =
+  fun lhs rhs env_builder vi slot ->
   let default_node store child =
     Node { swap = 0 ; store ; children = TCMap.empty
          ; abstraction = None ; product = None ; default = Some(child) }
@@ -731,4 +733,4 @@ let update_dtree : sym -> unit = fun symb ->
   let rules = lazy (CM.of_rules !(symb.sym_rules)) in
   let tree = lazy (compile symb.sym_mstrat (Lazy.force rules)) in
   let cap = lazy (Tree_type.tree_capacity (Lazy.force tree)) in
-  symb.sym_tree := (cap, tree)
+  symb.sym_dtree := (cap, tree)

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -36,11 +36,11 @@ let try_unif_rules : ctxt -> term -> term -> constr list option =
   let open Unif_rule in
   try
     let rhs =
-      match Eval.tree_walk !(equiv.sym_tree) ctx [s;t] with
+      match Eval.tree_walk !(equiv.sym_dtree) ctx [s;t] with
       | Some(r,[]) -> r
       | Some(_)    -> assert false (* Everything should be matched *)
       | None       ->
-      match Eval.tree_walk !(equiv.sym_tree) ctx [t;s] with
+      match Eval.tree_walk !(equiv.sym_dtree) ctx [t;s] with
       | Some(r,[]) -> r
       | Some(_)    -> assert false (* Everything should be matched *)
       | None       -> raise No_match
@@ -78,7 +78,7 @@ let do_type_check = Stdlib.ref true
 let initial : constr list Stdlib.ref = Stdlib.ref []
 
 (** [is_initial c] checks whether [c] occurs in [!initial]. *)
-let is_initial c = List.exists (LibTerm.eq_constr c) Stdlib.(!initial)
+let is_initial c = List.exists (eq_constr c) Stdlib.(!initial)
 
 (** [instantiate ctx m ts u] check whether, in a problem [m[ts] ≡ u], [m] can
    be instantiated and, if so, instantiate it. *)
@@ -203,8 +203,8 @@ let imitate_inj :
       ctxt -> meta -> term array -> term list -> sym -> term list -> bool =
   fun ctx m vs us s ts ->
   if !log_enabled then
-    log_unif "imitate_inj %a ≡ %a" pp_term (add_args (Meta(m,vs)) us)
-                                   pp_term (add_args (Symb s) ts);
+    log_unif "imitate_inj %a ≡ %a" pp_term (add_args (mk_Meta(m,vs)) us)
+                                   pp_term (add_args (mk_Symb s) ts);
   let exception Cannot_imitate in
   try
     if not (us = [] && is_injective s) then raise Cannot_imitate;
@@ -219,11 +219,11 @@ let imitate_inj :
     let k = Array.length vars in
     let t =
       let rec build i acc t =
-        if i <= 0 then add_args (Symb s) (List.rev acc) else
+        if i <= 0 then add_args (mk_Symb s) (List.rev acc) else
         match unfold t with
         | Prod(a,b) ->
             let m = Meta.fresh (Env.to_prod env (lift a)) k in
-            let u = Meta (m,vs) in
+            let u = mk_Meta (m,vs) in
             build (i-1) (u::acc) (Bindlib.subst b u)
         | _ -> raise Cannot_imitate
       in build (List.length ts) [] !(s.sym_type)
@@ -351,8 +351,8 @@ let rec solve : problem -> constr list = fun p ->
   (* We take the beta-whnf. *)
   let t1 = Eval.whnf_beta t1 and t2 = Eval.whnf_beta t2 in
   if !log_enabled then log_unif (gre "%a") pp_constr (ctx,t1,t2);
-  let (h1, ts1) = LibTerm.get_args t1
-  and (h2, ts2) = LibTerm.get_args t2 in
+  let (h1, ts1) = get_args t1
+  and (h2, ts2) = get_args t2 in
 
   match h1, h2 with
   | Type, Type
@@ -402,8 +402,8 @@ let rec solve : problem -> constr list = fun p ->
 
   (* We reduce [t1] and [t2] and try again. *)
   let t1 = Eval.whnf ctx t1 and t2 = Eval.whnf ctx t2 in
-  let (h1, ts1) = LibTerm.get_args t1
-  and (h2, ts2) = LibTerm.get_args t2 in
+  let (h1, ts1) = get_args t1
+  and (h2, ts2) = get_args t2 in
 
   if !log_enabled then log_unif "normalize";
   if !log_enabled then log_unif (gre "%a") pp_constr (ctx,t1,t2);

--- a/src/core/unif_rule.ml
+++ b/src/core/unif_rule.ml
@@ -25,24 +25,24 @@ let sign : Sign.t =
 (** Symbol of name LpLexer.equiv, with infix notation. *)
 let equiv : sym =
   let id = Pos.none "≡" in
-  let s = Sign.add_symbol sign Public Defin Eager false id Kind [] in
+  let s = Sign.add_symbol sign Public Defin Eager false id mk_Kind [] in
   Sign.add_notation sign s (Infix(Pratter.Neither, 1.1)); s
 
 (** Symbol of name LpLexer.cons, with infix right notation with priority <
    LpLexer.equiv. *)
 let cons : sym =
   let id = Pos.none ";" in
-  let s = Sign.add_symbol sign Public Const Eager true id Kind [] in
+  let s = Sign.add_symbol sign Public Const Eager true id mk_Kind [] in
   Sign.add_notation sign s (Infix(Pratter.Right, 1.0)); s
 
 (** [unpack eqs] transforms a term of the form
     [cons (equiv t u) (cons (equiv v w) ...)]
     into a list [[(t,u); (v,w); ...]]. *)
 let rec unpack : term -> (term * term) list = fun eqs ->
-  match LibTerm.get_args eqs with
+  match get_args eqs with
   | (Symb(s), [v; w]) ->
       if s == cons then
-        match LibTerm.get_args v with
+        match get_args v with
         | (Symb(e), [t; u]) when e == equiv -> (t, u) :: unpack w
         | _ -> assert false
       else if s == equiv then [(v, w)]

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -25,13 +25,13 @@ let _ =
       match !((StrMap.find "+1" ss.builtins).sym_type) with
       | Prod(a,_) -> a
       | _ -> assert false
-    with Not_found -> Meta (Meta.fresh Type 0, [||])
+    with Not_found -> mk_Meta (Meta.fresh mk_Type 0, [||])
   in
   register "0" expected_zero_type;
   let expected_succ_type ss _pos =
     let typ_0 =
       try lift !((StrMap.find "0" ss.builtins).sym_type)
-      with Not_found -> _Meta (Meta.fresh Type 0) [||]
+      with Not_found -> _Meta (Meta.fresh mk_Type 0) [||]
     in
     Bindlib.unbox (_Impl typ_0 typ_0)
   in
@@ -80,48 +80,46 @@ let handle_require_as :
 
 (** [handle_modifiers ms] verifies that the modifiers in [ms] are compatible.
     If so, they are returned as a tuple. Otherwise, it fails. *)
-let handle_modifiers : p_modifier list -> (prop * expo * match_strat) =
+let handle_modifiers : p_modifier list -> prop * expo * match_strat =
   fun ms ->
-  let die (ms: p_modifier list) =
-    let modifier oc (m: p_modifier) =
-      Format.fprintf oc "%a:\"%a\"" Pos.pp_short m.pos Pretty.modifier m
-    in
-    fatal_no_pos "%a" (List.pp modifier "; ") ms
+  let rec get_modifiers ((props, expos, strats) as acc) = function
+    | [] -> acc
+    | {elt=P_prop _;_} as p::ms -> get_modifiers (p::props, expos, strats) ms
+    | {elt=P_expo _;_} as e::ms -> get_modifiers (props, e::expos, strats) ms
+    | {elt=P_mstrat _;_} as s::ms ->
+        get_modifiers (props, expos, s::strats) ms
+    | {elt=P_opaq;_}::ms -> get_modifiers acc ms
   in
-  let prop = List.filter is_prop ms in
+  let props, expos, strats = get_modifiers ([],[],[]) ms in
   let prop =
-    match prop with
-    | _::_::_ ->
-        fatal_msg "Only one property modifier can be used, \
-                   %d have been found: " (List.length prop);
-        die prop
-    | [{elt=P_prop(p); _}] -> p
+    match props with
+    | [{elt=P_prop (Assoc b);_};{elt=P_prop Commu;_}]
+    | [{elt=P_prop Commu;_};{elt=P_prop (Assoc b);_}] -> AC b
+    | _::{pos;_}::_ -> fatal pos "Incompatible or duplicated properties."
+    | [{elt=P_prop (Assoc _);pos}] ->
+        fatal pos "Associativity alone is not allowed as \
+                   you can use a rewriting rule instead."
+    | [{elt=P_prop p;_}] -> p
     | [] -> Defin
     | _ -> assert false
   in
-  let expo = List.filter is_expo ms in
   let expo =
-    match expo with
-    | _::_::_ ->
-        fatal_msg "Only one exposition marker can be used, \
-                   %d have been found: " (List.length expo);
-        die expo
-    | [{elt=P_expo(e); _}] -> e
+    match expos with
+    | _::{pos;_}::_ ->
+        fatal pos "Incompatible or duplicated exposition markers."
+    | [{elt=P_expo e;_}] -> e
     | [] -> Public
     | _ -> assert false
   in
-  let mstrat = List.filter is_mstrat ms in
-  let mstrat =
-    match mstrat with
-    | _::_::_ ->
-        fatal_msg "Only one strategy modifier can be used, \
-                   %d have been found: " (List.length mstrat);
-        die mstrat
-    | [{elt=P_mstrat(s); _ }] -> s
+  let strat =
+    match strats with
+    | _::{pos;_}::_ ->
+        fatal pos "Incompatible or duplicated matching strategies."
+    | [{elt=P_mstrat s;_}] -> s
     | [] -> Eager
     | _ -> assert false
   in
-  (prop, expo, mstrat)
+  (prop, expo, strat)
 
 (** [handle_rule ss syms r] checks rule [r], adds it in [ss] and returns the
    set [syms] extended with the symbol [s] defined by [r]. However, it does
@@ -172,7 +170,7 @@ let handle_inductive_symbol : sig_state -> expo -> prop -> match_strat
      fatal pos "We have %a : %a." pp_uid name pp_term typ);
   (* Actually add the symbol to the signature and the state. *)
   Console.out 3 (red "(symb) %a : %a\n") pp_uid name pp_term typ;
-  let r = Sig_state.add_symbol ss expo prop mstrat false id typ impl None in
+  let r = add_symbol ss expo prop mstrat false id typ impl None in
   Print.sig_state := fst r; r
 
 (** Representation of a yet unchecked proof. The structure is initialized when
@@ -302,8 +300,7 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
           Console.out 3 (red "(symb) %a : %a\n")
             pp_uid rec_name pp_term rec_typ;
           let id = Pos.make pos rec_name in
-          let r =
-            Sig_state.add_symbol ss expo Defin Eager false id rec_typ [] None
+          let r = add_symbol ss expo Defin Eager false id rec_typ [] None
           in Print.sig_state := fst r; r
         in
         (ss, rec_sym::rec_sym_list)
@@ -331,9 +328,9 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
               p_sym_def} ->
     (* Check that this is a syntactically valid symbol declaration. *)
     begin
-      match (p_sym_typ, p_sym_def, p_sym_trm, p_sym_prf) with
-      | (None, true, None, Some _) -> fatal pos "missing type"
-      | (   _, true, None, None  ) -> fatal pos "missing definition"
+      match p_sym_typ, p_sym_def, p_sym_trm, p_sym_prf with
+      | None, true, None, Some _ -> fatal pos "missing type"
+      |    _, true, None, None   -> fatal pos "missing definition"
       | _ -> ()
     end;
     (* We check that the identifier is not already used. *)
@@ -345,10 +342,8 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
     let opaq = List.exists Syntax.is_opaq p_sym_mod in
     let pdata_prv = expo = Privat || (p_sym_def && opaq) in
     (match p_sym_def, opaq, prop, mstrat with
-     | false, true, _, _ ->
-         fatal pos "Symbol declarations cannot be opaque."
-     | true, _, Const, _ ->
-         fatal pos "Definitions cannot be constant."
+     | false, true, _, _ -> fatal pos "Symbol declarations cannot be opaque."
+     | true, _, Const, _ -> fatal pos "Definitions cannot be constant."
      | true, _, _, Sequen ->
          fatal pos "Definitions cannot have matching strategies."
      | _ -> ());
@@ -464,8 +459,7 @@ let handle : (Path.t -> Sign.t) -> sig_state -> p_command ->
               (Console.out 1 "%a" Proof.pp_goals ps;
                fatal pe.pos "The proof is not finished.");
             (* Add the symbol in the signature. *)
-            Console.out 3 (red "(symb) add %a : %a\n")
-              pp_uid id pp_term a;
+            Console.out 3 (red "(symb) add %a : %a\n") pp_uid id pp_term a;
             let t = Option.map (fun t -> t.elt) t in
             fst (add_symbol ss expo prop mstrat opaq p_sym_nam a impl t)
       in

--- a/src/handle/inductive.ml
+++ b/src/handle/inductive.ml
@@ -43,7 +43,7 @@ let get_config : Sig_state.t -> Pos.popt -> config = fun ss pos ->
 (** [prf_of p c ts t] returns the term [c.symb_prf (p t1 ... tn t)] where ts =
    [ts1;...;tsn]. *)
 let prf_of : config -> tvar -> tbox list -> tbox -> tbox = fun c p ts t ->
-  _Appl_symb c.symb_prf [_Appl (_Appl_list (_Vari p) ts) t]
+  _Appl_Symb c.symb_prf [_Appl (_Appl_list (_Vari p) ts) t]
 
 (** compute safe prefixes for predicate and constructor argument variables. *)
 let gen_safe_prefixes : inductive -> string * string * string =
@@ -80,7 +80,7 @@ let ind_typ_with_codom :
       popt -> sym -> Env.t -> (tbox list -> tbox) -> string -> term -> tbox =
   fun pos ind_sym env codom s a ->
   let rec aux : tvar list -> term -> tbox = fun xs a ->
-    match LibTerm.get_args a with
+    match get_args a with
     | (Type, _) -> codom (List.rev_map _Vari xs)
     | (Prod(a,b), _) ->
         let (x,b) = LibTerm.unbind_name s b in
@@ -111,7 +111,7 @@ let create_ind_pred_map :
     (* predicate variable *)
     let ind_var = new_tvar_ind p_str i in
     (* predicate type *)
-    let codom ts = _Impl (_Appl_symb ind_sym ts) (_Symb c.symb_Prop) in
+    let codom ts = _Impl (_Appl_Symb ind_sym ts) (_Symb c.symb_Prop) in
     let a = snd (Env.of_prod_using [] vs !(ind_sym.sym_type)) in
     let ind_type = ind_typ_with_codom pos ind_sym env codom x_str a in
     (* predicate conclusion *)
@@ -119,7 +119,7 @@ let create_ind_pred_map :
       let x = new_tvar x_str in
       let t = Bindlib.bind_var x
                 (prf_of c ind_var (List.remove_first arity ts) (_Vari x)) in
-      _Prod (_Appl_symb ind_sym ts) t
+      _Prod (_Appl_Symb ind_sym ts) t
     in
     let ind_conclu = ind_typ_with_codom pos ind_sym env codom x_str a in
     (ind_sym, {ind_var; ind_type; ind_conclu})
@@ -187,7 +187,7 @@ let fold_cons_type
 
     : 'c =
   let rec fold : 'var list -> 'a -> term -> 'c = fun xs acc t ->
-    match LibTerm.get_args t with
+    match get_args t with
     | (Symb(s), ts) ->
         if s == ind_sym then
           let d = List.assq ind_sym ind_pred_map in
@@ -199,7 +199,7 @@ let fold_cons_type
        let x = inj_var (List.length xs) x in
        begin
          let env, b = Env.of_prod [] "y" t in
-         match LibTerm.get_args b with
+         match get_args b with
          | (Symb(s), ts) ->
              begin
                match List.assq_opt s ind_pred_map with
@@ -253,7 +253,7 @@ let gen_rec_types :
     let nonrec_dom t x next = _Prod (lift t) (Bindlib.bind_var x next) in
     let codom xs _ p ts =
       prf_of c p (List.map lift (List.remove_first n ts))
-        (_Appl_symb cons_sym (List.rev_map _Vari xs))
+        (_Appl_Symb cons_sym (List.rev_map _Vari xs))
     in
     fold_cons_type pos ind_pred_map x_str ind_sym vs cons_sym inj_var
       init aux acc_rec_dom rec_dom acc_nonrec_dom nonrec_dom codom

--- a/src/handle/proof.ml
+++ b/src/handle/proof.ml
@@ -42,7 +42,7 @@ module Goal = struct
   let env : goal -> Env.t = fun g ->
     match g with
     | Unif (c,_,_) ->
-        let t, n = Ctxt.to_prod c Type in fst (Env.of_prod_nth c n t)
+        let t, n = Ctxt.to_prod c mk_Type in fst (Env.of_prod_nth c n t)
     | Typ gt -> gt.goal_hyps
 
   (** [of_meta m] creates a goal from the meta [m]. *)
@@ -62,7 +62,7 @@ module Goal = struct
     match g, g' with
     | Typ gt, Typ gt' -> (* Smaller (= older) metas are put first. *)
         Meta.compare gt.goal_meta gt'.goal_meta
-    | Unif c, Unif c' -> LibTerm.cmp_constr c c'
+    | Unif c, Unif c' -> cmp_constr c c'
     | Unif _, Typ _ -> 1
     | Typ _, Unif _ -> -1
 

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -102,7 +102,7 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
        | None -> fatal pos "Not in a proof"
        | Some ps ->
            match ps.proof_term with
-           | Some m -> return pp_term (Meta(m,[||]))
+           | Some m -> return pp_term (mk_Meta(m,[||]))
            | None -> fatal pos "Not in a definition")
   | _ ->
   let env = Proof.focus_env ps in

--- a/src/handle/why3_tactic.ml
+++ b/src/handle/why3_tactic.ml
@@ -78,7 +78,7 @@ let new_axiom_name : unit -> string =
 let translate_term : config -> cnst_table -> term ->
                        (cnst_table * Why3.Term.term) option = fun cfg tbl t ->
   let rec translate_prop tbl t =
-    match LibTerm.get_args t with
+    match get_args t with
     | (Symb(s), [t1; t2]) when s == cfg.symb_and ->
         let (tbl, t1) = translate_prop tbl t1 in
         let (tbl, t2) = translate_prop tbl t2 in
@@ -108,7 +108,7 @@ let translate_term : config -> cnst_table -> term ->
           let sym = Why3.Term.create_psymbol (Why3.Ident.id_fresh "P") [] in
           ((t, sym)::tbl, Why3.Term.ps_app sym [])
   in
-  match LibTerm.get_args t with
+  match get_args t with
   | (Symb(s), [t]) when s == cfg.symb_P -> Some (translate_prop tbl t)
   | _                                   -> None
 
@@ -208,6 +208,6 @@ let handle :
   in
   if !log_enabled then log_why3 "axiom %a created" Print.pp_uid axiom_name;
   (* Return the variable terms of each item in the context. *)
-  let terms = List.rev_map (fun (_, (x, _, _)) -> Vari x) hyps in
+  let terms = List.rev_map (fun (_, (x, _, _)) -> mk_Vari x) hyps in
   (* Apply the instance of the axiom with context. *)
-  LibTerm.add_args (Symb a) terms
+  add_args (mk_Symb a) terms

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -18,9 +18,11 @@ type token =
   | AS
   | ASSERT
   | ASSERTNOT
+  | ASSOCIATIVE
   | ASSUME
   | BEGIN
   | BUILTIN
+  | COMMUTATIVE
   | COMPUTE
   | CONSTANT
   | DEBUG
@@ -212,9 +214,11 @@ let is_keyword : string -> bool =
       ; "as"
       ; "assert"
       ; "assertnot"
+      ; "associative"
       ; "assume"
       ; "begin"
       ; "builtin"
+      ; "commutative"
       ; "compute"
       ; "constant"
       ; "debug"
@@ -287,9 +291,11 @@ let lexer buf =
   | "as" -> AS
   | "assert" -> ASSERT
   | "assertnot" -> ASSERTNOT
+  | "associative" -> ASSOCIATIVE
   | "assume" -> ASSUME
   | "begin" -> BEGIN
   | "builtin" -> BUILTIN
+  | "commutative" -> COMMUTATIVE
   | "compute" -> COMPUTE
   | "constant" -> CONSTANT
   | "debug" -> DEBUG

--- a/src/parsing/lpParser.mly
+++ b/src/parsing/lpParser.mly
@@ -34,9 +34,11 @@
 %token AS
 %token ASSERT
 %token ASSERTNOT
+%token ASSOCIATIVE
 %token ASSUME
 %token BEGIN
 %token BUILTIN
+%token COMMUTATIVE
 %token COMPUTE
 %token CONSTANT
 %token DEBUG
@@ -200,18 +202,19 @@ tactic:
   | INDUCTION { make_pos $sloc P_tac_induction }
   | REFINE t=term { make_pos $sloc (P_tac_refine t) }
   | REFLEXIVITY { make_pos $sloc P_tac_refl }
-  | REWRITE l=ASSOC? p=delimited(L_SQ_BRACKET, rw_patt, R_SQ_BRACKET)? t=term
-    { let b =
-        match l with
-        | Some(Pratter.Left) -> false
-        | _ -> true
-      in make_pos $sloc (P_tac_rewrite(b,p,t)) }
+  | REWRITE d=ASSOC? p=delimited(L_SQ_BRACKET, rw_patt, R_SQ_BRACKET)? t=term
+    { let b = match d with Some Pratter.Left -> false | _ -> true in
+      make_pos $sloc (P_tac_rewrite(b,p,t)) }
   | SIMPLIFY i=id? { make_pos $sloc (P_tac_simpl i) }
   | SOLVE { make_pos $sloc P_tac_solve }
   | SYMMETRY { make_pos $sloc P_tac_sym }
   | WHY3 s=STRINGLIT? { make_pos $sloc (P_tac_why3 s) }
 
 modifier:
+  | d=ASSOC? ASSOCIATIVE
+    { let b = match d with Some Pratter.Left -> true | _ -> false in
+      make_pos $sloc (P_prop (Term.Assoc b)) }
+  | COMMUTATIVE { make_pos $sloc (P_prop Term.Commu) }
   | CONSTANT { make_pos $sloc (P_prop Term.Const) }
   | INJECTIVE { make_pos $sloc (P_prop Term.Injec) }
   | OPAQUE { make_pos $sloc P_opaq }

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -550,16 +550,14 @@ let scope_rule : bool -> sig_state -> p_rule -> pre_rule loc = fun ur ss r ->
   in
   (* Check the head symbol and build the actual LHS. *)
   let (sym, pr_lhs) =
-    let (h, args) = LibTerm.get_args pr_lhs in
+    let (h, args) = get_args pr_lhs in
     match h with
     | Symb(s) ->
-        if is_constant s then
-          fatal p_lhs.pos "Constant LHS head symbol.";
+        if is_constant s then fatal p_lhs.pos "Constant LHS head symbol.";
         if s.sym_expo = Protec && ss.signature.sign_path <> s.sym_path then
           fatal p_lhs.pos "Cannot define rules on foreign protected symbols.";
         (s, args)
-    | _       ->
-        fatal p_lhs.pos "No head symbol in LHS."
+    | _ -> fatal p_lhs.pos "No head symbol in LHS."
   in
   (* Create the pattern variables that can be bound in the RHS. *)
   let pr_vars =

--- a/src/tool/hrs.ml
+++ b/src/tool/hrs.ml
@@ -11,7 +11,7 @@ open Timed
 open Core
 open Term
 open Print
- 
+
 (** [print_sym oc s] outputs the fully qualified name of [s] to [oc]. The name
     is prefixed by ["c_"], and modules are separated with ["_"], not ["."]. *)
 let print_sym : sym pp = fun oc s ->
@@ -36,7 +36,8 @@ let print_term : bool -> term pp = fun lhs ->
     | Symb(s)      -> print_sym oc s
     | Patt(i,n,ts) ->
         if ts = [||] then out "$%s" n else
-        pp oc (Array.fold_left (fun t u -> Appl(t,u)) (Patt(i,n,[||])) ts)
+          pp oc (Array.fold_left (fun t u -> mk_Appl(t,u))
+                   (mk_Patt(i,n,[||])) ts)
     | Appl(t,u)    -> out "app(%a,%a)" pp t pp u
     | Abst(a,t)    ->
         let (x, t) = Bindlib.unbind t in
@@ -81,7 +82,7 @@ let print_rule : Format.formatter -> term -> term -> unit =
 (** [print_sym_rule oc s r] outputs the rule declaration corresponding [r] (on
    the symbol [s]), to the output channel [oc]. *)
 let print_sym_rule : Format.formatter -> sym -> rule -> unit = fun oc s r ->
-  let lhs = LibTerm.add_args (Symb s) r.lhs in
+  let lhs = add_args (mk_Symb s) r.lhs in
   let rhs = LibTerm.term_of_rhs r in
   print_rule oc lhs rhs
 
@@ -130,7 +131,7 @@ let to_HRS : Format.formatter -> Sign.t -> unit = fun oc sign ->
   Format.fprintf oc "\n(COMMENT rewriting rules)\n";
   let print_rules s =
     match !(s.sym_def) with
-    | Some(d) -> print_rule oc (Symb s) d
+    | Some(d) -> print_rule oc (mk_Symb s) d
     | None    -> List.iter (print_sym_rule oc s) !(s.sym_rules)
   in
   iter_symbols print_rules

--- a/src/tool/sr.ml
+++ b/src/tool/sr.ml
@@ -86,7 +86,7 @@ let symb_to_tenv
     : Scope.pre_rule Pos.loc -> sym list -> index_tbl -> term -> tbox =
   fun {elt={pr_vars=vars;pr_arities=arities;_};pos} syms htbl t ->
   let rec symb_to_tenv t =
-    let (h, ts) = LibTerm.get_args t in
+    let (h, ts) = get_args t in
     let ts = List.map symb_to_tenv ts in
     let (h, ts) =
       match h with
@@ -155,7 +155,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
   (* Replace [Patt] nodes of LHS with corresponding elements of [vars]. *)
   let lhs_vars =
     let args = List.map (patt_to_tenv vars) lhs in
-    _Appl_symb s args
+    _Appl_Symb s args
   in
   (* Create metavariables that will stand for the variables of [vars].
      These metavariables are prefixed by "$" so that we can recognize them. *)
@@ -214,7 +214,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
       match !(m.meta_value) with
       | Some(_) ->
           (* Instantiate recursively the meta-variables of the definition. *)
-          let t = Meta(m, Array.make m.meta_arity Kind) in
+          let t = mk_Meta(m, Array.make m.meta_arity mk_Kind) in
           LibTerm.Meta.iter true instantiate t
       | None    ->
           (* Instantiate recursively the meta-variables of the type. *)

--- a/src/tool/tree_graphviz.ml
+++ b/src/tool/tree_graphviz.ml
@@ -106,4 +106,4 @@ let to_dot : Format.formatter -> sym -> unit = fun oc s ->
     end;
     out "@.}@\n@?"
   in
-  output_tree oc (Lazy.force (snd !(s.sym_tree)))
+  output_tree oc (Lazy.force (snd !(s.sym_dtree)))

--- a/tests/OK/ac.lp
+++ b/tests/OK/ac.lp
@@ -1,0 +1,14 @@
+// test commutative and associative-commutative symbols
+
+constant symbol A : TYPE;
+
+commutative symbol + : A → A → A;
+notation + infix 10;
+assert x y ⊢ x + y ≡ y + x;
+
+associative commutative symbol * : A → A → A;
+notation * infix 10;
+debug +m;
+assert x y ⊢ x * y ≡ y * x;
+assert x y z ⊢ (x * y) * z ≡ x * (y * z);
+assert x y z ⊢ (x * y) * z ≡ (z * x) * y;

--- a/tests/OK/ac.lp
+++ b/tests/OK/ac.lp
@@ -8,7 +8,6 @@ assert x y ⊢ x + y ≡ y + x;
 
 associative commutative symbol * : A → A → A;
 notation * infix 10;
-debug +m;
 assert x y ⊢ x * y ≡ y * x;
 assert x y z ⊢ (x * y) * z ≡ x * (y * z);
 assert x y z ⊢ (x * y) * z ≡ (z * x) * y;

--- a/tests/OK/ac.lp
+++ b/tests/OK/ac.lp
@@ -11,3 +11,9 @@ notation * infix 10;
 assert x y ⊢ x * y ≡ y * x;
 assert x y z ⊢ (x * y) * z ≡ x * (y * z);
 assert x y z ⊢ (x * y) * z ≡ (z * x) * y;
+
+left associative commutative symbol @ : A → A → A;
+notation @ infix 10;
+assert x y ⊢ x @ y ≡ y @ x;
+assert x y z ⊢ (x @ y) @ z ≡ x @ (y @ z);
+assert x y z ⊢ (x @ y) @ z ≡ (z @ x) @ y;


### PR DESCRIPTION
by privatizing the type `term` and adding `term.mli`