### PR TITLE
Allow the use of the builtin "0" without defining the builtin "+1"

### DIFF
--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -110,6 +110,9 @@ let nat_of_term : term -> int = fun t ->
     with Not_found -> raise Not_a_nat
   in
   let zero = get_builtin "0" in
+  match get_args t with
+  | (Symb s, []) when s == zero -> 0
+  | _ ->
   let succ = get_builtin "+1" in
   let rec nat acc = fun t ->
     match get_args t with

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -124,7 +124,7 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
         in
         (* Function to print a symbol declaration. *)
         let pp_decl ppf s =
-          out ppf "%a%a%asymbol %a : %a;@.%a%a%a"
+          out ppf "%a%a%asymbol %a : %a%a;@.%a%a"
             pp_expo s.sym_expo pp_prop s.sym_prop
             pp_match_strat s.sym_mstrat pp_sym s
             pp_prod (!(s.sym_type), s.sym_impl)

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -503,6 +503,7 @@ and scope_head :
   | (P_LLet(_), M_Patt) ->
       fatal t.pos "Let-bindings are not allowed in a pattern."
 
+  | (P_NLit(0), _) -> _Symb (Builtin.get ss t.pos "0")
   | (P_NLit(n), _) ->
       let sym_z = _Symb (Builtin.get ss t.pos "0")
       and sym_s = _Symb (Builtin.get ss t.pos "+1") in


### PR DESCRIPTION
and make the output of the print command parsable