### PR TITLE
Why3 tactic abstracts over products

### DIFF
--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -309,8 +309,13 @@ let handle : Sig_state.t -> bool -> proof_state -> p_tactic -> proof_state =
       | _ -> assert false
       end
   | P_tac_why3 cfg ->
-      let p = new_problem() in
-      tac_refine pos ps gt gs p (Why3_tactic.handle ss pos cfg gt)
+      let arity = count_products (Env.to_ctxt env) gt.goal_type in
+      let ps = assume arity in
+      (match ps.proof_goals with
+      | Typ gt::gs ->
+          let p = new_problem() in
+          tac_refine pos ps gt gs p (Why3_tactic.handle ss pos cfg gt)
+      | _ -> assert false)
 
 (** Representation of a tactic output. *)
 type tac_output = Sig_state.t * proof_state * Query.result

--- a/tests/OK/why3.lp
+++ b/tests/OK/why3.lp
@@ -7,43 +7,36 @@ prover_timeout 2;
 
 opaque symbol tautology : Π (a : Prop), P a → P a
 ≔ begin
-    assume a pa;
-    why3
+    why3;
 end;
 
 opaque symbol thm_and1 : Π (a b : Prop), P ({|and|} a b) → P a
 ≔ begin
-    assume a b pab;
-    why3
+    why3;
 end;
 
 
 opaque symbol thm_and2 : Π (a b : Prop), P ({|and|} a b) → P b
 ≔ begin
-    assume a b pab;
-    why3
+    why3;
 end;
 
 opaque symbol excluded_middle : Π (a : Prop), P (or a (not a))
 ≔ begin
-    assume a;
-    why3
+    why3;
 end;
 
 opaque symbol thm_or1 : Π (a b : Prop), P a → P (or a b)
 ≔ begin
-    assume a b pa;
-    why3
+    why3;
 end;
 
 opaque symbol thm_or2 : Π (a b : Prop), P b → P (or a b)
 ≔ begin
-    assume a b pb;
-    why3
+    why3;
 end;
 
 opaque symbol thm_imp : Π (a b : Prop), P (imp a b) → P a → P b
 ≔ begin
-    assume a b pab pa;
-    why3
+    why3;
 end;


### PR DESCRIPTION
No need to write assume "x y...; why3;", now "why3;" is enough.