### PR TITLE
Keep matching syntactic in rewrite tactic even with AC symbols

### DIFF
--- a/Logic/TFF/Nat.lp
+++ b/Logic/TFF/Nat.lp
@@ -51,9 +51,9 @@ end;
 
 symbol + : ℕ → ℕ → ℕ;
 
-notation + infix left 20;
+notation + infix right 20;
 
-assert x y z ⊢ x + y + z ≡ (x + y) + z; // check associativity
+assert x y z ⊢ x + y + z ≡ x + (y + z); // check associativity
 
 rule 0 + $y ↪ $y
 with s $x + $y ↪ s ($x + $y);
@@ -100,7 +100,7 @@ rule ($x + $y) + $z ↪ $x + ($y + $z);
 
 symbol × : ℕ → ℕ → ℕ; // \times
 
-notation × infix left 30;
+notation × infix right 30;
 
 assert x y z ⊢ x + y × z ≡ x + (y × z); // check priorities
 
@@ -123,13 +123,34 @@ induction
 { assume x' h y; simplify; rewrite h; reflexivity }
 end;
 
+/* We cannot declare
+rule $x × s $y ↪ $x × $y + $x;
+without having + declared as associative-commutative because of the
+Unjoinable critical pair:
+t ≔ s $0 × ($1' + $2')
+t ↪[] (s $0 × $1') + (s $0 × $2') ↪* $1' + (($0 × $1') + ($2' + ($0 × $2')))
+  with $0' × ($1' + $2') ↪ ($0' × $1') + ($0' × $2')
+t ↪[] ($1' + $2') + ($0 × ($1' + $2')) ↪* $1' + ($2' + (($0 × $1') + ($0 × $2')))
+  with s $0 × $1 ↪ $1 + ($0 × $1)]
+*/
+
+/* We cannot declare
 rule $x × s $y ↪ $x + $x × $y;
+without having + declared as associative-commutative because of the
+Unjoinable critical pair:
+t ≔ s $0 × s $1'
+t ↪[] s $0 + (s $0 × $1') ↪* s ($0 + ($1' + ($0 × $1')))
+  with $0' × s $1' ↪ $0' + ($0' × $1')
+t ↪[] s $1' + ($0 × s $1') ↪* s ($1' + ($0 + ($0 × $1')))
+  with s $0 × $1 ↪ $1 + ($0 × $1)]
+*/
 
 opaque symbol mul_com x y : π (x × y = y × x) ≔
 begin
 induction
 { reflexivity }
-{ assume x' h y; simplify; rewrite h; reflexivity }
+{ assume x' h y; rewrite mulsr; simplify; rewrite h; rewrite add_com;
+  reflexivity }
 end;
 
 // Multiplication distributes over addition
@@ -141,7 +162,16 @@ induction
 { assume x' h y z; simplify; rewrite h; reflexivity }
 end;
 
+/* We cannot declare
 rule ($x + $y) × $z ↪ $x × $z + $y × $z;
+without having + declared as associative-commutative because of the
+Unjoinable critical pair:
+t ≔ ($0 + s $1) × $2'
+t ↪[] ($0 × $2') + (s $1 × $2') ↪* ($0 × $2') + ($2' + ($1 × $2'))
+  with ($0' + $1') × $2' ↪ ($0' × $2') + ($1' × $2')
+t ↪[0; 1] s ($0 + $1) × $2' ↪* $2' + (($0 × $2') + ($1 × $2'))
+  with $0 + s $1 ↪ s ($0 + $1)]
+*/
 
 opaque symbol mul_addr x y z : π (z × (x + y) = z × x + z × y) ≔
 begin
@@ -149,7 +179,7 @@ assume x y z; rewrite mul_com; rewrite mul_addl; rewrite mul_com;
 rewrite .[y × _] mul_com; reflexivity
 end;
 
-rule $z × ($x + $y) ↪ $z × $x + $z × $y;
+//rule $z × ($x + $y) ↪ $z × $x + $z × $y;
 
 // Multiplication is associative
 
@@ -157,16 +187,25 @@ opaque symbol mul_assoc x y z : π ((x × y) × z = x × (y × z)) ≔
 begin
 induction
 { reflexivity }
-{ assume x' h y z; simplify; rewrite h; reflexivity }
+{ assume x' h y z; simplify; rewrite mul_addl; rewrite h; reflexivity }
 end;
 
+/* We cannot declare
 rule ($x × $y) × $z ↪ $x × ($y × $z);
+without having distributivity because
+Unjoinable critical pair:
+t ≔ (s $0 × $1) × $2'
+t ↪[] s $0 × ($1 × $2') ↪* ($1 × $2') + ($0 × ($1 × $2'))
+  with ($0' × $1') × $2' ↪ $0' × ($1' × $2')
+t ↪[0; 1] ($1 + ($0 × $1)) × $2' ↪* ($1 + ($0 × $1)) × $2'
+  with s $0 × $1 ↪ $1 + ($0 × $1)]
+*/
 
 // Maximum
 
 symbol ∨: ℕ → ℕ → ℕ;
 
-notation ∨ infix left 40;
+notation ∨ infix right 40;
 
 rule 0 ∨ $x ↪ $x
 with $x ∨ 0 ↪ $x

--- a/Logic/TFF/Nat.lp
+++ b/Logic/TFF/Nat.lp
@@ -2,8 +2,8 @@
 
 require open Logic.TFF.Set Logic.TFF.Prop Logic.TFF.Main Logic.TFF.Eq;
 
-inductive ℕ : TYPE ≔
-| zero : ℕ
+inductive ℕ : TYPE ≔ // `dN
+| 0 : ℕ
 | s : ℕ → ℕ;
 
 // set code for ℕ
@@ -14,10 +14,10 @@ rule τ nat ↪ ℕ;
 
 // Enabling the use of decimal notation
 
-builtin "0"  ≔ zero;
+builtin "0"  ≔ 0;
 builtin "+1" ≔ s;
 
-assert ⊢ 42 : ℕ;
+assert ⊢ 1 : ℕ;
 
 // is0 predicate
 
@@ -203,7 +203,7 @@ t ↪[0; 1] ($1 + ($0 × $1)) × $2' ↪* ($1 + ($0 × $1)) × $2'
 
 // Maximum
 
-symbol ∨: ℕ → ℕ → ℕ;
+symbol ∨: ℕ → ℕ → ℕ; // || or \vee
 
 notation ∨ infix right 40;
 
@@ -243,7 +243,7 @@ end;
 
 // Order on ℕ
 
-constant symbol ≤ : ℕ → ℕ → Prop; notation ≤ infix 10;
+constant symbol ≤ : ℕ → ℕ → Prop; notation ≤ infix 10; // \le
 constant symbol 0≤ x : π(0 ≤ x);
 constant symbol s_mon_≤ x y : π(x ≤ y) → π(s x ≤ s y);
 

--- a/Logic/TFF/NatAC.lp
+++ b/Logic/TFF/NatAC.lp
@@ -23,29 +23,20 @@ notation × infix right 30;
 rule 0 × _  ↪ 0
 with _ × 0 ↪ 0
 with s $x × $y ↪ $y + $x × $y
-with $x × s $y ↪ $x + $x × $y;
+with $x × s $y ↪ $x + $x × $y
+with ($x + $y) × $z ↪ $x × $z + $y × $z
+with $z × ($x + $y) ↪ $z × $x + $z × $y;
 
-// Multiplication distributes over addition
-
-opaque symbol mul_addl x y z : π ((x + y) × z = x × z + y × z) ≔
-begin
-induction
-{ reflexivity }
-{ assume x' h y z; simplify; rewrite h; reflexivity }
-end;
-
-rule ($x + $y) × $z ↪ $x × $z + $y × $z;
-
-opaque symbol mul_addr x y z : π (z × (x + y) = z × x + z × y) ≔
-begin
-assume x y z; rewrite left mul_addl; reflexivity;
-end;
-
-rule $z × ($x + $y) ↪ $z × $x + $z × $y;
+/* Check the confluence of critical pairs unjoianble in Nat. */
+assert v0 v1 v2 v1' v2' ⊢
+  (s v0 × v1') + (s v0 × v2') ≡ (v1' + v2') + (v0 × (v1' + v2'));
+assert v0 v1' ⊢ s v0 + (s v0 × v1') ≡ s v1' + (v0 × s v1');
+assert v0 v2' v1 ⊢ (v0 × v2') + (s v1 × v2') ≡ s (v0 + v1) × v2';
+assert v0 v1 v2' ⊢ s v0 × (v1 × v2') ≡ (v1 + (v0 × v1)) × v2';
 
 // Maximum
 
-associative commutative symbol ∨: ℕ → ℕ → ℕ;
+associative commutative symbol ∨: ℕ → ℕ → ℕ; // || or \vee
 
 notation ∨ infix right 40;
 

--- a/Logic/TFF/NatAC.lp
+++ b/Logic/TFF/NatAC.lp
@@ -1,0 +1,54 @@
+// Natural numbers
+
+require open Logic.TFF.Set Logic.TFF.Prop Logic.TFF.Main Logic.TFF.Eq
+             Logic.TFF.Nat;
+
+// Addition
+
+associative commutative symbol + : ℕ → ℕ → ℕ;
+
+notation + infix right 20;
+
+rule 0 + $x ↪ $x
+with $x + 0 ↪ $x
+with s $x + $y ↪ s ($x + $y)
+with $x + s $y ↪ s ($x + $y);
+
+// Multiplication
+
+associative commutative symbol × : ℕ → ℕ → ℕ; // \times
+
+notation × infix right 30;
+
+rule 0 × _  ↪ 0
+with _ × 0 ↪ 0
+with s $x × $y ↪ $y + $x × $y
+with $x × s $y ↪ $x + $x × $y;
+
+// Multiplication distributes over addition
+
+opaque symbol mul_addl x y z : π ((x + y) × z = x × z + y × z) ≔
+begin
+induction
+{ reflexivity }
+{ assume x' h y z; simplify; rewrite h; reflexivity }
+end;
+
+rule ($x + $y) × $z ↪ $x × $z + $y × $z;
+
+opaque symbol mul_addr x y z : π (z × (x + y) = z × x + z × y) ≔
+begin
+assume x y z; rewrite left mul_addl; reflexivity;
+end;
+
+rule $z × ($x + $y) ↪ $z × $x + $z × $y;
+
+// Maximum
+
+associative commutative symbol ∨: ℕ → ℕ → ℕ;
+
+notation ∨ infix right 40;
+
+rule 0 ∨ $x ↪ $x
+with $x ∨ 0 ↪ $x
+with s $x ∨ s $y ↪ s ($x ∨ $y);

--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,16 @@ zenon_modulo: bin
 
 #### Cleaning targets ########################################################
 
+.PHONY: lpoclean
+lpoclean:
+	@find . -type f -name "*.lpo" -exec rm {} \;
+
 .PHONY: clean
-clean:
+clean: lpoclean
 	@dune clean
 	@$(MAKE) -C editors/emacs clean
 	@$(MAKE) -C editors/vscode clean
 	@$(MAKE) -C Logic clean
-	@find . -type f -name "*.lpo" -exec rm {} \;
 
 .PHONY: distclean
 distclean: clean

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -117,7 +117,7 @@ the system with additional information on its properties and behavior.
   - ``constant``: No rule or definition can be given to the symbol
   - ``injective``: The symbol can be considered as injective, that is, if ``f t1 .. tn`` ≡ ``f u1 .. un``, then ``t1``\ ≡\ ``u1``, …, ``tn``\ ≡\ ``un``. For the moment, the verification is left to the user.
   - ``commutative``: Adds in the conversion the equation ``f t u ≡ f u t``.
-  - ``associative``: Adds in the conversion the equation ``f (f t u) v ≡ f t (f u v)`` (in conjonction with ``commutative`` only)
+  - ``associative``: Adds in the conversion the equation ``f (f t u) v ≡ f t (f u v)`` (in conjonction with ``commutative`` only).
 
     For handling commutative and associative-commutative symbols,
     terms are systemically put in some canonical form following a
@@ -129,7 +129,7 @@ the system with additional information on its properties and behavior.
     where ``≤`` is a total ordering on terms left unspecified.
 
     If a symbol ``f`` is ``associative left`` then there is no
-    caninical term of the form ``f t (f u v)`` and thus every
+    canonical term of the form ``f t (f u v)`` and thus every
     canonical term headed by ``f`` is of the form ``f … (f (f t₁ t₂)
     t₃) …  tₙ``. If a symbol ``f`` is ``associative`` or ``associative
     right`` then there is no canonical term of the form ``f (f t u)

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -122,7 +122,7 @@ let eq_modulo : (config -> term -> term) -> config -> term -> term -> bool =
     match l with
     | [] -> ()
     | (a,b)::l ->
-    (*if Logger.log_enabled () then log_conv "1: %a ≡ %a" term a term b;*)
+    if Logger.log_enabled () then log_conv "eq: %a ≡ %a" term a term b;
     let a = Config.unfold cfg a and b = Config.unfold cfg b in
     if a == b then eq cfg l else
     match a, b with
@@ -157,7 +157,7 @@ let eq_modulo : (config -> term -> term) -> config -> term -> term -> bool =
       raise Exit
     | _ ->
     let a = whnf cfg a and b = whnf cfg b in
-    (*if Logger.log_enabled () then log_conv "2: %a ≡ %a" term a term b;*)
+    if Logger.log_enabled () then log_conv "whnf: %a ≡ %a" term a term b;
     match a, b with
     | Patt(None,_,_), _ | _, Patt(None,_,_) -> assert false
     | Patt(Some i,_,ts), Patt(Some j,_,us) ->
@@ -178,7 +178,7 @@ let eq_modulo : (config -> term -> term) -> config -> term -> term -> bool =
     | _ -> raise Exit
   in
   fun cfg a b ->
-  if Logger.log_enabled () then log_conv "%a ≡ %a" term a term b;
+  if Logger.log_enabled () then log_conv "eq_modulo: %a ≡ %a" term a term b;
   try eq cfg [(a,b)]; true
   with Exit -> if Logger.log_enabled () then log_conv "failed"; false
 

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -69,8 +69,8 @@ let snf : (term -> term) -> (term -> term) = fun whnf ->
         mk_Abst(snf a, Bindlib.unbox (Bindlib.bind_var x (lift (snf b))))
     | Appl(t,u)   -> mk_Appl(snf t, snf u)
     | Meta(m,ts)  -> mk_Meta(m, Array.map snf ts)
-    | Plac _      -> assert false (* Typechecked terms are evaluated *)
-    | Patt(_,_,_) -> assert false
+    | Patt(i,n,ts) -> mk_Patt(i,n,Array.map snf ts)
+    | Plac _      -> assert false
     | TEnv(_,_)   -> assert false
     | Wild        -> assert false
     | TRef(_)     -> assert false

--- a/src/core/libMeta.ml
+++ b/src/core/libMeta.ml
@@ -63,8 +63,7 @@ let bmake : problem -> bctxt -> tbox -> tbox =
     updates [p] with generated metavariables. *)
 let make_codomain : problem -> ctxt -> term -> tbinder = fun p ctx a ->
   let x = new_tvar "x" in
-  let b = make p ((x, a, None) :: ctx) mk_Type in
-  Bindlib.unbox (Bindlib.bind_var x (lift b))
+  bind x lift (make p ((x, a, None) :: ctx) mk_Type)
 
 (** [bmake_codomain p bctx a] is [make_codomain p bctx a] but on boxed
     terms. *)

--- a/src/core/libTerm.ml
+++ b/src/core/libTerm.ml
@@ -156,6 +156,5 @@ let sym_to_var : tvar StrMap.t -> term -> term = fun map ->
     | TRef _ -> assert false
     | _ -> t
   and to_var_binder b =
-    let (x,b) = Bindlib.unbind b in
-    Bindlib.unbox (Bindlib.bind_var x (lift (to_var b)))
+    let (x,b) = Bindlib.unbind b in bind x lift (to_var b)
   in fun t -> if StrMap.is_empty map then t else to_var t

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -106,8 +106,7 @@ let link : t -> unit = fun sign ->
       | Wild -> assert false
       | TRef _ -> assert false
     and link_binder b =
-      let (x,t) = Bindlib.unbind b in
-      Bindlib.unbox (Bindlib.bind_var x (lift (link_term t)))
+      let (x,t) = Bindlib.unbind b in bind x lift (link_term t)
     in link_term
   in
   let link_lhs = link_term mk_Appl_not_canonical

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -747,6 +747,12 @@ let lift : (tbox -> tbox -> tbox) -> term -> tbox = fun mk_appl ->
 let lift = lift _Appl
 and lift_not_canonical = lift _Appl_not_canonical
 
+(** [bind v lift t] creates a tbinder by binding [v] in [lift t]. *)
+let bind : tvar -> (term -> tbox) -> term -> tbinder =
+  fun v lift t -> Bindlib.unbox (Bindlib.bind_var v (lift t))
+let binds : tvar array -> (term -> tbox) -> term -> tmbinder =
+  fun vs lift t -> Bindlib.unbox (Bindlib.bind_mvar vs (lift t))
+
 (** [cleanup t] builds a copy of the {!type:term} [t] where every instantiated
    metavariable, instantiated term environment, and reference cell has been
    eliminated using {!val:unfold}. Another effect of the function is that the

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -741,19 +741,18 @@ let lift : (tbox -> tbox -> tbox) -> term -> tbox = fun mk_appl ->
   | TE_Some _ -> assert false (* Unreachable. *)
   in lift
 
+(** [lift t] lifts the {!type:term} [t] to the type {!type:tbox}. This has the
+   effect of gathering its free variables, making them available for binding.
+   Bound variable names are automatically updated in the process. *)
+let lift = lift _Appl
+and lift_not_canonical = lift _Appl_not_canonical
+
 (** [cleanup t] builds a copy of the {!type:term} [t] where every instantiated
    metavariable, instantiated term environment, and reference cell has been
    eliminated using {!val:unfold}. Another effect of the function is that the
    the names of bound variables are updated. This is useful to avoid any form
    of "visual capture" while printing terms. *)
-let cleanup : term -> term =
-  let mk_appl = Bindlib.box_apply2 (fun t u -> Appl(t,u)) in
-  fun t -> Bindlib.unbox (lift mk_appl t)
-
-(** [lift t] lifts the {!type:term} [t] to the type {!type:tbox}. This has the
-   effect of gathering its free variables, making them available for binding.
-   Bound variable names are automatically updated in the process. *)
-let lift = lift _Appl
+let cleanup : term -> term = fun t -> Bindlib.unbox (lift_not_canonical t)
 
 (** Positions in terms in reverse order. The i-th argument of a constructor
    has position i-1. *)

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -493,6 +493,7 @@ val _TE_None : tebox
     effect of gathering its free variables, making them available for binding.
     Bound variable names are automatically updated in the process. *)
 val lift : term -> tbox
+val lift_not_canonical : term -> tbox
 
 (** [cleanup t] builds a copy of the {!type:term} [t] where every instantiated
    metavariable, instantiated term environment, and reference cell has been

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -495,6 +495,10 @@ val _TE_None : tebox
 val lift : term -> tbox
 val lift_not_canonical : term -> tbox
 
+(** [bind v lift t] creates a tbinder by binding [v] in [lift t]. *)
+val bind : tvar -> (term -> tbox) -> term -> tbinder
+val binds : tvar array -> (term -> tbox) -> term -> tmbinder
+
 (** [cleanup t] builds a copy of the {!type:term} [t] where every instantiated
    metavariable, instantiated term environment, and reference cell has been
    eliminated using {!val:unfold}. Another effect of the function is that the

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -219,9 +219,8 @@ let imitate_inj :
         | _ -> raise Cannot_imitate
       in build (List.length ts) [] !(s.sym_type)
     in
-    if Logger.log_enabled () then
-      log_unif (red "%a ≔ %a") meta m term t;
-    LibMeta.set p m (Bindlib.unbox (Bindlib.bind_mvar vars (lift t))); true
+    if Logger.log_enabled () then log_unif (red "%a ≔ %a") meta m term t;
+    LibMeta.set p m (binds vars lift t); true
   with Cannot_imitate | Invalid_argument _ -> false
 
 (** [imitate_lam_cond h ts] tells whether [ts] is headed by a variable not

--- a/src/export/xtc.ml
+++ b/src/export/xtc.ml
@@ -129,10 +129,7 @@ let get_vars : sym -> rule -> (string * Term.term) list = fun s r ->
     | Symb (_)            -> t
     | Abst (t1, b)        ->
        let (x,t2) = Bindlib.unbind b in
-       mk_Abst(
-           subst_patt v t1,
-           Bindlib.unbox (Bindlib.bind_var x (lift (subst_patt v t2)))
-         )
+       mk_Abst(subst_patt v t1, bind x lift (subst_patt v t2))
     | Appl (t1, t2)        -> mk_Appl(subst_patt v t1, subst_patt v t2)
     | Patt (None, x, a)    ->
        let v_i = new_tvar x in

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -112,8 +112,7 @@ let tac_refine :
   | Some t ->
   if Logger.log_enabled () then
     log_tact (Color.red "%a ≔ %a") meta gt.goal_meta term t;
-  LibMeta.set p gt.goal_meta
-    (Bindlib.unbox (Bindlib.bind_mvar (Env.vars gt.goal_hyps) (lift t)));
+  LibMeta.set p gt.goal_meta (binds (Env.vars gt.goal_hyps) lift t);
   (* Convert the metas and constraints of [p] not in [gs] into new goals. *)
   if Logger.log_enabled () then log_tact "%a" problem p;
   tac_solve pos {ps with proof_goals = Proof.add_goals_of_problem p gs}

--- a/src/lplib/list.ml
+++ b/src/lplib/list.ml
@@ -85,7 +85,7 @@ let filteri_map : (int -> 'a -> 'b option) -> 'a list -> 'b list = fun f l ->
   in loop 0 l
 
 (** [cut l k] returns a pair of lists [(l1, l2)] such that [l1] has length
-    [max (List.length l) k] and [l1 @ l2] is equal to [l]. *)
+    [min (List.length l) k] and [l1 @ l2] is equal to [l]. *)
 let cut : 'a list -> int -> 'a list * 'a list = fun l k ->
   let rec cut acc l k =
     if k <= 0 then (L.rev acc, l)
@@ -94,6 +94,13 @@ let cut : 'a list -> int -> 'a list * 'a list = fun l k ->
          | x :: l -> cut (x :: acc) l (k - 1)
   in
   if k <= 0 then ([], l) else cut [] l k
+
+let _ =
+  assert (cut [1;2;3] 0 = ([], [1;2;3]));
+  assert (cut [1;2;3] 1 = ([1], [2;3]));
+  assert (cut [1;2;3] 2 = ([1;2], [3]));
+  assert (cut [1;2;3] 3 = ([1;2;3], []));
+  assert (cut [1;2;3] 4 = ([1;2;3], []))
 
 (** [add_array a1 a2 l] returns a list containing the elements of [l], and the
     (corresponding) elements of [a1] and [a2]. Note that [a1] and [a2] should

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -448,17 +448,17 @@ and scope_head :
   | (P_Appl(_,_), _) ->  assert false (* Unreachable. *)
 
   | (P_Arro(_,_), M_Patt) ->
-      fatal t.pos "Implications are not allowed in a pattern."
+      fatal t.pos "Arrows are not allowed in patterns."
   | (P_Arro(a,b), _) ->
     _Impl (scope ~typ:true (k+1) md ss env a)
           (scope ~typ:true (k+1) md ss env b)
 
   | (P_Abst(_,_), M_Patt) ->
-      fatal t.pos "Abstractions are not allowed in a pattern."
+      fatal t.pos "Abstractions are not allowed in patterns."
   | (P_Abst(xs,t), _) -> scope_binder k md ss _Abst env xs (Some(t))
 
   | (P_Prod(_,_), M_Patt) ->
-      fatal t.pos "Dependent products are not allowed in a pattern."
+      fatal t.pos "Dependent products are not allowed in patterns."
   | (P_Prod(xs,b), _) -> scope_binder ~typ:true k md ss _Prod env xs (Some(b))
 
   | (P_LLet(x,xs,a,t,u), (M_Term _|M_URHS _|M_RHS _)) ->
@@ -472,7 +472,7 @@ and scope_head :
   | (P_LLet(_), M_LHS(_)) ->
       fatal t.pos "Let-bindings are not allowed in a LHS."
   | (P_LLet(_), M_Patt) ->
-      fatal t.pos "Let-bindings are not allowed in a pattern."
+      fatal t.pos "Let-bindings are not allowed in patterns."
 
   (* Evade the addition of implicit arguments inside the wrap *)
   | (P_Wrap ({ elt = (P_Iden _ | P_Abst _); _ } as id), _) ->
@@ -690,18 +690,18 @@ let scope_rw_patt : sig_state -> env -> p_rw_patt -> (term, tbinder) rw_patt =
   | Rw_InIdInTerm(x,t) ->
       let v = new_tvar x.elt in
       let t = scope_pattern ss ((x.elt,(v, _Kind, None))::env) t in
-      Rw_InIdInTerm(Bindlib.unbox (Bindlib.bind_var v (lift t)))
+      Rw_InIdInTerm(bind v lift_not_canonical t)
   | Rw_IdInTerm(x,t) ->
       let v = new_tvar x.elt in
       let t = scope_pattern ss ((x.elt,(v, _Kind, None))::env) t in
-      Rw_IdInTerm(Bindlib.unbox (Bindlib.bind_var v (lift t)))
+      Rw_IdInTerm(bind v lift_not_canonical t)
   | Rw_TermInIdInTerm(u,(x,t)) ->
       let u = scope_pattern ss env u in
       let v = new_tvar x.elt in
       let t = scope_pattern ss ((x.elt,(v, _Kind, None))::env) t in
-      Rw_TermInIdInTerm(u, Bindlib.unbox (Bindlib.bind_var v (lift t)))
+      Rw_TermInIdInTerm(u, bind v lift_not_canonical t)
   | Rw_TermAsIdInTerm(u,(x,t)) ->
       let u = scope_pattern ss env u in
       let v = new_tvar x.elt in
       let t = scope_pattern ss ((x.elt,(v, _Kind, None))::env) t in
-      Rw_TermAsIdInTerm(u, Bindlib.unbox (Bindlib.bind_var v (lift t)))
+      Rw_TermAsIdInTerm(u, bind v lift_not_canonical t)

--- a/src/tool/lcr.ml
+++ b/src/tool/lcr.ml
@@ -183,16 +183,13 @@ let apply_subs : term IntMap.t -> term -> term = fun s ->
     | Appl(u,v) -> mk_Appl (apply_subs u, apply_subs v)
     | Abst(a,b) ->
       let x,b = Bindlib.unbind b in
-      mk_Abst (apply_subs a,
-               Bindlib.unbox (Bindlib.bind_var x (lift (apply_subs b))))
+      mk_Abst (apply_subs a, bind x lift (apply_subs b))
     | Prod(a,b) ->
       let x,b = Bindlib.unbind b in
-      mk_Prod (apply_subs a,
-               Bindlib.unbox (Bindlib.bind_var x (lift (apply_subs b))))
+      mk_Prod (apply_subs a, bind x lift (apply_subs b))
     | LLet(a,t,b) ->
       let x,b = Bindlib.unbind b in
-      mk_LLet (apply_subs a, apply_subs t,
-               Bindlib.unbox (Bindlib.bind_var x (lift (apply_subs b))))
+      mk_LLet (apply_subs a, apply_subs t, bind x lift (apply_subs b))
     | Meta(m,ts) -> mk_Meta (m, Array.map apply_subs ts)
     | TEnv(te,ts) -> mk_TEnv (te, Array.map apply_subs ts)
     | TRef _ -> assert false

--- a/src/tool/lcr.ml
+++ b/src/tool/lcr.ml
@@ -274,7 +274,7 @@ let unif : Pos.popt -> term -> term -> term IntMap.t option =
 
 (* Unit tests. *)
 let _ =
-  let var i = mk_Patt (Some i, Format.sprintf "%d" i, [||]) in
+  let var i = mk_Patt (Some i, string_of_int i, [||]) in
   let v0 = var 0
   and v1 = var 1 in
   let sym name =
@@ -324,12 +324,12 @@ let check_cp_subterm_rule :
     if not (Eval.eq_modulo [] r1 r2) then
       wrn pos "@[<v>Unjoinable critical pair:@ \
                t ≔ %a@ \
-               t ↪[] %a@   \
+               t ↪[] %a ↪* %a@   \
                  with %a@ \
-               t ↪%a %a@   \
+               t ↪%a %a ↪* %a@   \
                  with %a]"
-        term (apply_subs s l) term r1 rule_of_pair (l,r)
-        subterm_pos p term r2 rule_of_pair (g,d)
+        term (apply_subs s l) term r1 term (Eval.snf [] r1) rule_of_pair (l,r)
+        subterm_pos p term r2 term (Eval.snf [] r2) rule_of_pair (g,d)
   | None -> ()
 
 (** [check_cp_subterms_rule pos sr1 sr2] checks the critical pairs between all


### PR DESCRIPTION
- remove rules generating unjoinable critical pair in Logic/TFF/Nat.lp
- add Logic/TFF/NatAC.lp
- Makefile: add target lpoclean
- Eval: evaluate terms with Patt's
- Term: add the functions bind and binds
- Rewrite:
  . change the order of arguments in match_pattern and find_subst
  . renamings: eq -> matches, add_refs -> replace_wild_by_tref, match_pattern -> matching_subs, make_pat -> find_subterm_matching
  . rewrite the function eq/matches
