### PR TITLE
Fix variable namings in induction principle generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,6 @@ jobs:
           make sanity_check
           eval $(opam env)
           opam pin add dedukti https://github.com/Deducteam/dedukti.git
-          opam install alt-ergo dedukti
+          opam install alt-ergo.2.4.1 dedukti
           why3 config detect
           make tests

--- a/src/handle/inductive.ml
+++ b/src/handle/inductive.ml
@@ -63,27 +63,27 @@ let gen_safe_prefixes : inductive -> string * string * string =
    generating the induction principles. *)
 type data = { ind_var : tvar (** predicate variable *)
             ; ind_type : tbox (** predicate variable type *)
-            ; ind_conclu : tbox (** induction principle conlusion *) }
+            ; ind_conclu : tbox (** induction principle conclusion *) }
 type ind_pred_map = (sym * data) list
 
-(** [ind_typ_with_codom pos ind_sym ind_env codom s a] assumes that [a] is of
+(** [ind_typ_with_codom pos ind_sym env codom x_str a] assumes that [a] is of
    the form [Π(i1:a1),...,Π(in:an), TYPE]. It then generates a [tbox] similar
    to this type except that [TYPE] is replaced by [codom [i1;...;in]]. The
-   string [s] is used as prefix for the variables [ik]. *)
+   string [x_str] is used as prefix for the variables [ik]. *)
 let ind_typ_with_codom :
       popt -> sym -> Env.t -> (tbox list -> tbox) -> string -> term -> tbox =
-  fun pos ind_sym env codom s a ->
+  fun pos ind_sym env codom x_str a ->
   let rec aux : tvar list -> term -> tbox = fun xs a ->
     match get_args a with
     | (Type, _) -> codom (List.rev_map _Vari xs)
     | (Prod(a,b), _) ->
-        let (x,b) = LibTerm.unbind_name s b in
+        let (x,b) = LibTerm.unbind_name x_str b in
         _Prod (lift a) (Bindlib.bind_var x (aux (x::xs) b))
     | _ -> fatal pos "The type of %a is not supported" sym ind_sym
   in
   aux (List.map (fun (_,(v,_,_)) -> v) env) a
 
-(** [create_ind_pred_map pos c ind_list a_str p_str x_str] builds an
+(** [create_ind_pred_map pos c arity ind_list a_str p_str x_str] builds an
    [ind_pred_map] from [ind_list]. The resulting list is in reverse order wrt
    [ind_list]. [a_str] is used as prefix for parameter names, [p_str] is used
    as prefix for predicate variable names, and [x_str] is used as prefix for
@@ -97,8 +97,7 @@ let create_ind_pred_map :
   let env =
     match ind_list with
     | [] -> assert false (* there must be at least one type definition *)
-    | (ind_sym, _) :: _ ->
-        fst (Env.of_prod_using [] vs !(ind_sym.sym_type))
+    | (ind_sym, _) :: _ -> fst (Env.of_prod_using [] vs !(ind_sym.sym_type))
   in
   (* create the ind_pred_map *)
   let create_sym_pred_data i (ind_sym,_) =
@@ -180,17 +179,17 @@ let fold_cons_type
       (codom : 'var list -> 'a -> tvar -> term list -> 'c)
 
     : 'c =
-  let rec fold : 'var list -> 'a -> term -> 'c = fun xs acc t ->
+  let rec fold : 'var list -> int -> 'a -> term -> 'c = fun xs n acc t ->
     match get_args t with
     | (Symb(s), ts) ->
         if s == ind_sym then
           let d = List.assq ind_sym ind_pred_map in
           codom xs acc d.ind_var ts
         else fatal pos "%a is not a constructor of %a"
-               sym cons_sym sym ind_sym
+            sym cons_sym sym ind_sym
     | (Prod(t,u), _) ->
-       let x, u = LibTerm.unbind_name x_str u in
-       let x = inj_var (List.length xs) x in
+       let x, u = LibTerm.unbind_name (x_str ^ string_of_int n) u in
+       let x = inj_var (Array.length vs + n) x in
        begin
          let env, b = Env.of_prod [] "y" t in
          match get_args b with
@@ -199,10 +198,10 @@ let fold_cons_type
                match List.assq_opt s ind_pred_map with
                | Some d ->
                    let v = aux env s d.ind_var ts x in
-                   let next = fold (x::xs) (acc_rec_dom acc x v) u in
+                   let next = fold (x::xs) (n+1) (acc_rec_dom acc x v) u in
                    rec_dom t x v next
                | None ->
-                   let next = fold (x::xs) (acc_nonrec_dom acc x) u in
+                   let next = fold (x::xs) (n+1) (acc_nonrec_dom acc x) u in
                    nonrec_dom t x next
              end
          | _ -> fatal pos "The type of %a is not supported" sym cons_sym
@@ -210,11 +209,11 @@ let fold_cons_type
     | _ -> fatal pos "The type of %a is not supported" sym cons_sym
   in
   let _, t = Env.of_prod_using [] vs !(cons_sym.sym_type) in
-  fold (List.mapi inj_var (Array.to_list vs)) init t
+  fold (List.mapi inj_var (Array.to_list vs)) 0 init t
 
-(** [gen_rec_type ss pos n ind_list ind_pred_map x_str] generates the
+(** [gen_rec_type c pos ind_list vs env ind_pred_map x_str] generates the
    induction principles for each type in the inductive definition [ind_list]
-   defined at the position [pos] whose number of parameters is [n]. [x_str] is
+   defined at the position [pos] whose parameters are [vs]. [x_str] is
    a string used for prefixing variable names that are generated. Remark: in
    the generated induction principles, each recursive argument is followed by
    its induction hypothesis. For instance, with [inductive T:TYPE := c:
@@ -265,8 +264,7 @@ let gen_rec_types :
     let add_quantifier t (_,d) =
       _Prod d.ind_type (Bindlib.bind_var d.ind_var t) in
     let rec_typ = List.fold_left add_quantifier rec_typ ind_pred_map in
-    let rec_typ = Env.to_prod_box env rec_typ in
-    Bindlib.unbox rec_typ
+    Bindlib.unbox (Env.to_prod_box env rec_typ)
   in
 
   List.map gen_rec_type ind_pred_map

--- a/src/handle/inductive.ml
+++ b/src/handle/inductive.ml
@@ -186,7 +186,7 @@ let fold_cons_type
           let d = List.assq ind_sym ind_pred_map in
           codom xs acc d.ind_var ts
         else fatal pos "%a is not a constructor of %a"
-            sym cons_sym sym ind_sym
+               sym cons_sym sym ind_sym
     | (Prod(t,u), _) ->
        let x, u = LibTerm.unbind_name (x_str ^ string_of_int n) u in
        let x = inj_var (Array.length vs + n) x in

--- a/src/handle/inductive.ml
+++ b/src/handle/inductive.ml
@@ -73,15 +73,15 @@ type ind_pred_map = (sym * data) list
 let ind_typ_with_codom :
       popt -> sym -> Env.t -> (tbox list -> tbox) -> string -> term -> tbox =
   fun pos ind_sym env codom x_str a ->
-  let rec aux : tvar list -> term -> tbox = fun xs a ->
+  let rec aux : tvar list -> int -> term -> tbox = fun xs k a ->
     match get_args a with
     | (Type, _) -> codom (List.rev_map _Vari xs)
     | (Prod(a,b), _) ->
-        let (x,b) = LibTerm.unbind_name x_str b in
-        _Prod (lift a) (Bindlib.bind_var x (aux (x::xs) b))
+        let (x,b) = LibTerm.unbind_name (x_str ^ string_of_int k) b in
+        _Prod (lift a) (Bindlib.bind_var x (aux (x::xs) (k+1) b))
     | _ -> fatal pos "The type of %a is not supported" sym ind_sym
   in
-  aux (List.map (fun (_,(v,_,_)) -> v) env) a
+  aux (List.map (fun (_,(v,_,_)) -> v) env) 0 a
 
 (** [create_ind_pred_map pos c arity ind_list a_str p_str x_str] builds an
    [ind_pred_map] from [ind_list]. The resulting list is in reverse order wrt

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -199,9 +199,15 @@ let handle :
   let assume n =
     if n <= 0 then ps
     else
-      let idopt = Some (Pos.none "y") in
+      let add_decl strings (s,_) = Extra.StrSet.add s strings in
+      let strings = List.fold_left add_decl Extra.StrSet.empty env in
+      let h = Extra.get_safe_prefix "h" strings in
       let rec mk_idopts acc k =
-        if k <= 0 then acc else mk_idopts (idopt::acc) (k-1) in
+        if k <= 0 then acc
+        else
+          let idopt = Some (Pos.make pos (h ^ string_of_int k)) in
+          mk_idopts (idopt::acc) (k-1)
+      in
       let t = P.abst_list (mk_idopts [] n) P.wild in
       let p = new_problem() in
       tac_refine pos ps gt gs p (scope t)
@@ -283,14 +289,13 @@ let handle :
   | P_tac_refl ->
       let cfg = Rewrite.get_eq_config ss pos in
       let (a,l,_), vs = Rewrite.get_eq_data cfg pos gt.goal_type in
-      let n = Array.length vs in
       (* We first do [n] times the [assume] tactic. *)
-      let ps = assume n in
+      let ps = assume (Array.length vs) in
       (* We then apply reflexivity. *)
       begin match ps.proof_goals with
       | Typ gt::gs ->
         let a,l =
-          if n = 0 then a,l
+          if Array.length vs = 0 then a,l
           else let (a,l,_),_ = Rewrite.get_eq_data cfg pos gt.goal_type in a,l
         in
         let prf = add_args (mk_Symb cfg.symb_refl) [a; l] in
@@ -305,14 +310,10 @@ let handle :
   | P_tac_sym ->
       let cfg = Rewrite.get_eq_config ss pos in
       let (a,l,r), vs = Rewrite.get_eq_data cfg pos gt.goal_type in
-      let n = Array.length vs in
-      (* We first do [n] times the [assume] tactic. *)
-      let ps = assume n in
-      (* We then apply symmetry. *)
       begin match ps.proof_goals with
       | Typ gt::gs ->
         let a,l,r =
-          if n = 0 then a,l,r
+          if Array.length vs = 0 then a,l,r
           else fst (Rewrite.get_eq_data cfg pos gt.goal_type)
         in
         let p = new_problem() in
@@ -328,8 +329,7 @@ let handle :
       | _ -> assert false
       end
   | P_tac_why3 cfg ->
-      let arity = count_products (Env.to_ctxt env) gt.goal_type in
-      let ps = assume arity in
+      let ps = assume (count_products (Env.to_ctxt env) gt.goal_type) in
       (match ps.proof_goals with
       | Typ gt::gs ->
           let p = new_problem() in

--- a/src/lplib/extra.ml
+++ b/src/lplib/extra.ml
@@ -19,14 +19,14 @@ let get_safe_prefix : string -> StrSet.t -> string =
   let f s acc =
     let s_len = String.length s in
     if head_len <= s_len && String.equal head (String.sub s 0 head_len) then
-      let curr_int =
-        try int_of_string (String.sub s head_len (s_len - 1)) with _ -> 0
-      in
-      if acc < curr_int then curr_int else acc
+      try
+        let curr_int = int_of_string (String.sub s head_len (s_len - 1)) in
+        if acc < curr_int then curr_int else acc
+      with Failure _ -> acc
     else acc
   in
   let res = StrSet.fold f set (-1) in
-  head ^ string_of_int (res + 1)
+  if res = -1 then head else head ^ string_of_int (res + 1)
 
 (** [time f x] times the application of [f] to [x], and returns the evaluation
     time in seconds together with the result of the application. *)

--- a/src/lplib/extra.ml
+++ b/src/lplib/extra.ml
@@ -11,7 +11,7 @@ module StrMap = Map.Make (String)
 module StrSet = Set.Make (String)
 
 (** [get_safe_prefix p strings] returns a string starting with [p] and so
-   that, there is no non-negative integer [k] such that [p ^ string_of_int k]
+   that there is no non-negative integer [k] such that [p ^ string_of_int k]
    belongs to [strings]. *)
 let get_safe_prefix : string -> StrSet.t -> string =
  fun head set ->

--- a/tests/OK/rewrite1.lp
+++ b/tests/OK/rewrite1.lp
@@ -155,7 +155,7 @@ opaque symbol addcomm : Π n m, P (eq nat (add n m) (add m n))
   refine nat_ind (λ (n:N), eq nat (add n m) (add m n)) _ _ n
   { // Case Z
   simplify;
-  generalize m; symmetry; refine add0r y }
+  symmetry; refine add0r m }
   { // Case S
   simplify;
   assume k ih;


### PR DESCRIPTION
- compatibility with both bindlib 5.0.1 and 6.0.0
- fix variable namings in induction principle generation
- fix variable namings in implicit assume tactics
- remove implicit assume tactic before symmetry
- improve Extra.get_safe_prefix