### PR TITLE
Sign.link: update decision trees of symbols in sign_deps

### DIFF
--- a/src/core/sig_state.ml
+++ b/src/core/sig_state.ml
@@ -33,7 +33,7 @@ type t = sig_state
 let create_sign : Path.t -> Sign.t = fun sign_path ->
   let d = Sign.dummy () in
   {d with sign_path;
-          sign_deps = ref (Path.Map.singleton Unif_rule.path [])}
+          sign_deps = ref (Path.Map.singleton Unif_rule.path StrMap.empty)}
 
 (** [add_symbol ss expo prop mstrat opaq id typ impl def] generates a new
    signature state from [ss] by creating a new symbol with expo [e], property

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -138,6 +138,10 @@ let link : t -> unit = fun sign ->
     let g n rs =
       let s = find sign n in
       s.sym_rules := !(s.sym_rules) @ List.map link_rule rs
+      (* /!\ The update of s.sym_dtree is not done here but later as a side
+         effect of link (dtree update of sign_symbols below) since
+         dependencies are recompiled or loaded and, in case a dependency is
+         loaded, it is linked too. *)
     in
     StrMap.iter g sm
   in

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -137,8 +137,7 @@ let link : t -> unit = fun sign ->
     let sign = Path.Map.find mp !loaded in
     let g n rs =
       let s = find sign n in
-      s.sym_rules := !(s.sym_rules) @ List.map link_rule rs;
-      Tree.update_dtree s
+      s.sym_rules := !(s.sym_rules) @ List.map link_rule rs
     in
     StrMap.iter g sm
   in

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -193,21 +193,21 @@ let unlink : t -> unit = fun sign ->
     let (_, rhs) = Bindlib.unmbind r.rhs in
     unlink_term rhs
   in
-  let fn _ (s,_) =
+  let f _ (s,_) =
     unlink_term !(s.sym_type);
     Option.iter unlink_term !(s.sym_def);
     List.iter unlink_rule !(s.sym_rules)
   in
-  StrMap.iter fn !(sign.sign_symbols);
-  let gn _ ls = List.iter (fun (_, r) -> unlink_rule r) ls in
-  Path.Map.iter gn !(sign.sign_deps);
+  StrMap.iter f !(sign.sign_symbols);
+  let f _ ls = List.iter (fun (_, r) -> unlink_rule r) ls in
+  Path.Map.iter f !(sign.sign_deps);
   StrMap.iter (fun _ s -> unlink_sym s) !(sign.sign_builtins);
   SymMap.iter (fun s _ -> unlink_sym s) !(sign.sign_notations);
   let unlink_ind_data i =
     List.iter unlink_sym i.ind_cons; unlink_sym i.ind_prop
   in
-  let fn s i = unlink_sym s; unlink_ind_data i in
-  SymMap.iter fn !(sign.sign_ind)
+  let f s i = unlink_sym s; unlink_ind_data i in
+  SymMap.iter f !(sign.sign_ind)
 
 (** [add_symbol sign expo prop mstrat opaq name typ impl] adds in the
    signature [sign] a symbol with name [name], exposition [expo], property
@@ -301,14 +301,14 @@ let read : string -> t = fun fname ->
     StrMap.iter (fun _ (s,_) -> reset_sym s) !(sign.sign_symbols);
     StrMap.iter (fun _ s -> shallow_reset_sym s) !(sign.sign_builtins);
     SymMap.iter (fun s _ -> shallow_reset_sym s) !(sign.sign_notations);
-    let fn (_,r) = reset_rule r in
-    Path.Map.iter (fun _ -> List.iter fn) !(sign.sign_deps);
+    let f (_,r) = reset_rule r in
+    Path.Map.iter (fun _ -> List.iter f) !(sign.sign_deps);
     let shallow_reset_ind_data i =
       shallow_reset_sym i.ind_prop;
       List.iter shallow_reset_sym i.ind_cons
     in
-    let fn s i = shallow_reset_sym s; shallow_reset_ind_data i in
-    SymMap.iter fn !(sign.sign_ind);
+    let f s i = shallow_reset_sym s; shallow_reset_ind_data i in
+    SymMap.iter f !(sign.sign_ind);
     sign
   in
   reset_timed_refs sign
@@ -357,8 +357,8 @@ let add_inductive : t -> sym -> sym list -> sym -> int -> int -> unit =
     that [sign] itself appears at the end of the list. *)
 let rec dependencies : t -> (Path.t * t) list = fun sign ->
   (* Recursively compute dependencies for the immediate dependencies. *)
-  let fn p _ l = dependencies (Path.Map.find p !loaded) :: l in
-  let deps = Path.Map.fold fn !(sign.sign_deps) [[(sign.sign_path, sign)]] in
+  let f p _ l = dependencies (Path.Map.find p !loaded) :: l in
+  let deps = Path.Map.fold f !(sign.sign_deps) [[(sign.sign_path, sign)]] in
   (* Minimize and put everything together. *)
   let rec minimize acc deps =
     let not_here (p,_) =

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -67,7 +67,8 @@ let handle_require : compiler -> bool -> sig_state -> p_path -> sig_state =
   (* Compile required path (adds it to [Sign.loaded] among other things) *)
   ignore (compile p);
   (* Add the dependency (it was compiled already while parsing). *)
-  ss.signature.sign_deps := Path.Map.add p [] !(ss.signature.sign_deps);
+  ss.signature.sign_deps
+    := Path.Map.add p StrMap.empty !(ss.signature.sign_deps);
   if b then open_sign ss (Path.Map.find p !(Sign.loaded)) else ss
 
 (** [handle_require_as compile ss p id] handles the command

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -88,6 +88,8 @@ let rec compile_with :
       Path.Map.iter compile !(sign.sign_deps);
       loaded := Path.Map.add mp sign !loaded;
       Sign.link sign;
+      if Path.Map.mem Unif_rule.path !(sign.sign_deps) then
+        Tree.update_dtree Unif_rule.equiv;
       Console.out 2 "Loaded \"%s\"\n%!" obj; sign
     end
 

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -88,6 +88,9 @@ let rec compile_with :
       Path.Map.iter compile !(sign.sign_deps);
       loaded := Path.Map.add mp sign !loaded;
       Sign.link sign;
+      (* Since Unif_rule.sign is always assumed to be already loaded, we need
+         to explicitly update the decision tree of Unif_rule.equiv since it is
+         not done in linking which normally follows loading. *)
       if Path.Map.mem Unif_rule.path !(sign.sign_deps) then
         Tree.update_dtree Unif_rule.equiv;
       Console.out 2 "Loaded \"%s\"\n%!" obj; sign


### PR DESCRIPTION
Alternative to #720 for fixing #718 which optimizes decision tree updates for Unif_rule.equiv.
It also changes the type of sign_deps from `(string * rule) list Path.Map.t ref` to `rule list StrMap.t Path.Map.t ref`,
and does a few renamings in sign.ml.