### PR TITLE
improve performances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ### Unreleased
 
+#### Improve evaluation and convertibility test (2021-06-02)
+
+- fix `_LLet` by calling mk_LLet
+- substitute arguments in TEnv's at construction time (mk_TEnv)
+- improve eq_modulo to avoid calling whnf when possible
+- use `Eval.pure_eq_modulo` in Infer and Unif (fix #693)
+
 #### Improve logs (2021-06-01)
 
 - add Base.out = Format.fprintf

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -77,7 +77,7 @@ let logger_hndl = new_logger 'h' "hndl" "command handling"
 let log_hndl = logger_hndl.logger
 
 (** To print time data. *)
-let do_print_time = ref true
+let do_print_time = ref false
 
 (** Print current time. *)
 let print_time : string -> unit = fun s ->

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -440,7 +440,7 @@ let hnf : ctxt -> term -> term = fun c t ->
 let eq_modulo : ctxt -> term -> term -> bool = fun c ->
   eq_modulo whnf (cfg_of_ctx c true)
 
-(** [eq_modulo c a b] tests the convertibility of [a] and [b] in context
+(** [pure_eq_modulo c a b] tests the convertibility of [a] and [b] in context
    [c] with no side effects. *)
 let pure_eq_modulo : ctxt -> term -> term -> bool = fun c a b ->
   Timed.pure_test (fun (c,a,b) -> eq_modulo c a b) (c,a,b)

--- a/src/core/eval.mli
+++ b/src/core/eval.mli
@@ -38,11 +38,11 @@ val tree_walk : problem -> ctxt -> dtree -> stack -> (term * stack) option
 val whnf : ?rewrite:bool -> ctxt -> term -> term
 
 (** [eq_modulo c a b] tests the convertibility of [a] and [b] in context
-   [c]. *)
+   [c]. WARNING: may have side effects in TRef's introduced by whnf. *)
 val eq_modulo : ctxt -> term -> term -> bool
 
-(** [eq_modulo c a b] tests the convertibility of [a] and [b] in context
-   [c]. WARNING: may have side effects in TRef's introduced by whnf. *)
+(** [pure_eq_modulo c a b] tests the convertibility of [a] and [b] in context
+   [c] with no side effects. *)
 val pure_eq_modulo : ctxt -> term -> term -> bool
 
 (** [snf c t] computes the strong normal form of the term [t] in the context

--- a/src/core/eval.mli
+++ b/src/core/eval.mli
@@ -41,6 +41,10 @@ val whnf : ?rewrite:bool -> ctxt -> term -> term
    [c]. *)
 val eq_modulo : ctxt -> term -> term -> bool
 
+(** [eq_modulo c a b] tests the convertibility of [a] and [b] in context
+   [c]. WARNING: may have side effects in TRef's introduced by whnf. *)
+val pure_eq_modulo : ctxt -> term -> term -> bool
+
 (** [snf c t] computes the strong normal form of the term [t] in the context
    [c]. It unfolds variables defined in the context [c]. *)
 val snf : ctxt -> term -> term

--- a/src/core/eval.mli
+++ b/src/core/eval.mli
@@ -37,8 +37,8 @@ val tree_walk : problem -> ctxt -> dtree -> stack -> (term * stack) option
    [c]. User-defined rewrite rules are used only if [~rewrite = true]. *)
 val whnf : ?rewrite:bool -> ctxt -> term -> term
 
-(** [eq_modulo ctx a b] tests the equivalence of [a] and [b] modulo rewriting
-   and the unfolding of variables of the context [ctx] (δ-reduction). *)
+(** [eq_modulo c a b] tests the convertibility of [a] and [b] in context
+   [c]. *)
 val eq_modulo : ctxt -> term -> term -> bool
 
 (** [snf c t] computes the strong normal form of the term [t] in the context

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -41,10 +41,10 @@ let set_to_prod : int -> problem -> meta -> unit = fun d p m ->
 (** [conv d p c a b] adds the the constraint [(c,a,b)] in [p], if [a] and
    [b] are not convertible. [d] is the call depth used for debug. *)
 let conv : int -> problem -> ctxt -> term -> term -> unit = fun d p c a b ->
-  if not (Eval.eq_modulo c a b) then
-    (let cstr = (c,a,b) in
-     p := {!p with to_solve = cstr::!p.to_solve};
-     if !log_enabled then log_infr (mag "%aadd %a") D.depth d pp_constr cstr)
+  let cstr = (c,a,b) in
+  if not (Timed.pure_test (fun (c,a,b) -> Eval.eq_modulo c a b) cstr) then
+    (if !log_enabled then log_infr (mag "%aadd %a") D.depth d pp_constr cstr;
+    p := {!p with to_solve = cstr::!p.to_solve})
 
 (** Exception that may be raised by type inference. *)
 exception NotTypable

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -41,10 +41,10 @@ let set_to_prod : int -> problem -> meta -> unit = fun d p m ->
 (** [conv d p c a b] adds the the constraint [(c,a,b)] in [p], if [a] and
    [b] are not convertible. [d] is the call depth used for debug. *)
 let conv : int -> problem -> ctxt -> term -> term -> unit = fun d p c a b ->
-  let cstr = (c,a,b) in
-  if not (Timed.pure_test (fun (c,a,b) -> Eval.eq_modulo c a b) cstr) then
-    (if !log_enabled then log_infr (mag "%aadd %a") D.depth d pp_constr cstr;
-    p := {!p with to_solve = cstr::!p.to_solve})
+  if not (Eval.pure_eq_modulo c a b) then
+    (let cstr = (c,a,b) in
+     if !log_enabled then log_infr (mag "%aadd %a") D.depth d pp_constr cstr;
+     p := {!p with to_solve = cstr::!p.to_solve})
 
 (** Exception that may be raised by type inference. *)
 exception NotTypable

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -490,11 +490,16 @@ let mk_Prod (a,b) = Prod (a,b)
 let mk_Abst (a,b) = Abst (a,b)
 let mk_Meta (m,ts) = Meta (m,ts)
 let mk_Patt (i,s,ts) = Patt (i,s,ts)
-let mk_TEnv (te,ts) = TEnv (te,ts)
 let mk_Wild = Wild
 let mk_TRef x = TRef x
+
 let mk_LLet (a,t,u) =
   if Bindlib.binder_constant u then Bindlib.subst u Kind else LLet (a,t,u)
+
+let mk_TEnv (te,ts) =
+  match te with
+  | TE_Some mb -> Bindlib.msubst mb ts
+  | _ -> TEnv (te,ts)
 
 (* We make the equality of terms modulo commutative and
    associative-commutative symbols syntactic by always ordering arguments in
@@ -676,7 +681,7 @@ let _Patt : int option -> string -> tbox array -> tbox = fun i n ts ->
 
 (** [_TEnv te ts] lifts a term environment to the {!type:tbox} type. *)
 let _TEnv : tebox -> tbox array -> tbox = fun te ts ->
-  Bindlib.box_apply2 (fun te ts -> TEnv(te,ts)) te (Bindlib.box_array ts)
+  Bindlib.box_apply2 (fun te ts -> mk_TEnv(te,ts)) te (Bindlib.box_array ts)
 
 (** [_Wild] injects the constructor [Wild] into the {!type:tbox} type. *)
 let _Wild : tbox = Bindlib.box Wild
@@ -688,7 +693,7 @@ let _TRef : term option ref -> tbox = fun r ->
 
 (** [_LLet t a u] lifts let binding [let x := t : a in u<x>]. *)
 let _LLet : tbox -> tbox -> tbinder Bindlib.box -> tbox =
-  Bindlib.box_apply3 (fun a t u -> LLet(a, t, u))
+  Bindlib.box_apply3 (fun a t u -> mk_LLet(a, t, u))
 
 (** [_TE_Vari x] injects a term environment variable [x] into the {!type:tbox}
     type so that it may be available for binding. *)

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -367,15 +367,12 @@ let rec unfold : term -> term = fun t ->
         | None    -> t
         | Some(b) -> unfold (Bindlib.msubst b ts)
       end
-  | TEnv(TE_Some(b), ts) -> unfold (Bindlib.msubst b ts)
   | TRef(r) ->
       begin
         match !r with
         | None    -> t
         | Some(v) -> unfold v
       end
-  | LLet(_,_,u) when Bindlib.binder_constant u ->
-      unfold (Bindlib.subst u Kind)
   | _ -> t
 
 (** {b NOTE} that {!val:unfold} must (almost) always be called before matching

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -37,7 +37,7 @@ let add_unif_rule_constr : problem -> constr -> unit = fun p (c,t,u) ->
   | None -> ignore (Infer.infer_noexn p c u)
   | Some a ->
       match Infer.infer_noexn p c u with
-      | Some b when not (Eval.eq_modulo c a b) -> add_constr p (c,a,b)
+      | Some b when not (Eval.pure_eq_modulo c a b) -> add_constr p (c,a,b)
       | _ -> ()
 
 (** [try_unif_rules p c s t] tries to simplify the unification problem [c
@@ -131,7 +131,7 @@ let instantiate : problem -> ctxt -> meta -> term array -> term -> bool =
    constraints of [p]. *)
 let add_to_unsolved : problem -> ctxt -> term -> term -> unit =
   fun p c t1 t2 ->
-  if Eval.eq_modulo c t1 t2 then
+  if Eval.pure_eq_modulo c t1 t2 then
     (if !log_enabled then log_unif "equivalent terms")
   else if not (try_unif_rules p c t1 t2) then
     (if !log_enabled then log_unif "move to unsolved";

--- a/tests/OK/693_assume.lp
+++ b/tests/OK/693_assume.lp
@@ -1,0 +1,32 @@
+symbol Prop : TYPE;
+symbol Type : TYPE;
+
+injective symbol π : Prop → TYPE;
+
+symbol ∀ {x : Prop} : (π x → Prop) → Prop;
+
+rule π (∀ $f) ↪  Π w, π ($f w);
+
+symbol ⊤ : Prop;
+symbol top : π ⊤;
+
+symbol ⊥ : Prop;
+
+symbol ⇒ A B ≔ @∀ A (λ _, B); notation ⇒ infix right 14;
+
+symbol bool : TYPE;
+symbol true : bool;
+symbol false : bool;
+
+symbol if : Prop → Prop → bool → Prop;
+
+rule if $vt _   true  ↪ $vt
+with if _   $vf false ↪ $vf;
+
+symbol is_true ≔ if ⊤ ⊥;
+
+symbol test b : π (is_true b ⇒ ⊤)
+≔ begin
+  assume b H;
+  refine top;
+end;


### PR DESCRIPTION
- substituting arguments in TEnv's at construction time (mk_TEnv)
- improving eq_modulo to avoid calling whnf when possible

This improves compilation time by 13% on make tests (6.7s instead of 7.7s).