### PR TITLE
fix whnf_stk with AC symbols

### DIFF
--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -166,19 +166,20 @@ let eq_modulo : (config -> term -> term) -> (config -> term -> term -> bool) =
 (** Abstract machine stack. *)
 type stack = term list
 
-(** [appl_to_tref t] transforms {!constructor:Appl} into
+(** [to_tref t] transforms {!constructor:Appl} into
    {!constructor:TRef}. *)
-let appl_to_tref : term -> term = fun t ->
+let to_tref : term -> term = fun t ->
   match t with
   | Appl _ -> mk_TRef(ref (Some t))
+  | Symb s when s.sym_prop <> Const -> mk_TRef(ref (Some t))
   | t -> t
 
 (** [whnf c t] computes a whnf of the term [t] wrt configuration [c]. *)
 let rec whnf : config -> term -> term = fun c t ->
   (*if !log_enabled then log_eval "whnf %a" pp_term t;*)
-  let s = Stdlib.(!steps) in
+  let n = Stdlib.(!steps) in
   let u, stk = whnf_stk c t [] in
-  let r = if Stdlib.(!steps) <> s then add_args u stk else unfold t in
+  let r = if Stdlib.(!steps) <> n then add_args u stk else unfold t in
   (*if !log_enabled then
     log_eval "whnf %a%a = %a" pp_ctxt c.context pp_term t pp_term r;*)
   r
@@ -191,7 +192,7 @@ and whnf_stk : config -> term -> stack -> term * stack = fun c t stk ->
       pp_ctxt c.context pp_term t (D.list pp_term) stk;*)
   let t = unfold t in
   match t, stk with
-  | Appl(f,u), stk -> whnf_stk c f (appl_to_tref u::stk)
+  | Appl(f,u), stk -> whnf_stk c f (to_tref u::stk)
   | Abst(_,f), u::stk ->
     Stdlib.incr steps; whnf_stk c (Bindlib.subst f u) stk
   | LLet(_,t,u), stk ->
@@ -204,10 +205,16 @@ and whnf_stk : config -> term -> stack -> term * stack = fun c t stk ->
       match tree_walk c !(s.sym_dtree) stk with
       | None -> r
       | Some(t',stk') ->
+        Stdlib.incr steps;
+        let h, ts =
+          match get_args t' with
+          | (Symb s as h), ts when is_modulo s -> add_args h (ts @ stk'), []
+          | _ -> t', stk'
+        in
         if !log_enabled then
           log_eval "tree_walk %a%a %a = %a %a" pp_ctxt c.context
-            pp_term t (D.list pp_term) stk pp_term t' (D.list pp_term) stk';
-        Stdlib.incr steps; whnf_stk c t' stk'
+            pp_term t (D.list pp_term) stk pp_term h (D.list pp_term) ts;
+        whnf_stk c h ts
     end
   | (Vari x, stk) as r ->
     begin match VarMap.find_opt x c.defmap with
@@ -344,7 +351,7 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
         else
           let s = Stdlib.(!steps) in
           let (t, args) = whnf_stk c examined [] in
-          let args = if store then List.map appl_to_tref args else args in
+          let args = if store then List.map to_tref args else args in
           (* If some reduction has been performed by [whnf_stk] ([steps <>
              0]), update the value of [examined] which may be stored into
              [vars]. *)

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -204,11 +204,13 @@ and whnf_stk : config -> term -> stack -> term * stack = fun c t stk ->
     | None ->
       match tree_walk c !(s.sym_dtree) stk with
       | None -> r
-      | Some(t',stk') ->
+      | Some (t', stk') ->
         Stdlib.incr steps;
         let h, ts =
           match get_args t' with
-          | (Symb s as h), ts when is_modulo s -> add_args h (ts @ stk'), []
+          | Symb s as h, ts when is_modulo s ->
+            (* AC-canonical form of [add_args t' stk']. *)
+            add_args h (ts @ stk'), []
           | _ -> t', stk'
         in
         if !log_enabled then

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -219,11 +219,10 @@ and whnf_stk : config -> term -> stack -> term * stack = fun c t stk ->
       match tree_walk c !(s.sym_dtree) stk with
       | None -> h, stk
       | Some (t', stk') ->
-        Stdlib.incr steps;
         if !log_enabled then
           log_eval "tree_walk %a%a %a = %a %a" pp_ctxt c.context
             pp_term t (D.list pp_term) stk pp_term t' (D.list pp_term) stk';
-        whnf_stk c t' stk'
+        Stdlib.incr steps; whnf_stk c t' stk'
     end
   | (Vari x, stk) as r ->
     begin match VarMap.find_opt x c.defmap with

--- a/tests/OK/suc-alg.lp
+++ b/tests/OK/suc-alg.lp
@@ -1,0 +1,49 @@
+// universe levels as in Agda syntax
+constant symbol L : TYPE;
+symbol Z : L;
+symbol S : L → L;
+symbol ∪ : L → L → L; notation ∪ infix right 10;
+symbol V : L → L; // to mark universe level variables
+
+// natural numbers
+constant symbol ℕ : TYPE;
+constant symbol 0ₙ : ℕ; builtin "0" ≔ 0ₙ;
+constant symbol sₙ : ℕ → ℕ; builtin "+1" ≔ sₙ;
+
+// max function on natural numbers
+symbol ⊕ₙ : ℕ → ℕ → ℕ; notation ⊕ₙ infix right 10;
+
+rule 0ₙ ⊕ₙ $y ↪ $y
+with $x ⊕ₙ 0ₙ ↪ $x
+with sₙ $x ⊕ₙ sₙ $y ↪ sₙ ($x ⊕ₙ $y);
+
+// addition on natural numbers
+symbol + : ℕ → ℕ → ℕ; notation + infix right 5;
+
+rule 0ₙ + $y ↪ $y
+with $x + 0ₙ ↪ $x
+with sₙ $x + $y ↪ sₙ ($x + $y)
+with $x + sₙ $y ↪ sₙ ($x + $y)
+with ($x + $y) + $z ↪ $x + ($y + $z);
+
+// s-max algebra: successor iterator and max operator on levels
+constant symbol z : L;
+symbol s : ℕ → L → L;
+associative commutative symbol ⊕ : L → L → L; // associative right by default
+notation ⊕ infix right 10;
+
+// Translation of Agda's levels to the s-max algebra 
+rule Z       ↪ s 0 z
+with S $x    ↪ s 1 $x
+with $x ∪ $y ↪ $x ⊕ $y
+with V $x    ↪ s 0 ($x ⊕ z);
+
+// rules for deciding the s-max algebra
+rule s $p (s $q $x) ↪ s ($p + $q) $x
+with s $p ($x ⊕ $y) ↪ s $p $x ⊕ s $p $y;
+
+rule s $p $x ⊕ s $q $x ↪ s ($p ⊕ₙ $q) $x
+with s $p $x ⊕ (s $q $x ⊕ $y) ↪ s ($p ⊕ₙ $q) $x ⊕ $y;
+
+// test
+assert x y ⊢ ((S (S (V x))) ∪ (S (V y))) ∪ Z ≡ s 1 y ⊕ (s 2 x ⊕ s 2 z);

--- a/tests/OK/suc-alg.lp
+++ b/tests/OK/suc-alg.lp
@@ -45,5 +45,6 @@ with s $p ($x ⊕ $y) ↪ s $p $x ⊕ s $p $y;
 rule s $p $x ⊕ s $q $x ↪ s ($p ⊕ₙ $q) $x
 with s $p $x ⊕ (s $q $x ⊕ $y) ↪ s ($p ⊕ₙ $q) $x ⊕ $y;
 
-// test
+// tests
 assert x y ⊢ ((S (S (V x))) ∪ (S (V y))) ∪ Z ≡ s 1 y ⊕ (s 2 x ⊕ s 2 z);
+assert a ⊢ s 1 (a ⊕ z) ⊕ s 2 (a ⊕ z) ≡ s 2 a ⊕ s 2 z;


### PR DESCRIPTION
fix #712 by normalizing all the stack elements and reorder them when the head is a C or AC symbol
