### PR TITLE
Enable type inference for Menhir.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -8,7 +8,7 @@
 (maintainers "dedukti-dev@inria.fr")
 (license CECILL-2.1)
 
-(using menhir 1.0)
+(using menhir 2.0)
 
 (package
  (name lambdapi)


### PR DESCRIPTION
This change is required by Menhir 20211223.

As far as I can see, there are two more problems that need fixing:

```
File "src/parsing/lpParser.mly", line 311, characters 15-27:
Error: $syntaxerror is no longer supported.
```
Instead of using `$syntaxerr`, you should raise an exception of your own.

```
File "src/parsing/dkParser.ml", lines 1754-1826, characters 4-20:
1754 | ....match _tok with
1755 |     | DkTokens.ARROW ->
1756 |         "ARROW"
1757 |     | DkTokens.ASSERT _ ->
1758 |         "ASSERT"
...
1823 |     | DkTokens.TYPE _ ->
1824 |         "TYPE"
1825 |     | DkTokens.UNDERSCORE _ ->
1826 |         "UNDERSCORE"
Error (warning 8): this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
(CCOLON|INT _)
```
To fix this, you could:
* either disable warning 8
* or declare the tokens `CCOLON` and `INT` in `dkParser.mly`;
* or just remove the tokens `CCOLON` and `INT` in `dkTokens.ml`.