### PR TITLE
Flush output on warning

### DIFF
--- a/src/common/console.ml
+++ b/src/common/console.ml
@@ -20,8 +20,7 @@ let set_default_verbose : int -> unit = fun i ->
 
 (** [out lvl fmt] prints an output message using the format [fmt], but only if
     [lvl] is strictly greater than the current verbosity level.  Note that the
-    output channel is automatically flushed,  and  the message is displayed in
-    magenta (and not default terminal color) if logging modes are enabled. *)
+    output channel is automatically flushed if logging modes are enabled. *)
 let out : int -> 'a outfmt -> 'a = fun lvl fmt ->
   if lvl > !verbose then Format.ifprintf Stdlib.(!out_fmt) fmt
   else Format.fprintf Stdlib.(!out_fmt)

--- a/src/common/error.ml
+++ b/src/common/error.ml
@@ -17,8 +17,8 @@ let wrn : Pos.popt -> 'a outfmt -> 'a = fun pos fmt ->
   let open Stdlib in
   let fprintf = if !no_wrn then Format.ifprintf else Format.fprintf in
   match pos with
-  | None    -> fprintf !err_fmt (yel fmt ^^ "\n")
-  | Some(_) -> fprintf !err_fmt (yel ("[%a] " ^^ fmt) ^^ "\n") Pos.pp pos
+  | None    -> fprintf !err_fmt (yel fmt ^^ "@.")
+  | Some(_) -> fprintf !err_fmt (yel ("[%a] " ^^ fmt) ^^ "@.") Pos.pp pos
 
 (** [with_no_wrn f x] disables warnings before executing [f x] and then
     restores the initial state of warnings. The result of [f x] is returned.


### PR DESCRIPTION
Fixes an issue where there would be no newline at the end of warning (can be reproduced running `dune exec -- lambdapi tests/OK/292.lp`).