### PR TITLE
Matching and rewriting constant TYPE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Propagate recompile flag to dependencies.
 - Postfix operators with the `notation <op> postfix <priority>;`
+- (API) the rewrite engine can match on the constant `TYPE`
 
 ### Removed
 

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -415,6 +415,14 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
             walk tr stk cursor vars_id id_vars
           in
           match t with
+          | Type       ->
+              begin
+                try
+                  let matched = TCMap.find TC.Type children in
+                  let stk = List.reconstruct left args right in
+                  walk matched stk cursor vars_id id_vars
+                with Not_found -> default ()
+              end
           | Symb(s)    ->
               let cons = TC.Symb(s.sym_path, s.sym_name, List.length args) in
               begin
@@ -451,7 +459,6 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
                 | Some(id,tr) -> walk_binder a b id tr
               end
           | Kind
-          | Type
           | Patt _
           | Meta(_, _) -> default ()
           | Plac _     -> assert false

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -196,6 +196,7 @@ module CM = struct
         | Vari _, _ -> "x"
         | Abst _, _ -> "λ"
         | Prod _, _ -> "Π"
+        | Type, _   -> "TYPE"
         | _ -> assert false (* Terms that souldn't appear in lhs *) )
 
   (** Representation of a subterm in argument position in a pattern. *)
@@ -272,12 +273,18 @@ module CM = struct
       {!type:Tree_type.TC.t}) that is a candidate for a specialization. *)
   let is_treecons : term -> bool = fun t ->
     match fst (get_args t) with
+    | TRef _ | TEnv _ | Appl _ -> assert false (* Cannot happen with get_args *)
+    | Meta _ -> assert false (* No metavars in rewrite rules LHS *)
+    | Wild -> assert false
+    | Plac _ -> assert false
+    | LLet _ -> assert false
+    | Kind
     | Patt(_) -> false
     | Vari(_)
     | Abst(_)
     | Prod(_)
+    | Type
     | Symb(_) -> true
-    | _       -> assert false
 
   (** [of_rules rs] transforms rewriting rules [rs] into a clause matrix. *)
   let of_rules : rule list -> t = fun rs ->
@@ -420,6 +427,7 @@ module CM = struct
           Some(TC.Symb(sym_path, sym_name, arity), e)
       | Vari(x)                       ->
           Some(TC.Vari(VarMap.find x vars_id), e)
+      | Type                          -> Some(TC.Type, e)
       | _                             -> None
     in
     let tc_fst_cmp (tca, _) (tcb, _) = TC.compare tca tcb in
@@ -525,6 +533,10 @@ module CM = struct
           if lenh = lenp && Bindlib.eq_vars x y
           then Some({r with c_lhs = insert (Array.of_list args)})
           else None
+      | Type, Type ->
+          if lenh = lenp (* they should be 0 if terms are well-typed *)
+          then Some({r with c_lhs = insert (Array.of_list args)})
+          else None
       | _      , Patt(_) ->
           let arity = List.length pargs in
           let e = Array.make arity (mk_wildcard free_vars) in
@@ -558,6 +570,7 @@ module CM = struct
           in
           Some({r with c_lhs})
       | Prod(_)
+      | Type
       | Symb(_) | Abst(_)
       | Vari(_) | Appl(_) -> None
       | _ -> assert false in

--- a/src/core/tree_type.ml
+++ b/src/core/tree_type.ml
@@ -21,6 +21,7 @@ module TC =
           two maps) to  a higher order (Bindlib) variable. They  are also used
           in the environment builder to refer  to the higher order variables a
           term may depend on. *)
+      | Type
 
     (** {b NOTE} the effective arity carried by the representation of a symbol
         is specific to a given symbol instance. Indeed, a symbol (in the sense
@@ -33,6 +34,7 @@ module TC =
       match c with
       | Vari(d)     -> int oc d
       | Symb(_,s,a) -> out oc "%s %d-ary" s a
+      | Type        -> out oc "TYPE"
 
     (** [compare c1 c2] implements a total order on constructors. *)
     let compare : t -> t -> int = Stdlib.compare

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -320,7 +320,6 @@ and scope_head :
   ?typ:bool -> int -> mode -> sig_state -> env -> p_term -> tbox =
   fun ?(typ=false) k md ss env t ->
   match (t.elt, md) with
-  | (P_Type, M_LHS(_)) -> fatal t.pos "TYPE is not allowed in a LHS."
   | (P_Type, _) -> _Type
 
   | (P_Iden(qid,_), _) -> scope_iden md ss env qid

--- a/src/tool/tree_graphviz.ml
+++ b/src/tool/tree_graphviz.ml
@@ -36,6 +36,7 @@ let to_dot : Format.formatter -> sym -> unit = fun ppf s ->
       | DotDefa              -> out ppf "*"
       | DotCons(Symb(_,n,a)) -> out ppf "%s<sub>%d</sub>" n a
       | DotCons(Vari(i))     -> out ppf "%s%d" var_px i
+      | DotCons(Type)        -> out ppf "TYPE"
       | DotSuccess           -> out ppf "✓"
       | DotFailure           -> out ppf "✗"
     in

--- a/tests/rewriting.ml
+++ b/tests/rewriting.ml
@@ -39,9 +39,9 @@ let arrow_matching () =
   Tree.update_dtree c [];
   let lhs = parse_term "C (A → A)" |> scope_term sig_state in
   Alcotest.(check bool)
-    "ok"
-    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
+    "C (A → A) matches C (A → A)"
     true
+    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
 
 (* Revert modifications performed on the signature. *)
 let arrow_matching = Timed.pure_apply arrow_matching
@@ -52,9 +52,9 @@ let prod_matching () =
   Tree.update_dtree c [];
   let lhs = parse_term "C (A → A)" |> scope_term sig_state in
   Alcotest.(check bool)
-    "ok"
-    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
+    "C (A → A) matches C (Π _: _, A)"
     true
+    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
 
 let prod_matching = Timed.pure_apply prod_matching
 
@@ -65,17 +65,41 @@ let arrow_default () =
   Tree.update_dtree c [];
   let lhs = parse_term "C (A → A)" |> scope_term sig_state in
   Alcotest.(check bool)
-    "Ok"
-    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
+    "C (A → A) matches C _"
     true
+    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
 
 (* Revert modifications performed on the signature. *)
 let arrow_default = Timed.pure_apply arrow_default
+
+let type_matching () =
+  let rule = parse_rule "rule C TYPE ↪ Ok;" in
+  Sign.add_rule sig_state.signature c rule;
+  Tree.update_dtree c [];
+  let lhs = parse_term "C TYPE" |> scope_term sig_state in
+  Alcotest.(check bool)
+    "C TYPE matches C TYPE"
+    true
+    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
+
+let type_matching = Timed.pure_apply type_matching
+
+let type_default () =
+  let rule = parse_rule "rule C _ ↪ Ok;" in
+  Sign.add_rule sig_state.signature c rule;
+  Tree.update_dtree c [];
+  let lhs = parse_term "C TYPE" |> scope_term sig_state in
+  Alcotest.(check bool)
+    "C TYPE matches C _"
+    true
+    (match Eval.snf [] lhs with Symb s -> s == ok | _ -> false)
 
 let _ =
   let open Alcotest in
   run "rewrite engine" [
     ("matching", [ test_case "arrow" `Quick arrow_matching
                  ; test_case "prod" `Quick prod_matching
-                 ; test_case "default" `Quick arrow_default ] )
+                 ; test_case "arrow default" `Quick arrow_default
+                 ; test_case "TYPE" `Quick type_matching
+                 ; test_case "TYPE default" `Quick type_default ] )
   ]


### PR DESCRIPTION
This pull request allows the rewriting engine to match on constant `TYPE`. This will allow to create coercions of the form
```
coercion coerce Set $x TYPE --> El $x;
```