### PR TITLE
Record time of various tasks

### DIFF
--- a/src/cli/config.ml
+++ b/src/cli/config.ml
@@ -16,6 +16,7 @@ type config =
   ; no_warnings : bool
   ; debug       : string
   ; no_colors   : bool
+  ; record_time : bool
   ; too_long    : float
   ; confluence  : string option
   ; termination : string option }
@@ -32,6 +33,7 @@ let default_config =
   ; no_warnings = false
   ; debug       = ""
   ; no_colors   = false
+  ; record_time = false
   ; too_long    = infinity
   ; confluence  = None
   ; termination = None }
@@ -47,6 +49,7 @@ let init : config -> unit = fun cfg ->
   Error.no_wrn := cfg.no_warnings;
   Logger.set_default_debug cfg.debug;
   Color.color := not cfg.no_colors;
+  Debug.do_record_time := cfg.record_time;
   Handle.Command.too_long := cfg.too_long;
   (* Log some configuration data. *)
   if Logger.log_enabled () then
@@ -138,6 +141,13 @@ let no_colors : bool Term.t =
   in
   Arg.(value & flag & info ["no-colors"] ~doc)
 
+let record_time : bool Term.t =
+  let doc =
+    "Print statistics on the time spent in different tasks (parsing, typing, \
+     etc.). Note that it slows down the program."
+  in
+  Arg.(value & flag & info ["record-time"] ~doc)
+
 let too_long : float Term.t =
   let doc =
     "Print a warning every time that a command requires more than $(docv) \
@@ -170,14 +180,14 @@ let termination : string option Term.t =
 
 (** [full] gathers the command line arguments common to most commands. *)
 let full : config Term.t =
-  let fn gen_obj lib_root map_dir verbose no_warnings
-      debug no_colors too_long confluence termination =
-    { gen_obj ; lib_root ; map_dir ; verbose ; no_warnings
-    ; debug ; no_colors ; too_long ; confluence ; termination }
+  let fn gen_obj lib_root map_dir verbose no_warnings debug
+      no_colors record_time too_long confluence termination =
+    { gen_obj ; lib_root ; map_dir ; verbose ; no_warnings ; debug
+    ; no_colors ; record_time ; too_long ; confluence ; termination }
   in
   let open Term in
-  const fn $ gen_obj $ lib_root $ map_dir $ verbose
-  $ no_warnings $ debug $ no_colors $ too_long $ confluence $ termination
+  const fn $ gen_obj $ lib_root $ map_dir $ verbose $ no_warnings $ debug
+  $ no_colors $ record_time $ too_long $ confluence $ termination
 
 (** [minimal] gathers the minimal command line options to enable debugging and
     access to the library root. *)

--- a/src/cli/config.ml
+++ b/src/cli/config.ml
@@ -108,8 +108,7 @@ let verbose : int option Term.t =
   let doc =
     "Set the verbosity level to $(docv). A value smaller or equal to 0 will \
      disable all printing (on standard output). Greater numbers lead to more \
-     and more informations being written to standard output. There is no \
-     difference between the values of 3 and more."
+     and more informations being written to standard output."
   in
   Arg.(value & opt (some int) None & info ["verbose"; "v"] ~docv:"NUM" ~doc)
 

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -58,7 +58,10 @@ let parse_cmd : Config.t -> string list -> unit = fun cfg files ->
     Config.init cfg;
     (* We save time to run each file in the same environment. *)
     let time = Time.save () in
-    let handle file = Time.restore time; ignore (Compile.parse_file file) in
+    let consume _ = () in
+    let handle file =
+      Time.restore time;
+      Debug.stream_iter consume (Compile.parse_file file) in
     List.iter handle files
   in
   Error.handle_exceptions run
@@ -258,6 +261,8 @@ let default_cmd =
   Term.info "lambdapi" ~version ~doc ~sdocs
 
 let _ =
+  let t0 = Sys.time () in
+  Stdlib.at_exit (Debug.print_time t0);
   Printexc.record_backtrace true;
   let cmds =
     [ check_cmd ; parse_cmd ; beautify_cmd ; lsp_server_cmd

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -81,7 +81,7 @@ let log_hndl = log_hndl.pp
 let do_print_time = ref false
 
 (** [time_of f x] computes [f x] and prints the time for computing it if
-   [!di_print_time] is true. *)
+   [!do_print_time] is true. *)
 let time_of : string -> (unit -> 'b) -> 'b = fun s f ->
   if !do_print_time && Logger.log_enabled () then begin
     let t0 = Sys.time () in

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -77,13 +77,9 @@ end
 let log_hndl = Logger.make 'h' "hndl" "command handling"
 let log_hndl = log_hndl.pp
 
-(** To print time when calling [time_of]. *)
-let do_print_time = ref false
-
-(** [time_of f x] computes [f x] and prints the time for computing it if
-   [!do_print_time] is true. *)
+(** [time_of f x] computes [f x] and prints the time for computing it. *)
 let time_of : string -> (unit -> 'b) -> 'b = fun s f ->
-  if !do_print_time && Logger.log_enabled () then begin
+  if false && Logger.log_enabled () then begin
     let t0 = Sys.time () in
     let log _ = log_hndl "%s time: %f" s (Sys.time () -. t0) in
     try f () |> D.log_and_return log
@@ -92,6 +88,7 @@ let time_of : string -> (unit -> 'b) -> 'b = fun s f ->
 
 (** To record time with [record_time]. *)
 let do_record_time = ref true
+let do_print_time = ref true
 
 (** [record_time s f] records under [s] the time spent in calling [f].
     [print_time ()] outputs the recorded times. *)
@@ -107,6 +104,7 @@ let record_time, print_time =
   in
   let do_not_record_time _ f = f () in
   let print_time : float -> unit -> unit = fun t0 () ->
+    if not !do_print_time then () else
     let tt = Sys.time () -. t0 in
     Format.printf "time %.2fs" tt;
     let map = !map in

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -87,7 +87,7 @@ let time_of : string -> (unit -> 'b) -> 'b = fun s f ->
   end else f ()
 
 (** To record time with [record_time]. *)
-let do_record_time = ref true
+let do_record_time = ref false
 let do_print_time = ref true
 
 type task =

--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -78,7 +78,7 @@ let log_hndl = Logger.make 'h' "hndl" "command handling"
 let log_hndl = log_hndl.pp
 
 (** To print time when calling [time_of]. *)
-let do_print_time = ref true
+let do_print_time = ref false
 
 (** [time_of f x] computes [f x] and prints the time for computing it if
    [!di_print_time] is true. *)

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -440,6 +440,10 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
   in
   walk tree stk 0 VarMap.empty IntMap.empty
 
+let whnf =
+  let open Stdlib in let r = ref mk_Kind in fun c t ->
+  Debug.record_time "eval" (fun () -> r := whnf c t); !r
+
 (** [snf c t] computes a snf of [t], unfolding the variables defined in the
    context [c]. *)
 let snf : ctxt -> term -> term = fun c t ->

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -440,10 +440,6 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
   in
   walk tree stk 0 VarMap.empty IntMap.empty
 
-let whnf =
-  let open Stdlib in let r = ref mk_Kind in fun c t ->
-  Debug.record_time "eval" (fun () -> r := whnf c t); !r
-
 (** [snf c t] computes a snf of [t], unfolding the variables defined in the
    context [c]. *)
 let snf : ctxt -> term -> term = fun c t ->
@@ -452,6 +448,10 @@ let snf : ctxt -> term -> term = fun c t ->
   let r = if Stdlib.(!steps = 0) then unfold t else u in
   (*if Logger.log_enabled () then
     log_eval "snf %a%a\n= %a" pp_ctxt c pp_term t pp_term r;*) r
+
+let snf =
+  let open Stdlib in let r = ref mk_Kind in fun c t ->
+  Debug.(record_time Rewriting (fun () -> r := snf c t)); !r
 
 (** [hnf c t] computes a hnf of [t], unfolding the variables defined in the
    context [c], and using user-defined rewrite rules. *)
@@ -462,10 +462,18 @@ let hnf : ctxt -> term -> term = fun c t ->
   (*if Logger.log_enabled () then
     log_eval "hnf %a%a\n= %a" pp_ctxt c pp_term t pp_term r;*) r
 
+let hnf =
+  let open Stdlib in let r = ref mk_Kind in fun c t ->
+  Debug.(record_time Rewriting (fun () -> r := hnf c t)); !r
+
 (** [eq_modulo c a b] tests the convertibility of [a] and [b] in context
    [c]. WARNING: may have side effects in TRef's introduced by whnf. *)
 let eq_modulo : ctxt -> term -> term -> bool = fun c ->
   eq_modulo whnf (cfg_of_ctx c true)
+
+let eq_modulo =
+  let open Stdlib in let r = ref false in fun c t u ->
+  Debug.(record_time Rewriting (fun () -> r := eq_modulo c t u)); !r
 
 (** [pure_eq_modulo c a b] tests the convertibility of [a] and [b] in context
    [c] with no side effects. *)
@@ -481,6 +489,10 @@ let whnf : ?rewrite:bool -> ctxt -> term -> term = fun ?(rewrite=true) c t ->
   (*if Logger.log_enabled () then
     log_eval "whnf %a%a\n= %a" pp_ctxt c pp_term t pp_term r;*) r
 
+let whnf =
+  let open Stdlib in let r = ref mk_Kind in fun ?rewrite c t ->
+  Debug.(record_time Rewriting (fun () -> r := whnf ?rewrite c t)); !r
+
 (** [simplify t] computes a beta whnf of [t] belonging to the set S such that:
 - terms of S are in beta whnf normal format
 - if [t] is a product, then both its domain and codomain are in S. *)
@@ -491,6 +503,10 @@ let rec simplify : term -> term = fun t ->
      let b = Bindlib.bind_var x (lift (simplify b)) in
      mk_Prod (simplify a, Bindlib.unbox b)
   | h, ts -> add_args_map h (whnf ~rewrite:false []) ts
+
+let simplify =
+  let open Stdlib in let r = ref mk_Kind in fun t ->
+  Debug.(record_time Rewriting (fun () -> r := simplify t)); !r
 
 (** If [s] is a non-opaque symbol having a definition, [unfold_sym s t]
    replaces in [t] all the occurrences of [s] by its definition. *)
@@ -543,6 +559,10 @@ let tree_walk : problem -> ctxt -> dtree -> stack -> (term * stack) option =
   fun p c dt ts ->
   let c = {context=c; defmap=Ctxt.to_map c; problem=p; rewrite=true} in
   tree_walk c dt ts
+
+let tree_walk =
+  let open Stdlib in let r = ref None in fun p c t s ->
+  Debug.(record_time Rewriting (fun () -> r := tree_walk p c t s)); !r
 
 (** Dedukti evaluation strategies. *)
 type strategy =

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -189,6 +189,10 @@ and check : int -> problem -> ctxt -> term -> term -> unit = fun d p c t a ->
     log_infr "%acheck %a" D.depth d pp_typing (c, t, a);
   conv d p c (infer (d+1) p c t) a
 
+let infer =
+  let open Stdlib in let r = ref mk_Kind in fun d p c t ->
+  Debug.record_time "infer" (fun () -> r := infer d p c t); !r
+
 (** [infer_noexn p c t] returns [None] if the type of [t] in context [c]
    cannot be inferred, or [Some a] where [a] is some type of [t] in the
    context [c], possibly adding new constraints in [p]. The metavariables of
@@ -222,4 +226,7 @@ let check_noexn : problem -> ctxt -> term -> term -> bool = fun p c t a ->
     true
   with NotTypable -> false
 
+(** Given a meta [m] of type [Πx1:a1,..,Πxn:an,b], [set_to_prod p m] sets
+   [m] to a product term of the form [Πy:m1[x1;..;xn],m2[x1;..;xn;y]] with
+   [m1] and [m2] fresh metavariables, and adds these metavariables to [p]. *)
 let set_to_prod = set_to_prod 0

--- a/src/core/infer.ml
+++ b/src/core/infer.ml
@@ -191,7 +191,9 @@ and check : int -> problem -> ctxt -> term -> term -> unit = fun d p c t a ->
 
 let infer =
   let open Stdlib in let r = ref mk_Kind in fun d p c t ->
-  Debug.record_time "infer" (fun () -> r := infer d p c t); !r
+  Debug.(record_time Typing (fun () -> r := infer d p c t)); !r
+
+let check d p c t a = Debug.(record_time Typing (fun () -> check d p c t a))
 
 (** [infer_noexn p c t] returns [None] if the type of [t] in context [c]
    cannot be inferred, or [Some a] where [a] is some type of [t] in the

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -156,6 +156,8 @@ let link : t -> unit = fun sign ->
   let f s i m = SymMap.add (link_symb s) (link_ind_data i) m in
   sign.sign_ind := SymMap.fold f !(sign.sign_ind) SymMap.empty
 
+let link s = Debug.record_time "link" (fun () -> link s)
+
 (** [unlink sign] removes references to external symbols (and thus signatures)
     in the signature [sign]. This function is used to minimize the size of our
     object files, by preventing a recursive inclusion of all the dependencies.

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -243,8 +243,8 @@ let write : t -> string -> unit = fun sign fname ->
   match Unix.fork () with
   | 0 -> let oc = open_out fname in
          unlink sign; Marshal.to_channel oc sign [Marshal.Closures];
-         close_out oc; exit 0
-  | i -> ignore (Unix.waitpid [] i)
+         close_out oc; Stdlib.(Debug.do_print_time := false); exit 0
+  | i -> ignore (Unix.waitpid [] i); Stdlib.(Debug.do_print_time := true)
 
 (* NOTE [Unix.fork] is used to safely [unlink] and write an object file, while
    preserving a valid copy of the written signature in the parent process. *)

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -156,7 +156,7 @@ let link : t -> unit = fun sign ->
   let f s i m = SymMap.add (link_symb s) (link_ind_data i) m in
   sign.sign_ind := SymMap.fold f !(sign.sign_ind) SymMap.empty
 
-let link s = Debug.record_time "link" (fun () -> link s)
+let link s = Debug.(record_time Sharing (fun () -> link s))
 
 (** [unlink sign] removes references to external symbols (and thus signatures)
     in the signature [sign]. This function is used to minimize the size of our
@@ -249,7 +249,7 @@ let write : t -> string -> unit = fun sign fname ->
          close_out oc; Stdlib.(Debug.do_print_time := false); exit 0
   | i -> ignore (Unix.waitpid [] i); Stdlib.(Debug.do_print_time := true)
 
-let write s n = Debug.record_time "write" (fun () -> write s n)
+let write s n = Debug.(record_time Writing (fun () -> write s n))
 
 (** [read fname] reads a signature from the object file [fname]. Note that the
     file can only be read properly if it was build with the same binary as the
@@ -320,7 +320,7 @@ let read : string -> t = fun fname ->
 
 let read =
   let open Stdlib in let r = ref (dummy ()) in fun n ->
-  Debug.record_time "read" (fun () -> r := read n); !r
+  Debug.(record_time Reading (fun () -> r := read n)); !r
 
 (** [add_rule sign sym r] adds the new rule [r] to the symbol [sym].  When the
     rule does not correspond to a symbol of signature [sign],  it is stored in

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -240,19 +240,23 @@ let strip_private : t -> unit = fun sign ->
 
 (** [write sign file] writes the signature [sign] to the file [fname]. *)
 let write : t -> string -> unit = fun sign fname ->
+  (* [Unix.fork] is used to safely [unlink] and write an object file, while
+     preserving a valid copy of the written signature in the parent
+     process. *)
   match Unix.fork () with
   | 0 -> let oc = open_out fname in
          unlink sign; Marshal.to_channel oc sign [Marshal.Closures];
          close_out oc; Stdlib.(Debug.do_print_time := false); exit 0
   | i -> ignore (Unix.waitpid [] i); Stdlib.(Debug.do_print_time := true)
 
-(* NOTE [Unix.fork] is used to safely [unlink] and write an object file, while
-   preserving a valid copy of the written signature in the parent process. *)
+let write s n = Debug.record_time "write" (fun () -> write s n)
 
 (** [read fname] reads a signature from the object file [fname]. Note that the
     file can only be read properly if it was build with the same binary as the
     one being evaluated. If this is not the case, the program gracefully fails
     with an error message. *)
+(* NOTE here, we rely on the fact that a marshaled closure can only be read by
+   processes running the same binary as the one that produced it. *)
 let read : string -> t = fun fname ->
   let ic = open_in fname in
   let sign =
@@ -261,8 +265,7 @@ let read : string -> t = fun fname ->
       close_in ic; sign
     with Failure _ ->
       close_in ic;
-      fatal_no_pos "File %S is incompatible with current binary...@."
-        fname
+      fatal_no_pos "File %S is incompatible with current binary." fname
   in
   (* Timed references need reset after unmarshaling (see [Timed] doc). *)
   let reset_timed_refs sign =
@@ -315,8 +318,9 @@ let read : string -> t = fun fname ->
   in
   reset_timed_refs sign
 
-(* NOTE here, we rely on the fact that a marshaled closure can only be read by
-   processes running the same binary as the one that produced it. *)
+let read =
+  let open Stdlib in let r = ref (dummy ()) in fun n ->
+  Debug.record_time "read" (fun () -> r := read n); !r
 
 (** [add_rule sign sym r] adds the new rule [r] to the symbol [sym].  When the
     rule does not correspond to a symbol of signature [sign],  it is stored in

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -472,3 +472,7 @@ let solve_noexn : ?type_check:bool -> problem -> bool =
   if Logger.log_enabled () then
     log_hndl (Color.blu "solve_noexn %a") pp_problem p;
   try time_of "solve" (fun () -> solve p; true) with Unsolvable -> false
+
+let solve_noexn =
+  let open Stdlib in let r = ref false in fun ?type_check p ->
+  Debug.record_time "unif" (fun () -> r := solve_noexn ?type_check p); !r

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -475,4 +475,4 @@ let solve_noexn : ?type_check:bool -> problem -> bool =
 
 let solve_noexn =
   let open Stdlib in let r = ref false in fun ?type_check p ->
-  Debug.record_time "unif" (fun () -> r := solve_noexn ?type_check p); !r
+  Debug.(record_time Solving (fun () -> r := solve_noexn ?type_check p)); !r

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -501,7 +501,7 @@ let get_proof_data : compiler -> sig_state -> p_command ->
   fun compile ss ({pos;_} as cmd) ->
   Print.sig_state := ss;
   try
-    let (tm, ss) = time (get_proof_data compile ss) cmd in
+    let (tm, ss) = Extra.time (get_proof_data compile ss) cmd in
     if Stdlib.(tm >= !too_long) then
       wrn pos "It took %.2f seconds to handle the command." tm;
     ss

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -74,7 +74,7 @@ let rec compile_with :
         Stdlib.(sig_st :=
                   handle (compile_with ~handle ~force:false) !sig_st cmd)
       in
-      Stream.iter consume (parse_file src);
+      Debug.stream_iter consume (parse_file src);
       Sign.strip_private sign;
       if Stdlib.(!gen_obj) then Sign.write sign obj;
       loading := List.tl !loading;

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -413,4 +413,4 @@ let lexer : lexbuf -> unit -> token * Lexing.position * Lexing.position =
 
 let lexer =
   let r = ref (EOF, Lexing.dummy_pos, Lexing.dummy_pos) in fun lb () ->
-  Debug.record_time "lexing" (fun () -> r := lexer lb ()); !r
+  Debug.(record_time Lexing (fun () -> r := lexer lb ())); !r

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -408,4 +408,9 @@ let lexer buf =
 
 (** [lexer buf] is a lexing function on buffer [buf] that can be passed to
     a parser. *)
-let lexer = with_tokenizer lexer
+let lexer : lexbuf -> unit -> token * Lexing.position * Lexing.position =
+  with_tokenizer lexer
+
+let lexer =
+  let r = ref (EOF, Lexing.dummy_pos, Lexing.dummy_pos) in fun lb () ->
+  Debug.record_time "lexing" (fun () -> r := lexer lb ()); !r

--- a/src/parsing/parser.ml
+++ b/src/parsing/parser.ml
@@ -94,6 +94,11 @@ end
 
 (** Parsing legacy (Dedukti2) syntax. *)
 module Dk : PARSER = struct
+
+  let token =
+    let r = ref DkLexer.EOF in fun lb ->
+    Debug.record_time "lexing" (fun () -> r := DkLexer.token lb); !r
+
   let stream_of_lexbuf :
     ?inchan:in_channel -> ?fname:string -> Lexing.lexbuf ->
     (* Input channel passed as parameter to be closed at the end of stream. *)
@@ -105,7 +110,7 @@ module Dk : PARSER = struct
       Option.iter fn fname;
         (*In OCaml >= 4.11: Lexing.set_filename lexbuf fname;*)
       let generator _ =
-        try Some(DkParser.command DkLexer.token lexbuf)
+        try Some(DkParser.command token lexbuf)
         with
         | End_of_file -> Option.iter close_in inchan; None
         | DkParser.Error ->

--- a/src/parsing/parser.ml
+++ b/src/parsing/parser.ml
@@ -97,12 +97,12 @@ module Dk : PARSER = struct
 
   let token : Lexing.lexbuf -> DkLexer.token =
     let r = ref DkLexer.EOF in fun lb ->
-    Debug.record_time "lexing" (fun () -> r := DkLexer.token lb); !r
+    Debug.(record_time Lexing (fun () -> r := DkLexer.token lb)); !r
 
   let command :
     (Lexing.lexbuf -> DkLexer.token) -> Lexing.lexbuf -> Syntax.p_command =
     let r = ref (Pos.none (Syntax.P_open [])) in fun token lb ->
-    Debug.record_time "parsing" (fun () -> r := DkParser.command token lb); !r
+    Debug.(record_time Parsing (fun () -> r := DkParser.command token lb)); !r
 
   let stream_of_lexbuf :
     ?inchan:in_channel -> ?fname:string -> Lexing.lexbuf ->

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -465,6 +465,10 @@ and scope_head : int -> mode -> sig_state -> env -> p_term -> tbox =
 
   | (P_Expl(_), _) -> fatal t.pos "Explicit argument not allowed here."
 
+let scope =
+  let open Stdlib in let r = ref _Kind in fun k md ss env t ->
+  Debug.record_time "scoping" (fun () -> r := scope k md ss env t); !r
+
 (** [scope expo ss env p mok mon t] turns into a term a pterm [t] in the
    signature state [ss], the environment [env] (for bound variables). [mok k]
    says if there already exists a meta with key [k]. [mon n] says if there

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -467,7 +467,7 @@ and scope_head : int -> mode -> sig_state -> env -> p_term -> tbox =
 
 let scope =
   let open Stdlib in let r = ref _Kind in fun k md ss env t ->
-  Debug.record_time "scoping" (fun () -> r := scope k md ss env t); !r
+  Debug.(record_time Scoping (fun () -> r := scope k md ss env t)); !r
 
 (** [scope expo ss env p mok mon t] turns into a term a pterm [t] in the
    signature state [ss], the environment [env] (for bound variables). [mok k]


### PR DESCRIPTION
and fix the command `lambdapi parse` (since ast is a stream, parsing is done only if the stream is consumed)