### PR TITLE
Don't colourise newlines

### DIFF
--- a/src/common/error.ml
+++ b/src/common/error.ml
@@ -17,8 +17,8 @@ let wrn : Pos.popt -> 'a outfmt -> 'a = fun pos fmt ->
   let open Stdlib in
   let fprintf = if !no_wrn then Format.ifprintf else Format.fprintf in
   match pos with
-  | None    -> fprintf !err_fmt (yel (fmt ^^ "\n"))
-  | Some(_) -> fprintf !err_fmt (yel ("[%a] " ^^ fmt ^^ "\n")) Pos.pp pos
+  | None    -> fprintf !err_fmt (yel fmt ^^ "\n")
+  | Some(_) -> fprintf !err_fmt (yel ("[%a] " ^^ fmt) ^^ "\n") Pos.pp pos
 
 (** [with_no_wrn f x] disables warnings before executing [f x] and then
     restores the initial state of warnings. The result of [f x] is returned.
@@ -65,7 +65,7 @@ let fatal_no_pos : ('a,'b) koutfmt -> 'a = fun fmt ->
     by the main program logic, not by the internals. *)
 let handle_exceptions : (unit -> unit) -> unit = fun f ->
   let exit_with : type a b. (a,b) koutfmt -> a = fun fmt ->
-    Format.(kfprintf (fun _ -> exit 1) err_formatter (red (fmt ^^ "\n%!")))
+    Format.(kfprintf (fun _ -> exit 1) err_formatter (red fmt ^^ "\n%!"))
   in
   try f () with
   | Fatal(None,    msg) -> exit_with "%s" msg

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -135,7 +135,7 @@ let handle_rule : sig_state -> p_rule -> sym = fun ss r ->
       pp_sym sym;
   let rule = Tool.Sr.check_rule pr in
   Sign.add_rule ss.signature sym rule;
-  Console.out 3 (red "(rule) add %a\n") pp_rule (sym, rule);
+  Console.out 3 (red "(rule) add %a" ^^ "\n") pp_rule (sym, rule);
   sym
 
 (** [handle_rules ss rs] handles the rules [rs] in signature state [ss], and
@@ -171,7 +171,7 @@ let handle_inductive_symbol : sig_state -> expo -> prop -> match_strat
     (fatal_msg "The type of %a has unsolved metavariables.\n" pp_uid name;
      fatal pos "We have %a : %a." pp_uid name pp_term typ);
   (* Actually add the symbol to the signature and the state. *)
-  Console.out 3 (red "(symb) %a : %a\n") pp_uid name pp_term typ;
+  Console.out 3 (red "(symb) %a : %a" ^^ "\n") pp_uid name pp_term typ;
   let r = add_symbol ss expo prop mstrat false id typ impl None in
   Print.sig_state := fst r; r
 
@@ -292,7 +292,7 @@ let get_proof_data : compiler -> sig_state -> p_command ->
         if Sign.mem ss.signature rec_name then
           fatal pos "Symbol %a already exists." pp_uid rec_name;
         let (ss, rec_sym) =
-          Console.out 3 (red "(symb) %a : %a\n")
+          Console.out 3 (red "(symb) %a : %a" ^^ "\n")
             pp_uid rec_name pp_term rec_typ;
           let id = Pos.make pos rec_name in
           let r = add_symbol ss expo Defin Eager false id rec_typ [] None
@@ -443,7 +443,7 @@ let get_proof_data : compiler -> sig_state -> p_command ->
                   in List.fold_left admit_goal ss ps.proof_goals
             in
             (* Add the symbol in the signature with a warning. *)
-            Console.out 3 (red "(symb) add %a : %a\n")
+            Console.out 3 (red "(symb) add %a : %a" ^^ "\n")
               pp_uid id pp_term a;
             wrn pe.pos "Proof admitted.";
             let t = Option.map (fun t -> t.elt) t in
@@ -454,7 +454,7 @@ let get_proof_data : compiler -> sig_state -> p_command ->
               (Console.out 1 "%a" Proof.pp_goals ps;
                fatal pe.pos "The proof is not finished.");
             (* Add the symbol in the signature. *)
-            Console.out 3 (red "(symb) add %a : %a\n") pp_uid id pp_term a;
+            Console.out 3 (red "(symb) add %a : %a" ^^ "\n") pp_uid id pp_term a;
             let t = Option.map (fun t -> t.elt) t in
             fst (add_symbol ss expo prop mstrat opaq p_sym_nam a impl t)
       in

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -19,7 +19,7 @@ type result = (unit -> string) option
 (** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose
    level 1 and returns a function for printing [x] on a string using [pp]. *)
 let return : 'a pp -> 'a -> result = fun pp x ->
-  Console.out 1 (Extra.red "%a\n") pp x;
+  Console.out 1 (Extra.red "%a" ^^ "\n") pp x;
   Some (fun () -> Format.asprintf "%a" pp x)
 
 (** [handle_query ss ps q] *)

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -36,7 +36,7 @@ let add_axiom : Sig_state.t -> Meta.t -> Sig_state.t = fun ss m ->
   in
   (* Create a symbol with the same type as the metavariable *)
   let ss, sym =
-    Console.out 3 (red "(symb) add axiom %a: %a\n")
+    Console.out 3 (red "(symb) add axiom %a: %a" ^^ "\n")
       pp_uid name pp_term !(m.meta_type);
     Sig_state.add_symbol
       ss Public Const Eager true (Pos.none name) !(m.meta_type) [] None


### PR DESCRIPTION
When a newline is colourised, especially if it is the last one before the prompt returns, the cursor keeps the colour on my console (KDE).

Not colouring the newlines shouldn't change anything else