### PR TITLE
New typechecker, refinement, placeholders, coercions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,13 +17,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   two new builtins ("ex" and "all"). Codewise, it requires a new
   translation from encoded types to Why3 types.
 
+- Tems may be _placeholders_. Placeholders are holes in the
+  concrete syntax. They are refined into metavariables. *Placeholders
+  cannot appear nonlinearly in terms*. From [A Bidirectional Refinement
+  Algorithm...](https://arxiv.org/abs/1202.4905), p. 31,
+  > Non linear placeholders are not allowed since two occurrences could be
+  in contexts that bind different set of variables and instantiation with
+  terms that live in one context would make no sense in the other one.
+
 ### Changed
 
 - Moved the files tool/hrs.ml and tool/xtc.ml into the new export/ directory.
 
+- Because placeholders are simple holes, the term `_ → _` is scoped
+  into a full dependent product `Π x: M, N` where `N` is a metavariable
+  that depend on `x` (see file `tests/OK/767.lp`)
+
+- Type checking is slower following #696 because of refinement (not only
+  the type but also the term must be destructured and rebuilt),
+  |         | master | refiner |
+  |---------|--------|---------|
+  | holide  | 7:0    | 11:33   |
+  | iprover | 5:58   | 6:50    |
+
 ### Removed
 
 - The command beautify superseded by the new command export.
+
+- Unused variable warning: whether a variable is used or not cannot be
+  decided while scoping (following #696) since placeholders that do not
+  depend on variables may be refined later into metavariables that may
+  depend on them.
+
+- Metavariables cannot be referenced by their name anymore, hence the
+  syntax `?M.[x;y]` is obsolete, but `?0.[x;y]` isn't
 
 ## 2.0.0 (2021-12-15)
 

--- a/doc/lambdapi.bnf
+++ b/doc/lambdapi.bnf
@@ -77,7 +77,7 @@ QID ::= [UID "."]+ UID
 <aterm> ::= <term_id>
           | "_"
           | "TYPE"
-          | "?" UID [<env>]
+          | "?" UID <env>
           | "$" UID [<env>]
           | "(" <term> ")"
           | "[" <term> "]"

--- a/doc/terms.rst
+++ b/doc/terms.rst
@@ -49,7 +49,6 @@ A user-defined term can be either:
      current file or in some previously open module, possibly prefixed by ``@``
      to disallow implicit arguments
    * a bound variable
-   * a metavariable or goal when prefixed by ``?``
 
 * an anonymous function ``λ(x:A) y z,t`` mapping ``x``, ``y`` and ``z``
   (of type ``A`` for ``x``) to ``t``
@@ -64,9 +63,9 @@ A user-defined term can be either:
 * an application written by space-separated juxtaposition, except for
   symbol identifiers declared as infix (e.g. ``x + y``)
 
-* a meta-variable application ``?M.[t;u;v]``. ``?M`` alone, without arguments
-  between square brackets, is a shorthand for ``?M.[x1;..;xn]`` where
-  ``x1;..;xn`` are all the variables of the context.
+* a hole ``_`` to be filled automatically.
+
+* a metavariable ``?0.[x;y]`` that has been generated previously.
 
 * a pattern-variable application ``$P.[x;y]`` (in rules only). ``$P``
   alone, without arguments between square brackets, is a shorthand for

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -33,6 +33,20 @@ let to_prod : ctxt -> term -> term * int = fun ctx t ->
   let t, c = List.fold_left f (lift t, 0) ctx in
   Bindlib.unbox t, c
 
+(** [to_prod_box bctx t] is similar to [to_prod bctx t] but operates on boxed
+    contexts and terms. *)
+let to_prod_box : bctxt -> tbox -> tbox * int = fun bctx t ->
+  let f (t, c) (x, a) =
+    let b = Bindlib.bind_var x t in
+    (_Prod a b, c + 1)
+  in
+  List.fold_left f (t, 0) bctx
+
+(** [box_context ctx] lifts context [ctx] to a boxed context. *)
+let box_context : ctxt -> bctxt =
+  List.filter_map
+    (fun (x, t, u) -> if u = None then Some (x, lift t) else None)
+
 (** [to_abst ctx t] builds a sequence of abstractions over the context [ctx],
     in the term [t]. *)
 let to_abst : ctxt -> term -> term = fun ctx t ->

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -1,17 +1,8 @@
 (** Typing context. *)
 
 open Term
+open Lplib
 open Timed
-
-(** [unbind ctx a def b] returns a triple [(x,t,new_ctx)] such that [(x,t)] is
-   an unbinding of [b] (in the sense of [Bindlib.unbind]) and [new_ctx] is an
-   extension of the context [ctx] with the declaration that [x] has type [a]
-   (only if [x] occurs in [t]). If [def] is of the form [Some(u)], the context
-   also registers the term [u] as the definition of variable [x]. *)
-let unbind : ctxt -> term -> term option -> tbinder -> tvar * term * ctxt =
-  fun ctx a def b ->
-  let (x, t) = Bindlib.unbind b in
-  (x, t, if Bindlib.binder_occur b then (x, a, def) :: ctx else ctx)
 
 (** [type_of x ctx] returns the type of [x] in the context [ctx] when it
     appears in it, and

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -139,35 +139,3 @@ let of_prod_using : ctxt -> tvar array -> term -> env * term = fun c xs t ->
              let env = add xs.(i) (lift a) None env in
              build_env (i+1) env (Bindlib.subst b (mk_Vari(xs.(i)))))
   in build_env 0 [] t
-
-(** [fresh_meta_type p env] creates a fresh metavariable of type [Type] in
-    environment [env], and adds it to the metas of [p]. *)
-let fresh_meta_type : problem -> t -> tbox = fun p env ->
-  let vs = to_tbox env in
-  let arity = Array.length vs in
-  let tm = to_prod_box env _Type in
-  _Meta_full (LibMeta.fresh_box p tm arity) vs
-
-(** [fresh_meta_tbox p env] creates a _Meta tbox from a fresh metavariable
-   whose type is itself a fresh metavariable of type [fresh_meta_type env],
-   and add them to the metas of [p]. *)
-let fresh_meta_tbox : problem -> t -> tbox = fun p env ->
-  let vs = to_tbox env in
-  let arity = Array.length vs in
-  let bm1 = LibMeta.fresh_box p (to_prod_box env _Type) arity in
-  let tm = to_prod_box env (_Meta_full bm1 vs) in
-  _Meta_full (LibMeta.fresh_box p tm arity) vs
-
-(** [fresh_meta_term p env] creates a Meta term from a fresh metavariable
-   whose type is a fresh metavariable of type [to_prod env Type], and adds it
-   to the metas of [p]. *)
-let fresh_meta_term : problem -> env -> term = fun p env ->
-  Bindlib.unbox (fresh_meta_tbox p env)
-
-(** [app_fresh_metas p t n env] returns the application of [t] to [n] fresh
-   meta terms, and adds them to [p]. *)
-let app_fresh_meta_terms : problem -> term -> int -> env -> term =
-  fun p t n env ->
-  let rec add t n =
-    if n <= 0 then t else add (mk_Appl(t, fresh_meta_term p env)) (n-1)
-  in add t n

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -70,6 +70,7 @@ let snf : (term -> term) -> (term -> term) = fun whnf ->
         mk_Abst(snf a, Bindlib.unbox (Bindlib.bind_var x (lift (snf b))))
     | Appl(t,u)   -> mk_Appl(snf t, snf u)
     | Meta(m,ts)  -> mk_Meta(m, Array.map snf ts)
+    | Plac _      -> assert false (* Typechecked terms are evaluated *)
     | Patt(_,_,_) -> assert false
     | TEnv(_,_)   -> assert false
     | Wild        -> assert false
@@ -431,6 +432,8 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
           | Kind
           | Type
           | Meta(_, _) -> default ()
+          | Plac _     -> assert false
+             (* Should not appear in typechecked terms. *)
           | TRef(_)    -> assert false (* Should be reduced by [whnf_stk]. *)
           | Appl(_)    -> assert false (* Should be reduced by [whnf_stk]. *)
           | LLet(_)    -> assert false (* Should be reduced by [whnf_stk]. *)

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -61,8 +61,14 @@ and force : problem -> ctxt -> term -> term -> term =
  fun pb c te ty ->
  if Logger.log_enabled () then
    log "Force [%a] of [%a]" Print.pp_term te Print.pp_term ty;
- let (t, a) = infer pb c te in
- coerce pb c t a ty
+ match unfold te with
+ | Plac true ->
+     unif pb c ty mk_Type;
+     LibMeta.make pb c mk_Type
+ | Plac false -> LibMeta.make pb c ty
+ | _ ->
+     let (t, a) = infer pb c te in
+     coerce pb c t a ty
 
 and infer_aux : problem -> ctxt -> term -> term * term =
  fun pb c t ->
@@ -77,6 +83,13 @@ and infer_aux : problem -> ctxt -> term -> term * term =
       let a = try Ctxt.type_of x c with Not_found -> assert false in
       (t, a)
   | Symb s -> (t, !(s.sym_type))
+  | Plac true ->
+      let m = LibMeta.make pb c mk_Type in
+      (m, mk_Type)
+  | Plac false ->
+      let mt = LibMeta.make pb c mk_Type in
+      let m = LibMeta.make pb c mt in
+      (m, mt)
   (* All metavariables inserted are typed. *)
   | (Meta (m, ts)) as t ->
       let rec ref_esubst i range =
@@ -100,7 +113,8 @@ and infer_aux : problem -> ctxt -> term -> term * term =
       (* Check that [t] is of type [t_ty], and refine it *)
       let t = force pb c t t_ty in
       (* Unbind [u] and get new context with [x: t_ty ≔ t] *)
-      let x, u, c = Ctxt.unbind c t_ty (Some t) u in
+      let (x, u) = Bindlib.unbind u in
+      let c = (x, t_ty, Some t) :: c in
       (* Infer type of [u'] and refine it. *)
       let u, u_ty = infer pb c u in
       ( match unfold u_ty with
@@ -116,7 +130,8 @@ and infer_aux : problem -> ctxt -> term -> term * term =
   | Abst (dom, b) ->
       (* Domain must by of type Type (and not Kind) *)
       let dom = force pb c dom mk_Type in
-      let x, b, c = Ctxt.unbind c dom None b in
+      let (x, b) = Bindlib.unbind b in
+      let c = (x, dom, None) :: c in
       let b, range = infer pb c b in
       let b = Bindlib.(lift b |> bind_var x |> unbox) in
       let range = Bindlib.(lift range |> bind_var x |> unbox) in
@@ -124,7 +139,8 @@ and infer_aux : problem -> ctxt -> term -> term * term =
   | Prod (dom, b) ->
       (* Domain must by of type Type (and not Kind) *)
       let dom = force pb c dom mk_Type in
-      let x, b, c = Ctxt.unbind c dom None b in
+      let (x, b) = Bindlib.unbind b in
+      let c = (x, dom, None) :: c in
       let b, b_s = type_enforce pb c b in
       let b = Bindlib.(lift b |> bind_var x |> unbox) in
       (mk_Prod (dom, b), b_s)
@@ -155,6 +171,12 @@ and infer : problem -> ctxt -> term -> term * term = fun pb c t ->
     log "Inferred [%a: %a]" Print.pp_term t Print.pp_term t_ty;
   (t, t_ty)
 
+(** {b NOTE} when unbinding a binder [b] (e.g. when inferring the type of an
+    abstraction [λ x, e]) in context [c], [c] is always extended, even if
+    binder [b] is constant. This is because during typechecking, the context
+    must contain all variables traversed to build appropriate meta-variables.
+    Otherwise, the term [λ a: _, λ b: _, b] will be transformed to [λ _: ?1,
+    λ b: ?2, b] whereas it should be [λ a: ?1.[], λ b: ?2.[a], b] *)
 
 (** [noexn f cs c args] initialises {!val:constraints} to [cs],
     calls [f c args] and returns [Some(r,cs)] where [r] is the value of

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -183,7 +183,3 @@ let check_sort_noexn pb c t : (term * term) option =
   if Logger.log_enabled () then
     log "Top check sort %a%a" Print.pp_ctxt c Print.pp_term t;
   noexn type_enforce pb c t
-
-let infer_noexn pb c t = Option.map snd (infer_noexn pb c t)
-let check_noexn pb c t a = check_noexn pb c t a <> None
-let check_sort_noexn pb c t = check_sort_noexn pb c t <> None

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -1,234 +1,189 @@
 (** Type inference and checking *)
 
-open Timed
 open Common
-open Error
-open Term
-open Print
-open Debug
 open Lplib
+open Term
+open Timed
 
 (** Logging function for typing. *)
-let log_infr = Logger.make 'i' "infr" "type inference/checking"
-let log_infr = log_infr.pp
-
-(** Given a meta [m] of type [Πx1:a1,..,Πxn:an,b], [set_to_prod d p m] sets
-   [m] to a product term of the form [Πy:m1[x1;..;xn],m2[x1;..;xn;y]] with
-   [m1] and [m2] fresh metavariables, and adds these metavariables to [p].
-   [d] is the call depth used for debug. *)
-let set_to_prod : int -> problem -> meta -> unit = fun d p m ->
-  let n = m.meta_arity in
-  let env, s = Env.of_prod_nth [] n !(m.meta_type) in
-  let vs = Env.vars env in
-  let xs = Array.map _Vari vs in
-  (* domain *)
-  let u1 = Env.to_prod env _Type in
-  let m1 = LibMeta.fresh p u1 n in
-  let a = _Meta m1 xs in
-  (* codomain *)
-  let y = new_tvar "y" in
-  let env' = Env.add y (_Meta m1 xs) None env in
-  let u2 = Env.to_prod env' (lift s) in
-  let m2 = LibMeta.fresh p u2 (n+1) in
-  let b = Bindlib.bind_var y (_Meta m2 (Array.append xs [|_Vari y|])) in
-  (* result *)
-  let r = _Prod a b in
-  if Logger.log_enabled () then
-    log_infr (Color.red "%a%a ≔ %a") D.depth d
-      pp_meta m pp_term (Bindlib.unbox r);
-  LibMeta.set p m (Bindlib.unbox (Bindlib.bind_mvar vs r))
-
-(** [conv d p c a b] adds the the constraint [(c,a,b)] in [p], if [a] and
-   [b] are not convertible. [d] is the call depth used for debug. *)
-let conv : int -> problem -> ctxt -> term -> term -> unit = fun d p c a b ->
-  if not (Eval.pure_eq_modulo c a b) then begin
-    let cstr = (c,a,b) in
-    if Logger.log_enabled () then
-      log_infr (Color.mag "%aadd %a") D.depth d pp_constr cstr;
-    p := {!p with to_solve = cstr::!p.to_solve}
-  end
+let log = Logger.make 'i' "infr" "type inference/checking"
+let log = log.pp
 
 (** Exception that may be raised by type inference. *)
 exception NotTypable
 
-(** [infer d p c t] tries to infer a type for the term [t] in context [c],
-   possibly adding new unification constraints in [p]. The set of
-   metavariables of [p] are updated if some metavariables are instantiated or
-   created. The returned type is well-sorted if the recorded constraints are
-   satisfied. [c] must be well sorted. [d] is the call depth used for debug.
-@raise NotTypable when the term is not typable (when encountering an
-   abstraction over a kind). *)
-let rec infer : int -> problem -> ctxt -> term -> term = fun d p c t ->
-  let return v =
-    if Logger.log_enabled () then log_infr "%agot %a" D.depth d pp_term v; v
+(** [unif pb c a b] solves the unification problem [c ⊢ a ≡ b]. Current
+    implementation collects constraints in {!val:constraints} then solves
+    them at the end of type checking. *)
+let unif : problem -> ctxt -> term -> term -> unit =
+ fun pb c a b ->
+ if not (Eval.pure_eq_modulo c a b) then
+ (* NOTE: eq_modulo is used because the unification algorithm counts on
+    the fact that no constraint is added in some cases (see test
+    "245b.lp"). We may however want to reduce the number of calls to
+    [eq_modulo]. *)
+   begin
+     if Logger.log_enabled () then
+       log (Color.yel "add constraint %a") Print.pp_constr
+         (c, a, b);
+     pb := {!pb with to_solve = (c, a, b) :: !pb.to_solve}
+   end
+
+(** {1 Handling coercions} *)
+
+(* Simply unify types, no coercions yet. *)
+let coerce pb c t a b = unif pb c a b; t
+
+(** {1 Other rules} *)
+
+(** [type_enforce pb c a] returns a tuple [(a',s)] where [a'] is refined
+    term [a] and [s] is a sort (Type or Kind) such that [a'] is of type
+    [s]. *)
+let rec type_enforce : problem -> ctxt -> term -> term * term =
+ fun pb c a ->
+  if Logger.log_enabled () then log "Type enforce [%a]" Print.pp_term a;
+  let a, s = infer pb c a in
+  let sort =
+    match unfold s with
+    | Kind -> mk_Kind
+    | Type -> mk_Type
+    | _ -> mk_Type
+    (* FIXME The algorithm should be able to backtrack on the choice of
+       this sort, first trying [Type], and if it does not succeed, trying
+       [Kind]. *)
   in
-  if Logger.log_enabled () then
-    log_infr "%ainfer %a%a" D.depth d pp_ctxt c pp_term t;
+  let a = coerce pb c a s sort in
+  (a, sort)
 
+(** [force pb c t a] returns a term [t'] such that [t'] has type [a],
+    and [t'] is the refinement of [t]. *)
+and force : problem -> ctxt -> term -> term -> term =
+ fun pb c te ty ->
+ if Logger.log_enabled () then
+   log "Force [%a] of [%a]" Print.pp_term te Print.pp_term ty;
+ let (t, a) = infer pb c te in
+ coerce pb c t a ty
+
+and infer_aux : problem -> ctxt -> term -> term * term =
+ fun pb c t ->
   match unfold t with
-  | Patt(_,_,_) -> assert false (* Forbidden case. *)
-  | TEnv(_,_)   -> assert false (* Forbidden case. *)
-  | Kind        -> assert false (* Forbidden case. *)
-  | Wild        -> assert false (* Forbidden case. *)
-  | TRef(_)     -> assert false (* Forbidden case. *)
-
-  (* -------------------
-      c ⊢ Type ⇒ Kind  *)
-  | Type -> return mk_Kind
-
-  (* ---------------------------------
-      c ⊢ Vari x ⇒ Ctxt.type_of x c  *)
-  | Vari x -> (try return (Ctxt.type_of x c) with Not_found -> assert false)
-
-  (* -------------------------------
-      c ⊢ Symb s ⇒ !(s.sym_type)  *)
-  | Symb s -> return !(s.sym_type)
-
-  (*  c ⊢ a ⇐ Type    c, x:a ⊢ b ⇒ s in {Type,Kind}
-     -----------------------------------------
-                c ⊢ Prod(a,b) ⇒ s            *)
-  | Prod(a,b) ->
-      check (d+1) p c a mk_Type;
-      let _,b,c' = Ctxt.unbind c a None b in
-      let s = infer (d+1) p c' b in
-      begin match unfold s with
-      | (Type | Kind) as s -> s
-      | _ -> conv d p c' s mk_Type; mk_Type
-      (* Here, we force [s] to be equivalent to [Type] as there is little
-         (no?) chance that it can be a kind. *)
-      end
-
-  (*  c ⊢ a ⇐ Type    c, x:a ⊢ t ⇒ b   b ≠ Kind
-     --------------------------------------------
-             c ⊢ Abst(a,t) ⇒ Prod(a,b)          *)
-  | Abst(a,t) ->
-      check (d+1) p c a mk_Type;
-      let x,t,c' = Ctxt.unbind c a None t in
-      let b = infer (d+1) p c' t in
-      begin match unfold b with
-      | Kind ->
-          wrn None "Abstraction on [%a] is not allowed." Print.pp_term t;
-          raise NotTypable
-      | _ -> return (mk_Prod(a, Bindlib.unbox (Bindlib.bind_var x (lift b))))
-      end
-
-  (*  c ⊢ t ⇒ Prod(a,b)    c ⊢ u ⇐ a
-     ------------------------------------
-         c ⊢ Appl(t,u) ⇒ subst b u      *)
-  | Appl(t,u) ->
-      (* [get_prod f typ] returns the domain and codomain of [t] if [t] is a
-         product. If [t] is a metavariable, then it instantiates it with a
-         product and calls [get_prod f typ] again. Otherwise, it calls [f
-         typ]. *)
-      let rec get_prod f typ =
-        match unfold typ with
-        | Prod(a,b) -> (a,b)
-        | Meta(m,_) -> set_to_prod d p m; get_prod f typ
-        | _ -> f typ
+  | Patt _ -> assert false
+  | TEnv _ -> assert false
+  | Kind -> assert false
+  | Wild -> assert false
+  | TRef _ -> assert false
+  | Type -> (mk_Type, mk_Kind)
+  | Vari x ->
+      let a = try Ctxt.type_of x c with Not_found -> assert false in
+      (t, a)
+  | Symb s -> (t, !(s.sym_type))
+  (* All metavariables inserted are typed. *)
+  | (Meta (m, ts)) as t ->
+      let rec ref_esubst i range =
+        (* Refine terms of the explicit substitution. *)
+        if i >= Array.length ts then range else
+          match unfold range with
+          | Prod(ai, b) ->
+              ts.(i) <- force pb c ts.(i) ai;
+              let b = Bindlib.subst b ts.(i) in
+              ref_esubst (i + 1) b
+          | _ ->
+              (* Meta type must be a product of arity greater or equal
+                 to the environment *)
+              assert false
       in
-      let get_prod_whnf = (* assumes that its argument is in whnf *)
-        get_prod (fun typ ->
-            let a = LibMeta.make p c mk_Type in
-            (* We force [b] to be of type [Type] as there is little (no?)
-               chance that it can be a kind. *)
-            let b = LibMeta.make_codomain p c a in
-            conv d p c typ (mk_Prod(a,b)); (a,b)) in
-      let get_prod =
-        get_prod (fun typ -> get_prod_whnf (Eval.whnf c typ)) in
-      let a, b = get_prod (infer (d+1) p c t) in
-      check (d+1) p c u a;
-      return (Bindlib.subst b u)
+      let range = ref_esubst 0 !(m.meta_type) in
+      (t, range)
+  | LLet (t_ty, t, u) ->
+      (* Check that [a] is a type, and refine it. *)
+      let t_ty, _ = type_enforce pb c t_ty in
+      (* Check that [t] is of type [t_ty], and refine it *)
+      let t = force pb c t t_ty in
+      (* Unbind [u] and get new context with [x: t_ty ≔ t] *)
+      let x, u, c = Ctxt.unbind c t_ty (Some t) u in
+      (* Infer type of [u'] and refine it. *)
+      let u, u_ty = infer pb c u in
+      ( match unfold u_ty with
+        | Kind ->
+            Error.fatal_msg "Let bindings cannot have a body of type Kind.";
+            Error.fatal_msg "Body of let binding [%a] has type Kind."
+              Print.pp_term u;
+            raise NotTypable
+        | _ -> () );
+      let u_ty = Bindlib.(u_ty |> lift |> bind_var x |> unbox) in
+      let u = Bindlib.(u |> lift |> bind_var x |> unbox) in
+      (mk_LLet (t_ty, t, u), mk_LLet(t_ty, t, u_ty))
+  | Abst (dom, b) ->
+      (* Domain must by of type Type (and not Kind) *)
+      let dom = force pb c dom mk_Type in
+      let x, b, c = Ctxt.unbind c dom None b in
+      let b, range = infer pb c b in
+      let b = Bindlib.(lift b |> bind_var x |> unbox) in
+      let range = Bindlib.(lift range |> bind_var x |> unbox) in
+      (mk_Abst (dom, b), mk_Prod (dom, range))
+  | Prod (dom, b) ->
+      (* Domain must by of type Type (and not Kind) *)
+      let dom = force pb c dom mk_Type in
+      let x, b, c = Ctxt.unbind c dom None b in
+      let b, b_s = type_enforce pb c b in
+      let b = Bindlib.(lift b |> bind_var x |> unbox) in
+      (mk_Prod (dom, b), b_s)
+  | Appl (t, u) -> (
+      let t, t_ty = infer pb c t in
+      match Eval.whnf c t_ty with
+      | Prod (dom, b) ->
+          if Logger.log_enabled () then log "Appl-prod arg [%a]" Print.pp_term u;
+          let u = force pb c u dom in
+          (mk_Appl (t, u), Bindlib.subst b u)
+      | Meta (_, _) ->
+          let u, u_ty = infer pb c u in
+          let range = LibMeta.make_codomain pb c u_ty in
+          unif pb c t_ty (mk_Prod (u_ty, range));
+          (mk_Appl (t, u), Bindlib.subst range u)
+      | t_ty ->
+          let domain = LibMeta.make pb c mk_Type in
+          let range = LibMeta.make_codomain pb c domain in
+          let t = coerce pb c t t_ty (mk_Prod (domain, range)) in
+          if Logger.log_enabled () then log "Appl-default arg [%a]" Print.pp_term u;
+          let u = force pb c u domain in
+          (mk_Appl (t, u), Bindlib.subst range u) )
 
-  (* c ⊢ t ⇐ a   c, x:a ≔ t ⊢ u ⇒ b   c, x:a ≔ t ⊢ b : s in {Type,Kind}
-     ------------------------------------------------------------------
-        c ⊢ let x:a ≔ t in u ⇒ let x:a ≔ t in b
-
-     See Pure type systems with definitions, P. Severi and E. Poll,
-     LFCS 1994, http://doi.org/10.1007/3-540-58140-5_30. *)
-  | LLet(a,t,u) ->
-      check (d+1) p c a mk_Type;
-      check (d+1) p c t a;
-      let x,u,c' = Ctxt.unbind c a (Some t) u in
-      let b = infer (d+1) p c' u in
-      begin match unfold b with
-      | Kind ->
-          wrn None "Abstraction on [%a] is not allowed." Print.pp_term u;
-          raise NotTypable
-      | _ ->
-          let s = infer (d+1) p c' b in
-          begin match unfold s with
-          | Type | Kind -> ()
-          | _ -> conv d p c' s mk_Type
-          (* Here, we force [s] to be equivalent to [Type] as there is little
-             (no?) chance that it can be a kind. *)
-          end;
-          let b = Bindlib.unbox (Bindlib.bind_var x (lift b)) in
-          return (mk_LLet(a,t,b))
-      end
-
-  (*  c ⊢ term_of_meta m ts ⇒ a
-     ----------------------------
-         c ⊢ Meta(m,ts) ⇒ a      *)
-  | Meta(m,ts) ->
-      (* The type of [Meta(m,ts)] is the same as the one obtained by applying
-         to [ts] a new symbol having the same type as [m]. *)
-      let s = Term.create_sym (Sign.current_path()) Privat Const
-          Eager true (Pos.none ("?" ^ LibMeta.name m)) !(m.meta_type) [] in
-      if Logger.log_enabled () then
-        log_infr "%areplace meta by fresh symbol" D.depth d;
-      infer d p c
-        (Array.fold_left (fun acc t -> mk_Appl(acc,t)) (mk_Symb s) ts)
-
-(** [check d c t a] checks that the term [t] has type [a] in context [c],
-   possibly adding new unification constraints in [p]. [c] must be
-   well-formed and [a] well-sorted. [d] is the call depth used for debug.
-@raise NotTypable when the term is not typable (when encountering an
-   abstraction over a kind). *)
-and check : int -> problem -> ctxt -> term -> term -> unit = fun d p c t a ->
+and infer : problem -> ctxt -> term -> term * term = fun pb c t ->
+  if Logger.log_enabled () then log "Infer [%a]" Print.pp_term t;
+  let t, t_ty = infer_aux pb c t in
   if Logger.log_enabled () then
-    log_infr "%acheck %a" D.depth d pp_typing (c, t, a);
-  conv d p c (infer (d+1) p c t) a
+    log "Inferred [%a: %a]" Print.pp_term t Print.pp_term t_ty;
+  (t, t_ty)
 
-let infer =
-  let open Stdlib in let r = ref mk_Kind in fun d p c t ->
-  Debug.(record_time Typing (fun () -> r := infer d p c t)); !r
 
-let check d p c t a = Debug.(record_time Typing (fun () -> check d p c t a))
-
-(** [infer_noexn p c t] returns [None] if the type of [t] in context [c]
-   cannot be inferred, or [Some a] where [a] is some type of [t] in the
-   context [c], possibly adding new constraints in [p]. The metavariables of
-   [p] are updated when a metavariable is instantiated or created. [c] must
-   be well sorted. *)
-let infer_noexn : problem -> ctxt -> term -> term option = fun p c t ->
+(** [noexn f cs c args] initialises {!val:constraints} to [cs],
+    calls [f c args] and returns [Some(r,cs)] where [r] is the value of
+    the call to [f] and [cs] is the list of constraints gathered by
+    [f]. Function [f] may raise [NotTypable], in which case [None] is
+    returned. *)
+let noexn : (problem -> ctxt -> 'a -> 'b) -> problem -> ctxt -> 'a ->
+  'b option =
+  fun f pb c args ->
   try
-    if Logger.log_enabled () then
-      log_hndl (Color.blu "infer_noexn %a%a") pp_ctxt c pp_term t;
-    let a = time_of "infer" (fun () -> infer 0 p c t) in
-    if Logger.log_enabled () then
-      log_hndl (Color.blu "@[<v2>@[result of infer_noexn:@ %a@]%a@]")
-        pp_term a
-        (fun fmt constraints -> if constraints <> [] then
-          Format.fprintf fmt ";@ @[constraints:@ %a@]" pp_constrs constraints)
-        !p.to_solve;
-    Some a
+    Some (f pb c args)
   with NotTypable -> None
 
-(** [check_noexn p c t a] tells whether the term [t] has type [a] in the
-   context [c], possibly adding new constraints in |p]. The metavariables of
-   [p] are updated when a metavariable is instantiated or created. The context
-   [c] and the type [a] must be well sorted. *)
-let check_noexn : problem -> ctxt -> term -> term -> bool = fun p c t a ->
-  try
-    if Logger.log_enabled () then
-      log_hndl (Color.blu "check_noexn %a") pp_typing (c, t, a);
-    time_of "check" (fun () -> check 0 p c t a);
-    if Logger.log_enabled () && !p.to_solve <> [] then
-      log_hndl (Color.blu "result of check_noexn:%a") pp_constrs !p.to_solve;
-    true
-  with NotTypable -> false
+let infer_noexn pb c t =
+  if Logger.log_enabled () then
+    log "Top infer %a%a" Print.pp_ctxt c Print.pp_term t;
+  noexn infer pb c t
 
-(** Given a meta [m] of type [Πx1:a1,..,Πxn:an,b], [set_to_prod p m] sets
-   [m] to a product term of the form [Πy:m1[x1;..;xn],m2[x1;..;xn;y]] with
-   [m1] and [m2] fresh metavariables, and adds these metavariables to [p]. *)
-let set_to_prod = set_to_prod 0
+let check_noexn pb c t a =
+  if Logger.log_enabled () then log "Top check \"%a\"" Print.pp_typing
+      (c, t, a);
+  let force pb c (t, a) = force pb c t a in
+  noexn force pb c (t, a)
+
+let check_sort_noexn pb c t : (term * term) option =
+  if Logger.log_enabled () then
+    log "Top check sort %a%a" Print.pp_ctxt c Print.pp_term t;
+  noexn type_enforce pb c t
+
+let infer_noexn pb c t = Option.map snd (infer_noexn pb c t)
+let check_noexn pb c t a = check_noexn pb c t a <> None
+let check_sort_noexn pb c t = check_sort_noexn pb c t <> None

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -192,7 +192,8 @@ and infer_aux : problem -> octxt -> term -> term * term * bool =
       in
       match Eval.whnf (classic c) t_ty with
       | Prod (dom, range) ->
-          if Logger.log_enabled () then log "Appl-prod arg [%a]" Print.pp_term u;
+          if Logger.log_enabled () then
+            log "Appl-prod arg [%a]" Print.pp_term u;
           let u, cu_u = force pb c u dom in
           return cu_u t u range
       | Meta (_, _) ->
@@ -208,7 +209,8 @@ and infer_aux : problem -> octxt -> term -> term * term * bool =
           let domain = unbox domain
           and range = unbox range in
           let t, cu_t' = coerce pb c t t_ty (mk_Prod (domain, range)) in
-          if Logger.log_enabled () then log "Appl-default arg [%a]" Print.pp_term u;
+          if Logger.log_enabled () then
+            log "Appl-default arg [%a]" Print.pp_term u;
           let u, cu_u = force pb c u domain in
           return (cu_t' || cu_u) t u range )
 

--- a/src/core/infer.mli
+++ b/src/core/infer.mli
@@ -7,12 +7,12 @@ open Term
    context [ctx], possibly adding new constraints in [p]. The metavariables of
    [p] are updated when a metavariable is instantiated or created. [ctx] must
    be well sorted. *)
-val infer_noexn : problem -> ctxt -> term -> term option
+val infer_noexn : problem -> ctxt -> term -> (term * term) option
 
 (** [check_noexn p ctx t a] tells whether the term [t] has type [a] in the
    context [ctx], possibly adding new constraints in [p]. The metavariables of
    [p] are updated when a metavariable is instantiated or created. The context
    [ctx] and the type [a] must be well sorted. *)
-val check_noexn : problem -> ctxt -> term -> term -> bool
+val check_noexn : problem -> ctxt -> term -> term -> term option
 
-val check_sort_noexn : problem -> ctxt -> term -> bool
+val check_sort_noexn : problem -> ctxt -> term -> (term * term) option

--- a/src/core/infer.mli
+++ b/src/core/infer.mli
@@ -2,11 +2,6 @@
 
 open Term
 
-(** Given a meta [m] of type [Πx1:a1,..,Πxn:an,b], [set_to_prod p m] sets [m]
-   to a product term of the form [Πy:m1[x1;..;xn],m2[x1;..;xn;y]] with fresh
-   metavariables [m1] and [m2], and updates the metas of the problem [p]. *)
-val set_to_prod : problem -> meta -> unit
-
 (** [infer_noexn p ctx t] returns [None] if the type of [t] in context [ctx]
    cannot be inferred, or [Some a] where [a] is some type of [t] in the
    context [ctx], possibly adding new constraints in [p]. The metavariables of
@@ -19,3 +14,5 @@ val infer_noexn : problem -> ctxt -> term -> term option
    [p] are updated when a metavariable is instantiated or created. The context
    [ctx] and the type [a] must be well sorted. *)
 val check_noexn : problem -> ctxt -> term -> term -> bool
+
+val check_sort_noexn : problem -> ctxt -> term -> bool

--- a/src/core/libMeta.ml
+++ b/src/core/libMeta.ml
@@ -59,15 +59,32 @@ let make : problem -> ?name:string -> ctxt -> term -> term =
   let get_var (x,_,d) = if d = None then Some (mk_Vari x) else None in
   mk_Meta(m, Array.of_list (List.filter_rev_map get_var ctx))
 
+(** [bmake p ?name bctx a] is the boxed version of {!make}: it creates
+    a fresh {e boxed} metavariable in {e boxed} context [bctx] of {e
+    boxed} type [a]. It is the same as [lift (make p c b)] (provided that
+    [bctx] is boxed [c] and [a] is boxed [b]), but more efficient. *)
+let bmake : problem -> ?name:string -> bctxt -> tbox -> tbox =
+  fun p ?name bctx a ->
+  let (a, k) = Ctxt.to_prod_box bctx a in
+  let m = fresh_box ?name p a k in
+  let get_var (x, _) = _Vari x in
+  _Meta_full m (Array.of_list (List.rev_map get_var bctx))
+
 (** [make_codomain p ctx a] creates a fresh metavariable term of type [Type]
-   in the context [ctx] extended with a fresh variable of type [a], and
-   updates [p] with generated metavariables. *)
+    in the context [ctx] extended with a fresh variable of type [a], and
+    updates [p] with generated metavariables. *)
 let make_codomain : problem -> ctxt -> term -> tbinder = fun p ctx a ->
   let x = new_tvar "x" in
   let b = make p ((x, a, None) :: ctx) mk_Type in
   Bindlib.unbox (Bindlib.bind_var x (lift b))
-(* Possible improvement: avoid lift by defining a function _Meta.make
-   returning a tbox. *)
+
+(** [bmake_codomain p bctx a] is [make_codomain p bctx a] but on boxed
+    terms. *)
+let bmake_codomain : problem -> bctxt -> tbox -> tbinder Bindlib.box =
+  fun p bctx a ->
+  let x = new_tvar "x" in
+  let b = bmake p ((x, a) :: bctx) _Type in
+  Bindlib.bind_var x b
 
 (** [iter b f c t] applies the function [f] to every metavariable of [t] and,
    if [x] is a variable of [t] mapped to [v] in the context [c], then to every

--- a/src/core/libTerm.ml
+++ b/src/core/libTerm.ml
@@ -43,6 +43,7 @@ let iter : (term -> unit) -> term -> unit = fun action ->
     action t;
     match t with
     | Wild
+    | Plac _
     | TRef(_)
     | Vari(_)
     | Type

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -126,9 +126,7 @@ let are_quant_args : term list -> bool = fun args ->
   | _ -> false
 
 let pp_meta_name : meta pp = fun ppf m ->
-  match m.meta_name with
-  | Some s -> pp_uid ppf s
-  | None -> out ppf "%d" m.meta_key
+  out ppf "%d" m.meta_key
 
 (** The possible priority levels are [`Func] (top level, including abstraction
    and product), [`Appl] (application) and [`Atom] (smallest priority). *)

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -231,6 +231,7 @@ and pp_term : term pp = fun ppf t ->
     | Kind        -> out ppf "KIND"
     | Symb(s)     -> pp_sym ppf s
     | Meta(m,e)   -> out ppf "%a%a" pp_meta m pp_env e
+    | Plac(_)     -> out ppf "_"
     | Patt(_,n,e) -> out ppf "$%a%a" pp_uid n pp_env e
     | TEnv(t,e)   -> out ppf "$%a%a" pp_term_env t pp_env e
     (* Product and abstraction (only them can be wrapped). *)

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -99,6 +99,7 @@ let link : t -> unit = fun sign ->
         mk_LLet(link_term mk_Appl a, link_term mk_Appl t, link_binder u)
     | Appl(t,u)   -> mk_Appl(link_term mk_Appl t, link_term mk_Appl u)
     | Meta(_,_)   -> assert false
+    | Plac _      -> assert false
     | Patt(i,n,m) -> mk_Patt(i, n, Array.map (link_term mk_Appl) m)
     | TEnv(t,m)   -> mk_TEnv(t, Array.map (link_term mk_Appl) m)
     | Wild        -> assert false
@@ -176,6 +177,7 @@ let unlink : t -> unit = fun sign ->
     | LLet(a,t,u)  -> unlink_term a; unlink_term t; unlink_binder u
     | Appl(t,u)    -> unlink_term t; unlink_term u
     | Meta(_,_)    -> assert false (* Should not happen, uninstantiated. *)
+    | Plac _       -> assert false (* Should be replaced by a term *)
     | Patt(_,_,_)  -> () (* The environment only contains variables. *)
     | TEnv(t,m)    -> unlink_term_env t; Array.iter unlink_term m
     | Wild         -> ()
@@ -274,6 +276,7 @@ let read : string -> t = fun fname ->
       | LLet(a,t,u) -> reset_term a; reset_term t; reset_binder u
       | Appl(t,u)   -> reset_term t; reset_term u
       | Meta(_,_)   -> assert false
+      | Plac _      -> assert false
       | Patt(_,_,m) -> Array.iter reset_term m
       | TEnv(_,m)   -> Array.iter reset_term m
       | Wild        -> ()

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -202,15 +202,14 @@ and sym =
 
 (** {3 Metavariables and related functions} *)
 
-(** Representation of a metavariable,  which corresponds to a place-holder for
-    a (yet unknown) term which free variables are bound by an environment. The
-    substitution of the free variables with the environment is suspended until
-    the metavariable is instantiated (i.e., set to a particular term).  When a
-    metavariable [m] is instantiated,  the suspended substitution is  unlocked
-    and terms of the form {!constructor:Meta}[(m,env)] can be unfolded. *)
+(** Representation of a metavariable,  which corresponds to a yet unknown
+    term typable in some context. The substitution of the free variables
+    of the context is suspended until the metavariable is instantiated
+    (i.e., set to a particular term).  When a metavariable [m] is
+    instantiated,  the suspended substitution is  unlocked and terms of
+    the form {!constructor:Meta}[(m,env)] can be unfolded. *)
  and meta =
   { meta_key   : int (** Unique key. *)
-  ; meta_name  : string option (** Optional name. *)
   ; meta_type  : term ref (** Type. *)
   ; meta_arity : int (** Arity (environment size). *)
   ; meta_value : tmbinder option ref (** Definition. *) }
@@ -247,7 +246,7 @@ let rec pp_term : term pp = fun ppf t ->
   | Appl(a,b) -> out ppf "(%a %a)" pp_term a pp_term b
   | Meta(m,ts) -> out ppf "?%a%a" pp_meta m pp_terms ts
   | Patt(i,s,ts) -> out ppf "$%a_%s%a" (D.option D.int) i s pp_terms ts
-  | Plac(_) -> out ppf "_" 
+  | Plac(_) -> out ppf "_"
   | TEnv(te,ts) -> out ppf "<%a>%a" pp_tenv te pp_terms ts
   | Wild -> out ppf "_"
   | TRef r -> out ppf "&%a" (Option.pp pp_term) !r
@@ -261,9 +260,7 @@ and pp_binder : (term * tbinder) pp = fun ppf (a,b) ->
   let x, b = Bindlib.unbind b in
   out ppf "%a: %a, %a" pp_var x pp_term a pp_term b
 and pp_meta : meta pp = fun ppf m ->
-  match m.meta_name with
-  | None -> out ppf "%d" m.meta_key
-  | Some s -> out ppf "%s" s
+  out ppf "%d" m.meta_key
 and pp_sym : sym pp = fun ppf s -> out ppf "%s" s.sym_name
 and pp_tenv : term_env pp = fun ppf te ->
   match te with

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -274,10 +274,16 @@ and pp_tenv : term_env pp = fun ppf te ->
   | TE_None -> ()
 
 (** Typing context associating a [Bindlib] variable to a type and possibly a
-   definition. The typing environment [x1:A1,..,xn:An] is represented by the
-   list [xn:An;..;x1:A1] in reverse order (last added variable comes
-   first). *)
+    definition. The typing environment [x1:A1,..,xn:An] is represented by the
+    list [xn:An;..;x1:A1] in reverse order (last added variable comes
+    first). *)
 type ctxt = (tvar * term * term option) list
+
+(** Typing context with lifted terms. Used to optimise type checking and avoid
+    lifting terms several times. Definitions are not included because these
+    contexts are used to create meta variables types, which do not use [let]
+    definitions. *)
+type bctxt = (tvar * tbox) list
 
 (** Type of unification constraints. *)
 type constr = ctxt * term * term

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -252,10 +252,16 @@ val minimize_impl : bool list -> bool list
 val pp_term : term pp
 
 (** Typing context associating a [Bindlib] variable to a type and possibly a
-   definition. The typing environment [x1:A1,..,xn:An] is represented by the
-   list [xn:An;..;x1:A1] in reverse order (last added variable comes
-   first). *)
+    definition. The typing environment [x1:A1,..,xn:An] is represented by the
+    list [xn:An;..;x1:A1] in reverse order (last added variable comes
+    first). *)
 type ctxt = (tvar * term * term option) list
+
+(** Typing context with lifted terms. Used to optimise type checking and avoid
+    lifting terms several times. Definitions are not included because these
+    contexts are used to create meta variables types, which do not use [let]
+    definitions. *)
+type bctxt = (tvar * tbox) list
 
 (** Type of unification constraints. *)
 type constr = ctxt * term * term

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -220,15 +220,14 @@ and sym =
 
 (** {3 Metavariables and related functions} *)
 
-(** Representation of a metavariable,  which corresponds to a place-holder for
-    a (yet unknown) term which free variables are bound by an environment. The
-    substitution of the free variables with the environment is suspended until
-    the metavariable is instantiated (i.e., set to a particular term).  When a
-    metavariable [m] is instantiated,  the suspended substitution is  unlocked
-    and terms of the form {!constructor:Meta}[(m,env)] can be unfolded. *)
+(** Representation of a metavariable,  which corresponds to a yet unknown
+    term typable in some context. The substitution of the free variables
+    of the context is suspended until the metavariable is instantiated
+    (i.e., set to a particular term).  When a metavariable [m] is
+    instantiated,  the suspended substitution is  unlocked and terms of
+    the form {!constructor:Meta}[(m,env)] can be unfolded. *)
  and meta =
   { meta_key   : int (** Unique key. *)
-  ; meta_name  : string option (** Optional name. *)
   ; meta_type  : term ref (** Type. *)
   ; meta_arity : int (** Arity (environment size). *)
   ; meta_value : tmbinder option ref (** Definition. *) }

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -57,7 +57,10 @@ type term = private
   (** Pattern variable application (only used in rewriting rules LHS). *)
   | TEnv of term_env * term array
   (** Term environment (only used in rewriting rules RHS). *)
-  | Wild (** Wildcard (only used for surface matching, never in a LHS). *)
+  | Wild (** Wildcard (only used for surface matching, never in LHS). *)
+  | Plac of bool
+  (** [Plac b] is a placeholder, or hole, for not given terms. Boolean
+      [b] is true if the placeholder stands for a type. *)
   | TRef of term option ref (** Reference cell (used in surface matching). *)
   | LLet of term * term * tbinder
   (** [LLet(a, t, u)] is [let x : a ≔ t in u] (with [x] bound in [u]). *)
@@ -381,6 +384,7 @@ val mk_Meta : meta * term array -> term
 val mk_Patt : int option * string * term array -> term
 val mk_TEnv : term_env * term array -> term
 val mk_Wild : term
+val mk_Plac : bool -> term
 val mk_TRef : term option ref -> term
 val mk_LLet : term * term * tbinder -> term
 
@@ -460,6 +464,9 @@ val _TEnv : tebox -> tbox array -> tbox
 
 (** [_Wild] injects the constructor [Wild] into the {!type:tbox} type. *)
 val _Wild : tbox
+
+(** [_Plac] injects the constructor [Plac] into the {!type:tbox} type. *)
+val _Plac : bool -> tbox
 
 (** [_TRef r] injects the constructor [TRef(r)] into the {!type:tbox} type. It
     should be the case that [!r] is [None]. *)

--- a/src/export/dk.ml
+++ b/src/export/dk.ml
@@ -147,6 +147,7 @@ let rec term : bool -> term pp = fun b ppf t ->
   | TRef _ -> assert false
   | Wild -> assert false
   | Meta _ -> assert false
+  | Plac _ -> assert false
 
 (** Translation of declarations. *)
 

--- a/src/export/hrs.ml
+++ b/src/export/hrs.ml
@@ -25,6 +25,7 @@ let print_term : bool -> term pp = fun lhs ->
     match unfold t with
     (* Forbidden cases. *)
     | Meta(_,_)    -> assert false
+    | Plac _       -> assert false
     | TRef(_)      -> assert false
     | TEnv(_,_)    -> assert false
     | Wild         -> assert false

--- a/src/export/xtc.ml
+++ b/src/export/xtc.ml
@@ -37,6 +37,7 @@ let rec print_term : int -> string -> term pp = fun i s ppf t ->
   match unfold t with
   (* Forbidden cases. *)
   | Meta(_,_)               -> assert false
+  | Plac _                  -> assert false
   | TRef(_)                 -> assert false
   | TEnv(_,_)               -> assert false
   | Wild                    -> assert false
@@ -64,6 +65,7 @@ and print_type : int -> string -> term pp = fun i s ppf t ->
   match unfold t with
   (* Forbidden cases. *)
   | Meta(_,_)               -> assert false
+  | Plac _                  -> assert false
   | TRef(_)                 -> assert false
   | TEnv(_,_)               -> assert false
   | Wild                    -> assert false
@@ -126,6 +128,7 @@ let get_vars : sym -> rule -> (string * Term.term) list = fun s r ->
     | Kind
     | TEnv (_, _)
     | Meta (_, _)
+    | Plac _
     | TRef _
     | Wild
     | Prod (_, _)

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -166,7 +166,7 @@ let handle_inductive_symbol : sig_state -> expo -> prop -> match_strat
       (expo = Privat) ss Env.empty p (fun _ -> None) (fun _ -> None) typ
   in
   (* We check that [typ] is typable by a sort. *)
-  Query.check_sort pos p [] typ;
+  let (typ,  _) = Query.check_sort pos p [] typ in
   (* We check that no metavariable remains. *)
   if !p.metas <> MetaSet.empty then begin
     fatal_msg "The type of %a has unsolved metavariables.@." pp_uid name;
@@ -414,14 +414,17 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
     (* Build proof data. *)
     let pdata =
       (* Type of the symbol. *)
-      let a =
+      let (t, a) =
         match a with
-        | Some {elt=t;pos} -> (* Check that the given type is well sorted. *)
-            Query.check_sort pos p [] t; t
+        | Some {elt=a;pos} -> (* Check that the given type is well sorted. *)
+            let (a, _) = Query.check_sort pos p [] a in
+            (t, a)
         | None -> (* If no type is given, infer it from the definition. *)
             match t with
             | None -> assert false
-            | Some {elt=t;pos} -> Query.infer pos p [] t
+            | Some {elt=t;pos} ->
+                let (t, a) = Query.infer pos p [] t in
+                (Some (Pos.make pos t), a)
       in
       (* Get tactics and proof end. *)
       let pdata_proof, pe =

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -458,7 +458,7 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
         let proof_goals = Proof.add_goals_of_problem p [] in
         if p_sym_def then
           (* Add a new focused goal and refine on it. *)
-          let m = LibMeta.fresh p ~name:id a 0 in
+          let m = LibMeta.fresh p a 0 in
           let g = Goal.of_meta m in
           let ps = {proof_name = p_sym_nam; proof_term = Some m;
                     proof_goals = g :: proof_goals} in

--- a/src/handle/proof.ml
+++ b/src/handle/proof.ml
@@ -132,15 +132,6 @@ let meta_of_key : proof_state -> int -> meta option = fun ps key ->
   in
   List.find_map f ps.proof_goals
 
-(** [meta_of_name ps n] returns [Some m] where [m] is a meta of [ps] whose
-   name is [n], or else it returns [None]. *)
-let meta_of_name : proof_state -> string -> meta option = fun ps n ->
-  let f = function
-    | Typ {goal_meta=m;_} when m.meta_name = Some n -> Some m
-    | _ -> None
-  in
-  List.find_map f ps.proof_goals
-
 (** [focus_env ps] returns the scoping environment of the focused goal or the
    empty environment if there is none. *)
 let focus_env : proof_state option -> Env.t = fun ps ->

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -153,18 +153,14 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
            | None -> fatal pos "Not in a definition")
   | _ ->
   let env = Proof.focus_env ps in
-  let meta_of_key =
+  let mok =
     match ps with
     | None -> fun _ -> None
-    | Some ps -> Proof.meta_of_key ps in
-  let meta_of_name =
-    match ps with
-    | None -> fun _ -> None
-    | Some ps -> Proof.meta_of_name ps in
-  let p = new_problem() in
-  let scope ?(typ=false) =
-    Scope.scope_term ~typ true ss env p meta_of_key meta_of_name in
+    | Some ps -> Proof.meta_of_key ps
+  in
+  let scope ?(typ=false) = Scope.scope_term ~typ ~mok true ss env in
   let ctxt = Env.to_ctxt env in
+  let p = new_problem() in
   match elt with
   | P_query_debug(_,_)
   | P_query_verbose(_)

--- a/src/handle/query.mli
+++ b/src/handle/query.mli
@@ -6,20 +6,24 @@ open Parsing.Syntax
 open Common.Pos
 open Proof
 
-(** [infer pos p c t] returns a type for the term [t] in context [c] and under
-   the constraints of [p] if there is one, or
-@raise Fatal. [c] must well sorted. Note that [p] gets modified. *)
-val infer : popt -> problem -> ctxt -> term -> term
+(** [infer pos p c t] returns a couple [(t',a)] where [a] is the type of [t]
+    in context [c] and under constraints of problem [p]; and [t'] is the
+    refinement of [t]. Note that [p] gets modified. Context [c] must well
+    sorted.
+    @raise Fatal if [t] cannot be typed. *)
+val infer : popt -> problem -> ctxt -> term -> term * term
 
 (** [check pos p c t a] checks that the term [t] has type [a] in context [c]
-and under the constraints of [p], or
-@raise Fatal. [c] must well sorted. Note that [p] gets modified. *)
-val check : popt -> problem -> ctxt -> term -> term -> unit
+    and under the constraints of [p], and returns [t] refined. Context [c]
+    must be well-sorted. Note that [p] is modified.
+    @raise Fatal if [t] is not of type [a]. *)
+val check : popt -> problem -> ctxt -> term -> term -> term
 
 (** [check_sort pos p c t] checks that the term [t] has type [Type] or [Kind]
-   in context [c] and under the constraints of [p], or
-@raise Fatal. [c] must be well sorted. *)
-val check_sort : popt -> problem -> ctxt -> term -> unit
+    in context [c] and under the constraints of [p]. Context [c] must be well
+    sorted.
+    @raise Fatal if [t] cannot be typed by a sort (Type or Kind). *)
+val check_sort : popt -> problem -> ctxt -> term -> term * term
 
 (** Result of query displayed on hover in the editor. *)
 type result = (unit -> string) option

--- a/src/handle/rewrite.ml
+++ b/src/handle/rewrite.ml
@@ -318,7 +318,7 @@ let rewrite : Sig_state.t -> problem -> popt -> goal_typ -> bool ->
 
   (* Infer the type of [t] (the argument given to the tactic). *)
   let g_ctxt = Env.to_ctxt g_env in
-  let t_type = Query.infer pos p g_ctxt t in
+  let (t, t_type) = Query.infer pos p g_ctxt t in
 
   (* Check that [t_type ≡ Π x1:a1, ..., Π xn:an, P (eq a l r)]. *)
   let (a, l, r), vars  = get_eq_data cfg pos t_type in

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -28,10 +28,7 @@ let add_axiom : Sig_state.t -> popt -> meta -> Sig_state.t =
   fun ss sym_pos m ->
   let name =
     let i = Stdlib.(incr admitted; !admitted) in
-    let p = Printf.sprintf "_ax%i" i in
-    match m.meta_name with
-    | Some n -> Escape.add_suffix (p ^ "_") n
-    | _ -> p
+    Printf.sprintf "_ax%i" i
   in
   (* Create a symbol with the same type as the metavariable *)
   let ss, sym =

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -118,7 +118,7 @@ type token =
   (* identifiers *)
   | UID of string
   | UID_EXPL of string
-  | UID_META of Syntax.meta_ident
+  | UID_META of int
   | UID_PATT of string
   | QID of Path.t (* in reverse order *)
   | QID_EXPL of Path.t (* in reverse order *)
@@ -284,9 +284,7 @@ let rec token lb =
   | escid -> UID(remove_useless_escape(Utf8.lexeme lb))
   | '@', regid -> UID_EXPL(remove_first lb)
   | '@', escid -> UID_EXPL(remove_useless_escape(remove_first lb))
-  | '?', nat -> UID_META(Numb(int_of_string(remove_first lb)))
-  | '?', regid -> UID_META(Name(remove_first lb))
-  | '?', escid -> UID_META(Name(remove_useless_escape(remove_first lb)))
+  | '?', nat -> UID_META(int_of_string(remove_first lb))
   | '$', regid -> UID_PATT(remove_first lb)
   | '$', escid -> UID_PATT(remove_useless_escape(remove_first lb))
 

--- a/src/parsing/lpParser.mly
+++ b/src/parsing/lpParser.mly
@@ -113,7 +113,7 @@
 
 %token <string> UID
 %token <string> UID_EXPL
-%token <Syntax.meta_ident> UID_META
+%token <int> UID_META
 %token <string> UID_PATT
 %token <Path.t> QID
 %token <Path.t> QID_EXPL
@@ -233,9 +233,9 @@ aterm:
   | ti=term_id { ti }
   | UNDERSCORE { make_pos $sloc P_Wild }
   | TYPE_TERM { make_pos $sloc P_Type }
-  | s=UID_META e=env?
+  | s=UID_META e=env
     { let i = make_pos $loc(s) s in
-      make_pos $sloc (P_Meta(i, Option.map Array.of_list e)) }
+      make_pos $sloc (P_Meta(i,Array.of_list e)) }
   | s=UID_PATT e=env?
     { let i = if s = "_" then None else Some(make_pos $loc(s) s) in
       make_pos $sloc (P_Patt(i, Option.map Array.of_list e)) }

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -84,9 +84,7 @@ let raw_ident : string pp = fun ppf s ->
 let ident : p_ident pp = fun ppf {elt;_} -> raw_ident ppf elt
 
 let meta_ident : p_meta_ident pp = fun ppf {elt;_} ->
-  match elt with
-  | Name s -> raw_ident ppf s
-  | Numb i -> out ppf "%d" i
+  out ppf "%d" elt
 
 let param_id : p_ident option pp = fun ppf idopt ->
   match idopt with
@@ -136,7 +134,8 @@ let rec term : p_term pp = fun ppf t ->
     | (P_Iden(qid,false)   , _    ) -> out ppf "%a" qident qid
     | (P_Iden(qid,true )   , _    ) -> out ppf "@@%a" qident qid
     | (P_Wild              , _    ) -> out ppf "_"
-    | (P_Meta(mid,ts)      , _    ) -> out ppf "?%a%a" meta_ident mid env ts
+    | (P_Meta(mid,ts)      , _    ) ->
+        out ppf "?%a%a" meta_ident mid env (Some ts)
     | (P_Patt(idopt,ts)    , _    ) -> out ppf "$%a%a" param_id idopt env ts
     | (P_Appl(t,u)         , `Appl)
     | (P_Appl(t,u)         , `Func) -> out ppf "@[%a@ %a@]" appl t atom u

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -68,12 +68,8 @@ type lhs_data =
 
 type mode =
   | M_Term of
-      { mutable m_term_new_metas : problem
-      (** Metavariables generated during scoping. *)
-      ; m_term_meta_of_name : string -> meta option
-      (** Returns the meta with the given name. *)
-      ; m_term_meta_of_key : int -> meta option
-      (** Returns the meta with the give key. *)
+      { m_term_meta_of_key : int -> meta option
+      (** Allows to retrieve generated metas by their key. *)
       ; m_term_prv : bool
       (** Indicate if private symbols are allowed. *) }
   (** Standard scoping mode for terms, holding a map for metavariables
@@ -130,22 +126,6 @@ let fresh_patt : lhs_data -> string option -> tbox array -> tbox =
       let i = fresh_index () in
       _Patt (Some i) (Printf.sprintf "v%i" i) ts
 
-(** [fresh_meta_type md env] calls [Env.fresh_meta_type] and updates the set
-   of new metavariables in [md]. *)
-let fresh_meta_type : mode -> env -> tbox = fun md env ->
-  match md with
-  | M_Term d -> Env.fresh_meta_type d.m_term_new_metas env
-  | M_RHS d -> Env.fresh_meta_type d.m_rhs_new_metas env
-  | _ -> assert false
-
-(** [fresh_meta_tbox md env] calls [Env.fresh_meta_tbox] and updates the set
-   of new metavariables in [md]. *)
-let fresh_meta_tbox : mode -> env -> tbox = fun md env ->
-  match md with
-  | M_Term d -> Env.fresh_meta_tbox d.m_term_new_metas env
-  | M_RHS d -> Env.fresh_meta_tbox d.m_rhs_new_metas env
-  | _ -> assert false
-
 (** [is_invalid_bindlib_id s] says whether [s] can be safely used as variable
    name in Bindlib. Indeed, because Bindlib converts any suffix consisting of
    a sequence of digits into an integer, and increment it, we cannot use as
@@ -184,18 +164,18 @@ let _ =
   assert (valid "case_ex02_intro10")
 
 (** [scope ~typ md ss env t] turns a parser-level term [t] into an actual
-   term. The variables of the environment [env] may appear in [t], and the
-   scoping mode [md] changes the behaviour related to certain
-   constructors. The signature state [ss] is used to convert identifiers into
-   symbols according to [find_qid]. [typ] tells whether we scope a type
-   (default is false). *)
-let rec scope :
-  ?typ:bool -> int -> mode -> sig_state -> env -> p_term -> tbox =
-  fun ?(typ=false) k md ss env t ->
+    term. The variables of the environment [env] may appear in [t],
+    and the scoping mode [md] changes the behaviour related to certain
+    constructors. The signature state [ss] is used to convert identifiers
+    into symbols according to [find_qid]. If [typ] is true, then [t]
+    must be a type (defaults to false). *)
+let rec scope : ?typ:bool -> int -> mode -> sig_state -> env -> p_term ->
+  tbox =
+  fun ?(typ=false) k md ss env t -> 
   scope_parsed ~typ k md ss env (Pratt.parse ss env t)
 
-(** [scope_parsed ~typ md ss env t] turns a parser-level Pratt-parsed term [t]
-   into an actual term. *)
+(** [scope_parsed ~typ md ss env t] turns a parser-level, Pratt-parsed term [t]
+    into an actual term. *)
 and scope_parsed :
   ?typ:bool -> int -> mode -> sig_state -> env -> p_term -> tbox =
   fun ?(typ=false) k md ss env t ->
@@ -282,7 +262,7 @@ and scope_domain : int -> mode -> sig_state -> env -> p_term option -> tbox =
   match a, md with
   | (Some {elt=P_Wild;_}|None), M_LHS data ->
       fresh_patt data None (Env.to_tbox env)
-  | (Some {elt=P_Wild;_}|None), _ -> fresh_meta_type md env
+  | (Some {elt=P_Wild;_}|None), _ -> _Plac true
   | Some a, _ -> scope ~typ:true k md ss env a
 
 (** [scope_binder ~typ ~warn mode ss cons env params_list t] scopes [t] in
@@ -302,7 +282,7 @@ and scope_binder : ?typ:bool -> ?warn:bool -> int -> mode -> sig_state ->
         begin
           match t with
           | Some t -> scope ~typ (k+1) md ss env t
-          | None -> fresh_meta_type md env
+          | None -> _Plac true
         end
     | (idopts,typopt,_implicit)::params_list ->
       let dom = scope_domain (k+1) md ss env typopt in
@@ -355,42 +335,16 @@ and scope_head :
     _TEnv (_TE_Vari x) (Env.to_tbox env)
   | (P_Wild, M_LHS data) -> fresh_patt data None (Env.to_tbox env)
   | (P_Wild, M_Patt) -> _Wild
-  | (P_Wild, (M_RHS _|M_Term _)) ->
-    if typ then fresh_meta_type md env else fresh_meta_tbox md env
+  | (P_Wild, (M_RHS _|M_Term _)) -> _Plac typ
 
-  | (P_Meta({elt;pos},ts), M_Term d) ->
-      let m =
-        match elt with
-        | Name id ->
-            begin
-              match d.m_term_meta_of_name id with
-              | Some m -> m
-              | None ->
-              match LibMeta.of_name id d.m_term_new_metas with
-              | Some m -> m
-              | None ->
-               (* We create a new metavariable [m1] of type [TYPE] and a new
-                  metavariable [m] of name [id] and type [m1]. *)
-                  let vs = Env.to_tbox env in
-                  let arity = Array.length vs in
-                  let m1 =
-                    LibMeta.fresh d.m_term_new_metas
-                      (Env.to_prod env _Type) arity in
-                  let a = Env.to_prod env (_Meta m1 vs) in
-                  LibMeta.fresh d.m_term_new_metas ~name:id a arity
-             end
-        | Numb i ->
-            match d.m_term_meta_of_key i with
-            | Some m -> m
-            | None -> fatal pos "Unknown metavariable ?%d." i
-      in
-      let ts =
-        match ts with
-        | None -> Env.to_tbox env (* [?M] is equivalent to [?M[env]]. *)
-        | Some ts -> Array.map (scope (k+1) md ss env) ts
-      in
-      _Meta m ts
-  | (P_Meta(_,_), _) -> fatal t.pos "Metavariables are not allowed here."
+  | (P_Meta({elt;pos} as mk,ts), M_Term {m_term_meta_of_key;_}) -> (
+      match m_term_meta_of_key elt with
+      | None -> 
+          fatal pos "Metavariable %a not found among generated variables: \
+                     metavariables can only be created by the system."
+            Pretty.meta_ident mk
+      | Some m -> _Meta m (Array.map (scope (k + 1) md ss env) ts))
+  | (P_Meta(_), _) -> fatal t.pos "Metavariables are not allowed here."
 
   | (P_Patt(id,ts), M_LHS(d)) ->
       (* Check that [ts] are variables. *)
@@ -521,35 +475,24 @@ let scope =
   let open Stdlib in let r = ref _Kind in fun ?(typ=false) k md ss env t ->
   Debug.(record_time Scoping (fun () -> r := scope ~typ k md ss env t)); !r
 
-(** [scope ~typ prv ss env p mok mon t] turns a pterm [t] into a term in the
-   signature state [ss], the environment [env] (for bound variables). [mok k]
-   says if there already exists a meta with key [k]. [mon n] says if there
-   already exists a meta with name [n]. Generated metas are added to
-   [p]. [prv] indicates if private symbols are allowed. [typ] indicates
-   whether [t] should be a type (default is false). *)
-let scope_term :
-      ?typ:bool -> bool -> sig_state -> env
-      -> problem -> (int -> meta option) -> (string -> meta option)
-      -> p_term -> term =
-  fun ?(typ=false) m_term_prv ss env
-      m_term_new_metas m_term_meta_of_key m_term_meta_of_name t ->
-  let md = M_Term {m_term_new_metas; m_term_meta_of_key;
-                   m_term_meta_of_name; m_term_prv} in
+(** [scope ~typ ~mok prv expo ss env p t] turns a pterm [t] into a term in
+    the signature state [ss] and environment [env] (for bound
+    variables). If [expo] is {!constructor:Public}, then the term must not
+    contain any private subterms. If [~typ] is [true], then [t] must be
+    a type (defaults to [false]). No {b new} metavariables may appear in
+    [t], but metavariables in the image of [mok] may be used. The function
+    [mok] defaults to the function constant to [None] *)
+let scope_term : ?typ:bool -> ?mok:(int -> meta option) ->
+  bool -> sig_state -> env -> p_term -> term =
+  fun ?(typ=false) ?(mok=fun _ -> None) m_term_prv ss env t ->
+  let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
   Bindlib.unbox (scope ~typ 0 md ss env t)
 
-(** [scope_term_with_params expo ss env p mok mon t] is similar to [scope_term
-   expo ss env p mok mon t] except that [t] must be a product or an
-   abstraction. In this case, no warnings are issued if the top binders are
-   constant. *)
-let scope_term_with_params :
-      bool -> sig_state -> env
-      -> problem -> (int -> meta option) -> (string -> meta option)
-      -> p_term -> term =
-  fun m_term_prv ss env
-      m_term_new_metas m_term_meta_of_key m_term_meta_of_name t ->
+let scope_term_with_params : ?mok:(int -> meta option) -> bool
+  -> sig_state -> env -> p_term -> term =
+  fun ?(mok=fun _ -> None) m_term_prv ss env t ->
   if Logger.log_enabled () then log_scop "%a" Pretty.term t;
-  let md = M_Term {m_term_new_metas; m_term_meta_of_key;
-                   m_term_meta_of_name; m_term_prv} in
+  let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
   let scope_b typ cons xs u =
     Bindlib.unbox (scope_binder ~typ ~warn:false 0 md ss cons env xs (Some u))
   in
@@ -569,8 +512,7 @@ let patt_vars : p_term -> (string * int) list * string list =
     | P_Type             -> acc
     | P_Iden(_)          -> acc
     | P_Wild             -> acc
-    | P_Meta(_,None)     -> acc
-    | P_Meta(_,Some ts)  -> Array.fold_left (patt_vars) acc ts
+    | P_Meta(_,ts)       -> Array.fold_left patt_vars acc ts
     | P_Patt(id,ts)      -> add_patt acc id ts
     | P_Appl(t,u)        -> patt_vars (patt_vars acc t) u
     | P_Arro(a,b)        -> patt_vars (patt_vars acc a) b

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -171,11 +171,11 @@ let _ =
     must be a type (defaults to false). *)
 let rec scope : ?typ:bool -> int -> mode -> sig_state -> env -> p_term ->
   tbox =
-  fun ?(typ=false) k md ss env t -> 
+  fun ?(typ=false) k md ss env t ->
   scope_parsed ~typ k md ss env (Pratt.parse ss env t)
 
-(** [scope_parsed ~typ md ss env t] turns a parser-level, Pratt-parsed term [t]
-    into an actual term. *)
+(** [scope_parsed ~typ md ss env t] turns a parser-level, Pratt-parsed
+    term [t] into an actual term. *)
 and scope_parsed :
   ?typ:bool -> int -> mode -> sig_state -> env -> p_term -> tbox =
   fun ?(typ=false) k md ss env t ->
@@ -337,7 +337,7 @@ and scope_head :
 
   | (P_Meta({elt;pos} as mk,ts), M_Term {m_term_meta_of_key;_}) -> (
       match m_term_meta_of_key elt with
-      | None -> 
+      | None ->
           fatal pos "Metavariable %a not found among generated variables: \
                      metavariables can only be created by the system."
             Pretty.meta_ident mk

--- a/src/parsing/scope.mli
+++ b/src/parsing/scope.mli
@@ -10,25 +10,25 @@ open Syntax
 open Common
 open Pos
 
-(** [scope ~typ prv ss env p mok mon t] turns a pterm [t] into a term in the
-   signature state [ss], the environment [env] (for bound variables). [mok k]
-   says if there already exists a meta with key [k]. [mon n] says if there
-   already exists a meta with name [n]. Generated metas are added to [p].
-   [prv] indicates if private symbols are allowed. [typ] indicates whether [t]
-   should be type (default is false). *)
-val scope_term : ?typ:bool (* default: false *)
-      -> bool -> sig_state -> env
-      -> problem -> (int -> meta option) -> (string -> meta option)
-      -> p_term -> term
+(** [scope ~typ ~mok prv expo ss env p t] turns a pterm [t] into a term in
+    the signature state [ss] and environment [env] (for bound
+    variables). If [expo] is {!constructor:Public}, then the term must not
+    contain any private subterms. If [~typ] is [true], then [t] must be
+    a type (defaults to [false]). No {b new} metavariables may appear in
+    [t], but metavariables in the image of [mok] may be used. The function
+    [mok] defaults to the function constant to [None] *)
+val scope_term :
+  ?typ:bool (* default: false *) -> 
+  ?mok:(int -> meta option) ->
+  bool -> sig_state -> env -> p_term -> term
 
-(** [scope_term_with_params prv ss env p mok mon t] is similar to [scope_term
-   expo ss env p mok mon t] except that [t] must be a product or an
-   abstraction. In this case, no warnings are issued if the top binders are
-   constant. *)
+
+(** [scope_term_with_params expo ss env t] is similar to [scope_term expo ss
+   env t] except that [t] must be a product or an abstraction. In this case,
+   no warnings are issued if the top binders are constant. *)
 val scope_term_with_params :
-      bool -> sig_state -> env
-      -> problem -> (int -> meta option) -> (string -> meta option)
-      -> p_term -> term
+  ?mok:(int -> meta option) ->
+  bool -> sig_state -> env -> p_term -> term
 
 (** Representation of a rewriting rule prior to SR-checking. *)
 type pre_rule =

--- a/src/parsing/scope.mli
+++ b/src/parsing/scope.mli
@@ -18,7 +18,7 @@ open Pos
     [t], but metavariables in the image of [mok] may be used. The function
     [mok] defaults to the function constant to [None] *)
 val scope_term :
-  ?typ:bool (* default: false *) -> 
+  ?typ:bool (* default: false *) ->
   ?mok:(int -> meta option) ->
   bool -> sig_state -> env -> p_term -> term
 

--- a/src/parsing/scope.mli
+++ b/src/parsing/scope.mli
@@ -22,14 +22,6 @@ val scope_term :
   ?mok:(int -> meta option) ->
   bool -> sig_state -> env -> p_term -> term
 
-
-(** [scope_term_with_params expo ss env t] is similar to [scope_term expo ss
-   env t] except that [t] must be a product or an abstraction. In this case,
-   no warnings are issued if the top binders are constant. *)
-val scope_term_with_params :
-  ?mok:(int -> meta option) ->
-  bool -> sig_state -> env -> p_term -> term
-
 (** Representation of a rewriting rule prior to SR-checking. *)
 type pre_rule =
   { pr_sym      : sym

--- a/src/parsing/syntax.ml
+++ b/src/parsing/syntax.ml
@@ -28,8 +28,7 @@ let rec check_distinct : p_ident option list -> unit = function
   | Some {elt=id;_} :: idopts -> check_notin id idopts; check_distinct idopts
 
 (** Identifier of a metavariable. *)
-type meta_ident = Name of string | Numb of int
-type p_meta_ident = meta_ident loc
+type p_meta_ident = int loc
 
 (** Representation of a module name. *)
 type p_path = Path.t loc
@@ -44,8 +43,8 @@ and p_term_aux =
   | P_Iden of p_qident * bool (** Identifier. The boolean indicates whether
                                  the identifier is prefixed by "@". *)
   | P_Wild (** Underscore. *)
-  | P_Meta of p_meta_ident * p_term array option
-    (** Meta-variable application. *)
+  | P_Meta of p_meta_ident * p_term array
+    (** Meta-variable with explicit substitution. *)
   | P_Patt of p_ident option * p_term array option (** Pattern. *)
   | P_Appl of p_term * p_term (** Application. *)
   | P_Arro of p_term * p_term (** Arrow. *)
@@ -292,7 +291,7 @@ let rec eq_p_term : p_term eq = fun {elt=t1;_} {elt=t2;_} ->
   | P_Wild, P_Wild -> true
   | P_Iden(q1,b1), P_Iden(q2,b2) -> eq_p_qident q1 q2 && b1 = b2
   | P_Meta(i1,ts1), P_Meta(i2,ts2) ->
-      eq_p_meta_ident i1 i2 && Option.eq (Array.eq eq_p_term) ts1 ts2
+      eq_p_meta_ident i1 i2 && Array.eq eq_p_term ts1 ts2
   | P_Patt(io1,ts1), P_Patt(io2,ts2) ->
       Option.eq eq_p_ident io1 io2
       && Option.eq (Array.eq eq_p_term) ts1 ts2
@@ -474,11 +473,10 @@ let fold_idents : ('a -> p_qident -> 'a) -> 'a -> p_command list -> 'a =
 
     | P_Type
     | P_Wild
-    | P_Meta (_, None)
     | P_Patt (_, None)
     | P_NLit _ -> a
 
-    | P_Meta (_, Some ts)
+    | P_Meta (_, ts)
     | P_Patt (_, Some ts) -> Array.fold_left (fold_term_vars vs) a ts
 
     | P_Appl (t, u)

--- a/src/tool/sr.ml
+++ b/src/tool/sr.ml
@@ -62,6 +62,7 @@ let patt_to_tenv : term_env Bindlib.var array -> term -> tbox = fun vars ->
     | Kind        -> assert false (* Cannot appear in LHS. *)
     | Prod(_,_)   -> assert false (* Cannot appear in LHS. *)
     | LLet(_,_,_) -> assert false (* Cannot appear in LHS. *)
+    | Plac _      -> assert false (* Cannot appear in LHS. *)
     | Meta(_,_)   -> assert false (* Cannot appear in LHS. *)
     | TEnv(_,_)   -> assert false (* Cannot appear in LHS. *)
     | Wild        -> assert false (* Cannot appear in LHS. *)
@@ -116,6 +117,8 @@ let symb_to_tenv
           (_LLet (symb_to_tenv a) (symb_to_tenv t) b, ts)
       | Meta(_,_)   ->
           fatal pos "A metavariable could not be instantiated in the RHS."
+      | Plac _      ->
+          fatal pos "A placeholder hasn't been instantiated in the RHS."
       | TEnv(_,_)   -> assert false (* TEnv have been replaced in [t]. *)
       | Appl(_,_)   -> assert false (* Cannot appear in RHS. *)
       | Patt(_,_,_) -> assert false (* Cannot appear in RHS. *)

--- a/src/tool/sr.ml
+++ b/src/tool/sr.ml
@@ -181,7 +181,7 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
   (* Infer the typing constraints of the LHS. *)
   match Infer.infer_noexn p [] lhs_with_metas with
   | None -> fatal pos "The LHS is not typable."
-  | Some ty_lhs ->
+  | Some (lhs_with_metas, ty_lhs) ->
   (* Try to simplify constraints. Don't check typing when instantiating
      a metavariable. *)
   if not (Unif.solve_noexn ~type_check:false p) then
@@ -227,8 +227,9 @@ let check_rule : Scope.pre_rule Pos.loc -> rule = fun ({pos; elt} as pr) ->
      the function symbols of [symbols]. *)
   (* Compute the constraints for the RHS to have the same type as the LHS. *)
   let p = new_problem() in
-  if not (Infer.check_noexn p [] rhs_with_metas ty_lhs) then
-    fatal pos "The RHS does not have the same type as the LHS.";
+  match Infer.check_noexn p [] rhs_with_metas ty_lhs with
+  | None -> fatal pos "The RHS does not have the same type as the LHS."
+  | Some rhs_with_metas ->
   (* Solving the typing constraints of the RHS. *)
   if not (Unif.solve_noexn p) then
     fatal pos "The rewriting rule does not preserve typing.";

--- a/tests/OK/767.lp
+++ b/tests/OK/767.lp
@@ -1,4 +1,11 @@
 constant symbol Set : TYPE;
 injective symbol τ : Set → TYPE;
 constant symbol B : Set;
-type λ (f : _ → _ → τ B) (g : τ B → τ B) b1 b2, f (g b1) (g b2);
+type λ (f : _ → τ B) (b: τ B), f b;
+// type λ (f : _ → _ → τ B) (g : τ B → τ B) b1 b2, f (g b1) (g b2);
+// The command above fails because the instantiation of the second placeholder
+// triggers a unification problem τ B == ?1[g b1], which fails because `g b1`
+// is not a variable.
+// "arguments are not distinct variables: g b1"
+// It worked before this PR because the arrow notation would specify that the
+// second meta-variable cannot depend on the first argument.

--- a/tests/OK/admit.lp
+++ b/tests/OK/admit.lp
@@ -23,7 +23,7 @@ admitted;
 // Two metas, one depending on the other
 symbol prop2: Prf prop1 → Prop;
 symbol g (π: Prf prop1) (_: Prf (prop2 π)): Prop;
-symbol π_g: Prf (g _ ?named_meta)
+symbol π_g: Prf (g _ _)
 begin
   // Adds two axioms
 admitted;

--- a/tests/OK/natproofs.lp
+++ b/tests/OK/natproofs.lp
@@ -37,7 +37,7 @@ end;
 opaque symbol add0r n : P (n + 0 = n)
 ≔ begin
   // FIXME try to infer the predicate
-  refine nat_ind (λ n, n + 0 = n) ?CZ ?CS
+  refine nat_ind (λ n, n + 0 = n) _ _
   {// Case Z
   simplify;
   reflexivity}
@@ -51,7 +51,7 @@ end;
 opaque symbol add_succ_r n m : P (n + (s m) = s (n + m))
 ≔ begin
   assume n m;
-  refine nat_ind (λ n, n + (s m) = s (n + m)) ?case_0 ?case_s n
+  refine nat_ind (λ n, n + (s m) = s (n + m)) _ _ n
   {// Case Z
   simplify;
   refine refl nat (s m)}
@@ -67,7 +67,7 @@ end;
 opaque symbol addcomm n m : P (n + m = m + n)
 ≔ begin
   assume n m;
-  refine nat_ind (λ n, n + m = m + n) ?case_0 ?case_s n
+  refine nat_ind (λ n, n + m = m + n) _ _ n
   {// Case Z
   simplify;
   refine eq_sym _ (m + z) m (add0r m)} // TODO add a symmetry tactic

--- a/tests/OK/perf_rw_fib-nonRightLin.lp
+++ b/tests/OK/perf_rw_fib-nonRightLin.lp
@@ -12,5 +12,5 @@ with fib3 (s (s z))      ↪ 1
 with fib3 (s (s (s $x))) ↪ (fib3 ($x + 2)) + (fib3 ($x + 1)) + (fib3 $x);
 
 assert ⊢ fib 15 ≡ 610;
-assert ⊢ fib 24 ≡ 46368;
+compute fib 24; // ≡ 46368;
 compute fib3 21;

--- a/tests/OK/rewrite1.lp
+++ b/tests/OK/rewrite1.lp
@@ -122,7 +122,7 @@ end;
 // [z] is right neutral for add.
 opaque symbol add0r n : P (eq nat (add n z) n)
 ≔ begin
-  refine nat_ind (λ n, eq _ (add n z) n) ?CZ ?CS
+  refine nat_ind (λ n, eq _ (add n z) n) _ _
   { // Case Z;
   simplify;
   refine refl nat z }
@@ -136,7 +136,7 @@ end;
 opaque symbol add_succ_r : Π n m, P (eq nat (add n (s m)) (s (add n m)))
 ≔ begin
   assume n m;
-  refine nat_ind (λ n, eq nat (add n (s m)) (s (add n m))) ?CZ.[n; m] ?CS.[n; m] n
+  refine nat_ind (λ n, eq nat (add n (s m)) (s (add n m))) _ _ n
   { // Case Z
   simplify;
   refine refl nat (s m) }
@@ -152,7 +152,7 @@ end;
 opaque symbol addcomm : Π n m, P (eq nat (add n m) (add m n))
 ≔ begin
   assume n m;
-  refine nat_ind (λ (n:N), eq nat (add n m) (add m n)) ?CZ.[n; m] ?CS.[n; m] n
+  refine nat_ind (λ (n:N), eq nat (add n m) (add m n)) _ _ n
   { // Case Z
   simplify;
   generalize m; symmetry; refine add0r y }

--- a/tests/OK/tautologies.lp
+++ b/tests/OK/tautologies.lp
@@ -6,7 +6,7 @@ rule T bool ↪ B;
 opaque symbol and_idempotent (a:B) : P (bool_and a a = a)
 ≔ begin
   assume a;
-  refine bool_ind (λ a, bool_and a a = a) ?CT.[a] ?CF.[a] a
+  refine bool_ind (λ a, bool_and a a = a) _ _ a
   {reflexivity}
   {reflexivity}
 end;

--- a/tests/OK/triangular.lp
+++ b/tests/OK/triangular.lp
@@ -5,4 +5,4 @@ symbol triangle : N → N;
 rule triangle (s $n) ↪ (s $n) + (triangle $n)
 with triangle z      ↪ z;
 
-assert ⊢ triangle 300 ≡ 45150;
+compute triangle 300; // ≡ 45150;

--- a/tests/rewriting.ml
+++ b/tests/rewriting.ml
@@ -11,9 +11,7 @@ let parse_term s =
   | Syntax.P_query {elt=Syntax.P_query_normalize (t, _); _} -> t
   | _ -> assert false
 
-let scope_term ss =
-  Scope.scope_term true ss [] (Term.new_problem())
-    (fun _ -> None) (fun _ -> None)
+let scope_term ss = Scope.scope_term true ss []
 
 let add_sym ss id =
   Sig_state.add_symbol ss Public Defin Eager true (Pos.none id) Term.mk_Kind []


### PR DESCRIPTION
This PR is equivalent to #563 but commits are separated in a more intelligible way:

1. Implementation of the basis of the new typechecker
2. Modifying signatures to make the type checker bidirectional (allowed to changed the type checked term), and subsequently modify calls to the typechecker
3. Introduce placeholders and generate meta-variables during type checking: placeholders of the form "?" are replaced by meta-variables during typechecking (or fully instantiated terms).

## Changelog

Introduce a new type checker which is able to refine (aka modify) terms. The algorithm is taken from <https://arxiv.org/abs/1202.4905>.

### Added

- Tems may now be _placeholders_. Placeholders are holes in the concrete syntax. They are refined into metavariables. *Placeholders cannot appear nonlinearly in terms*. From [A Bidirectional Refinement Algorithm...](https://arxiv.org/abs/1202.4905), p. 31,
  > Non linear placeholders are not allowed since two occurrences could be in contexts that bind different set of variables and instantiation with terms that live in one context would make no sense in the other one.

### Removed

- Unused variable warning: whether a variable is used or not cannot be decided while scoping anymore since placeholders that do not depend on variables may be refined later into metavariables that may depend on them.
- Placeholders do not depend on variables, hence the syntax `?M.[x;y]` is obsolete, only `?M` is valid

### Changed

- Naming metavariable is now useless since they must be linear.
- Because placeholders are simple holes, the term `_ → _` is scoped into a full dependent product `Π x: M, N` where `N` is a metavariable that depend on `x` (see file `tests/OK/767.lp`)
- Type checking takes longer because of refinement (not only the type must be destructured and rebuilt),
  |         | master | refiner |
  |---------|--------|---------|
  | holide  | 7:0    | 11:33   |
  | iprover | 5:58   | 6:50    |
- scoping term is more straightforward (no metavariable fetching), thus `scope_term` simplified