### PR TITLE
Do not expand definitions in unification

### DIFF
--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -357,8 +357,8 @@ let solve : problem -> unit = fun p ->
   p := {!p with to_solve};
 
   (* We first try without normalizing wrt user-defined rules. *)
-  let t1 = Eval.whnf ~tags:[`NoRw] c t1
-  and t2 = Eval.whnf ~tags:[`NoRw] c t2 in
+  let t1 = Eval.whnf ~tags:[`NoRw; `NoExpand] c t1
+  and t2 = Eval.whnf ~tags:[`NoRw; `NoExpand] c t2 in
   if Logger.log_enabled () then log_unif (gre "solve %a") constr (c,t1,t2);
   let h1, ts1 = get_args t1 and h2, ts2 = get_args t2 in
 

--- a/tests/OK/iss861.lp
+++ b/tests/OK/iss861.lp
@@ -1,0 +1,57 @@
+// Define the CoC encoding
+symbol Prop : TYPE;
+symbol Type : TYPE;
+
+injective symbol π : Prop → TYPE;
+injective symbol ε : Type → TYPE;
+
+symbol dotProp : Type;
+rule ε dotProp ↪ Prop;
+
+symbol ∀ₚₚ [x : Prop] : (π x → Prop) → Prop;
+symbol ∀ₚₜ [x : Prop] : (π x → Type) → Type;
+symbol ∀ₜₚ [x : Type] : (ε x → Prop) → Prop;
+symbol ∀ₜₜ [x : Type] : (ε x → Type) → Type;
+
+rule π (∀ₚₚ $f) ↪  Π w, π ($f w)
+with ε (∀ₚₜ $f) ↪  Π w, ε ($f w)
+with π (∀ₜₚ $f) ↪  Π w, π ($f w)
+with ε (∀ₜₜ $f) ↪  Π w, ε ($f w);
+
+symbol ⇒ A B ≔  @∀ₚₚ A (λ _, B);
+notation ⇒  infix right 14;
+
+notation ∀ₜₚ quantifier;
+
+// Define the equality in this setting
+symbol = [T] (x y : π T) : Prop
+≔ `∀ₜₚ P, P y ⇒ P x;
+notation = infix 20;
+
+symbol =_refl [T] (x : π T) : π (x = x) ≔ λ P px, px;
+symbol =_ind [T] (x y : π T) : π (x = y) → Π P, π (P y) → π (P x)
+≔ λ eqxy, eqxy (λ t, t = y) (=_refl y);
+
+builtin "P"     ≔ π;
+builtin "Prop"  ≔ Prop;
+builtin "T"     ≔ π;
+builtin "eq"    ≔ =;
+builtin "refl"  ≔ =_refl;
+builtin "eqind" ≔ =_ind;
+
+inductive ℕ : TYPE ≔
+| zero : ℕ
+| s : ℕ → ℕ;
+
+symbol nat : Prop;
+rule π nat ↪ ℕ;
+
+
+symbol rewrite_test (x : ℕ) : π (x = x)
+≔ begin
+
+  induction
+    { reflexivity }
+    { reflexivity }
+
+end;


### PR DESCRIPTION
Fix issue #861: new reduction interface brings more granularity,
the old `Eval.whnf ~rewrite:false` is equivalent to
``Eval.whnf [`NoRw, `NoExpand]``.