### PR TITLE
Fix Dedukti export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed generation of metavariables through the rewriting engine.
 - Fixed application of pattern variables in rewrite rules RHS in the Dedukti
   export.
+- Fixed Dedukti export: invalid Dedukti module name were not brace-quoted,
+  for instance, `#REQUIRE module-name.` could be exported, while `module-name`
+  is not recognised by Dedukti2. It is now exported as `#REQUIRE {|module-name|}`,
+  and symbols are exported as `{|module-name|}.foo`.
 
 ## 2.2.1 (2022-07-04)
 

--- a/src/export/dk.ml
+++ b/src/export/dk.ml
@@ -53,6 +53,9 @@ let _ = let open Parsing.DkTokens in
 let is_ident : string -> bool = fun s ->
   Parsing.DkLexer.is_ident (Lexing.from_string s)
 
+let is_mident : string -> bool = fun s ->
+  Parsing.DkLexer.is_mident (Lexing.from_string s)
+
 let escape : string pp = fun ppf s -> out ppf "{|%s|}" s
 
 let replace_spaces : string -> string = fun s ->
@@ -87,7 +90,12 @@ let path : Path.t pp = fun ppf p ->
   if p <> Stdlib.(!current_path) then
   match p with
   | [] -> ()
-  | p -> out ppf "%a." (List.pp path_elt "_") p
+  | p ->
+      let joined_path = Format.asprintf "%a" (List.pp path_elt "_") p in
+      if List.for_all is_mident p then
+        out ppf "%s." joined_path
+      else
+        Format.fprintf ppf "%a." escape joined_path
 
 let qid : (Path.t * string) pp = fun ppf (p, i) ->
   out ppf "%a%a" path p ident i

--- a/src/parsing/dkLexer.mll
+++ b/src/parsing/dkLexer.mll
@@ -101,6 +101,10 @@ and sident op buf = parse
   | eof
   { fail (get_loc lexbuf) "Unexpected end of file in ident." }
 
+and is_mident = parse
+  | mident eof { true }
+  | _ { false }
+
 and is_ident = parse
   | ident eof { true }
   | _ { false }

--- a/tests/OK/require_nondkmident.lp
+++ b/tests/OK/require_nondkmident.lp
@@ -1,0 +1,5 @@
+// Module name suc-alg is not a valid Dedukti2 module name, the exporter must
+// brace-quote it.
+require tests.OK.suc-alg;
+
+symbol Z ≔ tests.OK.suc-alg.Z;


### PR DESCRIPTION
Properly brace-quote (`{|...|}`) module identifiers that cannot be parsed by Dedukti