### PR TITLE
simplifications in tactic handling

### DIFF
--- a/src/common/pos.ml
+++ b/src/common/pos.ml
@@ -69,7 +69,7 @@ let cat : popt -> popt -> popt = fun p1 p2 ->
   | None, Some p -> Some p
   | None, None -> None
 
-(** [shift k p] returns a position that is [k] characters before [p]. *)
+(** [shift k p] returns a position that is [k] characters after [p]. *)
 let shift : int -> popt -> popt = fun k p ->
   match p with
   | None -> assert false

--- a/src/handle/fol.ml
+++ b/src/handle/fol.ml
@@ -1,0 +1,31 @@
+(** Configuration for tactics based on first-order logic. *)
+
+open Common
+open Core open Term
+
+(** Builtin configuration for propositional logic. *)
+type config =
+  { symb_P   : sym (** Encoding of propositions. *)
+  ; symb_T   : sym (** Encoding of types. *)
+  ; symb_or  : sym (** Disjunction(∨) symbol. *)
+  ; symb_and : sym (** Conjunction(∧) symbol. *)
+  ; symb_imp : sym (** Implication(⇒) symbol. *)
+  ; symb_bot : sym (** Bot(⊥) symbol. *)
+  ; symb_top : sym (** Top(⊤) symbol. *)
+  ; symb_not : sym (** Not(¬) symbol. *)
+  ; symb_ex  : sym (** Exists(∃) symbol. *)
+  ; symb_all : sym (** Forall(∀) symbol. *) }
+
+(** [get_config ss pos] build the configuration using [ss]. *)
+let get_config : Sig_state.t -> Pos.popt -> config = fun ss pos ->
+  let builtin = Builtin.get ss pos in
+  { symb_P   = builtin "P"
+  ; symb_T   = builtin "T"
+  ; symb_or  = builtin "or"
+  ; symb_and = builtin "and"
+  ; symb_imp = builtin "imp"
+  ; symb_bot = builtin "bot"
+  ; symb_top = builtin "top"
+  ; symb_not = builtin "not"
+  ; symb_ex  = builtin "ex"
+  ; symb_all = builtin "all" }

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -17,16 +17,17 @@ let log_tact = log_tact.pp
 let admitted : int Stdlib.ref = Stdlib.ref (-1)
 
 (** [add_axiom ss sym_pos m] adds in signature state [ss] a new axiom symbol
-   of type [!(m.meta_type)] and instantiate [m] with it. WARNING: It does not
-   check whether the type of [m] contains metavariables. *)
-let add_axiom : Sig_state.t -> popt -> meta -> Sig_state.t =
+    of type [!(m.meta_type)] and instantiate [m] with it. WARNING: It does not
+    check whether the type of [m] contains metavariables. Return updated
+    signature state [ss] and the new axiom symbol.*)
+let add_axiom : Sig_state.t -> popt -> meta -> sym =
   fun ss sym_pos m ->
   let name =
     let i = Stdlib.(incr admitted; !admitted) in
     Printf.sprintf "_ax%i" i
   in
   (* Create a symbol with the same type as the metavariable *)
-  let ss, sym =
+  let sym =
     Console.out 1 (Color.red "axiom %a: %a")
       uid name term !(m.meta_type);
     (* Temporary hack for axioms to have a declaration position in the order
@@ -37,7 +38,10 @@ let add_axiom : Sig_state.t -> popt -> meta -> Sig_state.t =
       else shift (n - 100) sym_pos
     in
     let id = Pos.make pos name in
-    Sig_state.add_symbol ss Public Defin Eager true id !(m.meta_type) [] None
+    (* We ignore the new ss returned by Sig_state.add_symbol: axioms do not
+       need to be in scope. *)
+    snd (Sig_state.add_symbol ss
+           Public Defin Eager true id !(m.meta_type) [] None)
   in
   (* Create the value which will be substituted for the metavariable. This
      value is [sym x0 ... xn] where [xi] are variables that will be
@@ -48,29 +52,26 @@ let add_axiom : Sig_state.t -> popt -> meta -> Sig_state.t =
     let ax = _Appl_Symb sym (Array.to_list vars |> List.map _Vari) in
     Bindlib.(bind_mvar vars ax |> unbox)
   in
-  LibMeta.set (new_problem()) m meta_value; ss
+  LibMeta.set (new_problem()) m meta_value; sym
 
 (** [admit_meta ss sym_pos m] adds as many axioms as needed in the signature
    state [ss] to instantiate the metavariable [m] by a fresh axiom added to
    the signature [ss]. *)
-let admit_meta : Sig_state.t -> popt -> meta -> Sig_state.t =
+let admit_meta : Sig_state.t -> popt -> meta -> unit =
   fun ss sym_pos m ->
-  let ss = Stdlib.ref ss in
   (* [ms] records the metas that we are instantiating. *)
   let rec admit ms m =
     (* This assertion should be ensured by the typechecking algorithm. *)
     assert (not (MetaSet.mem m ms));
     LibMeta.iter true (admit (MetaSet.add m ms)) [] !(m.meta_type);
-    Stdlib.(ss := add_axiom !ss sym_pos m)
+    ignore (add_axiom ss sym_pos m)
   in
-  admit MetaSet.empty m; Stdlib.(!ss)
+  admit MetaSet.empty m
 
 (** [tac_admit ss pos ps gt] admits typing goal [gt]. *)
-let tac_admit :
-  Sig_state.t -> popt -> proof_state -> goal_typ -> Sig_state.t * proof_state
-  = fun ss sym_pos ps gt ->
-  let ss = admit_meta ss sym_pos gt.goal_meta in
-  ss, remove_solved_goals ps
+let tac_admit: Sig_state.t -> popt -> proof_state -> goal_typ -> proof_state =
+  fun ss sym_pos ps gt ->
+  admit_meta ss sym_pos gt.goal_meta; remove_solved_goals ps
 
 (** [tac_solve pos ps] tries to simplify the unification goals of the proof
    state [ps] and fails if constraints are unsolvable. *)
@@ -181,6 +182,7 @@ let handle :
   match elt with
   | P_tac_fail
   | P_tac_query _ -> assert false (* done before *)
+  (* Tactics that apply to both unification and typing goals: *)
   | P_tac_simpl None ->
       {ps with proof_goals = Goal.simpl (Eval.snf []) g :: gs}
   | P_tac_simpl (Some qid) ->
@@ -188,6 +190,7 @@ let handle :
       {ps with proof_goals = Goal.simpl (Eval.unfold_sym s) g :: gs}
   | P_tac_solve -> tac_solve pos ps
   | _ ->
+  (* Tactics that apply to typing goals only: *)
   match g with
   | Unif _ -> fatal pos "Not a typing goal."
   | Typ ({goal_hyps=env;_} as gt) ->
@@ -213,11 +216,11 @@ let handle :
       tac_refine pos ps gt gs p (scope t)
   in
   match elt with
-  | P_tac_admit
   | P_tac_fail
   | P_tac_query _
   | P_tac_simpl _
   | P_tac_solve -> assert false (* done before *)
+  | P_tac_admit -> tac_admit ss sym_pos ps gt
   | P_tac_apply pt ->
       let t = scope pt in
       (* Compute the product arity of the type of [t]. *)
@@ -284,8 +287,7 @@ let handle :
         tac_refine pos ps gt gs p u
       end
   | P_tac_induction -> tac_induction pos ps gt gs
-  | P_tac_refine t ->
-      let p = new_problem() in tac_refine pos ps gt gs p (scope t)
+  | P_tac_refine t -> tac_refine pos ps gt gs (new_problem()) (scope t)
   | P_tac_refl ->
       let cfg = Rewrite.get_eq_config ss pos in
       let (a,l,_), vs = Rewrite.get_eq_data cfg pos gt.goal_type in
@@ -299,7 +301,7 @@ let handle :
           else let (a,l,_),_ = Rewrite.get_eq_data cfg pos gt.goal_type in a,l
         in
         let prf = add_args (mk_Symb cfg.symb_refl) [a; l] in
-        let p = new_problem() in tac_refine pos ps gt gs p prf
+        tac_refine pos ps gt gs (new_problem()) prf
       | _ -> assert false
       end
   | P_tac_rewrite(l2r,pat,eq) ->
@@ -310,34 +312,29 @@ let handle :
   | P_tac_sym ->
       let cfg = Rewrite.get_eq_config ss pos in
       let (a,l,r), vs = Rewrite.get_eq_data cfg pos gt.goal_type in
-      begin match ps.proof_goals with
-      | Typ gt::gs ->
-        let a,l,r =
-          if Array.length vs = 0 then a,l,r
-          else fst (Rewrite.get_eq_data cfg pos gt.goal_type)
-        in
-        let p = new_problem() in
-        let prf =
-          let mt =
-            mk_Appl(mk_Symb cfg.symb_P,
-                    add_args (mk_Symb cfg.symb_eq) [a; r; l]) in
-          let meta_term = LibMeta.make p (Env.to_ctxt gt.goal_hyps) mt in
-          (* The proofterm is [eqind a r l M (λx,eq a l x) (refl a l)]. *)
-          Rewrite.swap cfg a r l meta_term
-        in
-        tac_refine pos ps gt gs p prf
-      | _ -> assert false
-      end
+      let a,l,r =
+        if Array.length vs = 0 then a,l,r
+        else fst (Rewrite.get_eq_data cfg pos gt.goal_type)
+      in
+      let p = new_problem() in
+      let prf =
+        let mt =
+          mk_Appl(mk_Symb cfg.symb_P,
+                  add_args (mk_Symb cfg.symb_eq) [a; r; l]) in
+        let meta_term = LibMeta.make p (Env.to_ctxt gt.goal_hyps) mt in
+        (* The proofterm is [eqind a r l M (λx,eq a l x) (refl a l)]. *)
+        Rewrite.swap cfg a r l meta_term
+      in
+      tac_refine pos ps gt gs p prf
   | P_tac_why3 cfg ->
       let ps = assume (count_products (Env.to_ctxt env) gt.goal_type) in
       (match ps.proof_goals with
-      | Typ gt::gs ->
-          let p = new_problem() in
-          tac_refine pos ps gt gs p (Why3_tactic.handle ss sym_pos cfg gt)
-      | _ -> assert false)
+       | Typ gt::_ ->
+         Why3_tactic.handle ss pos cfg gt; tac_admit ss sym_pos ps gt
+       | _ -> assert false)
 
 (** Representation of a tactic output. *)
-type tac_output = Sig_state.t * proof_state * Query.result
+type tac_output = proof_state * Query.result
 
 (** [handle ss sym_pos prv ps tac] applies tactic [tac] in the proof state
    [ps] and returns the new proof state. *)
@@ -348,23 +345,22 @@ let handle :
   | P_tac_fail -> fatal pos "Call to tactic \"fail\""
   | P_tac_query(q) ->
     if Logger.log_enabled () then log_tact "%a@." Pretty.tactic tac;
-    ss, ps, Query.handle ss (Some ps) q
+    ps, Query.handle ss (Some ps) q
   | _ ->
   match ps.proof_goals with
   | [] -> fatal pos "No remaining goals."
-  | Typ gt::_ when elt = P_tac_admit ->
-    let ss, ps = tac_admit ss sym_pos ps gt in ss, ps, None
   | g::_ ->
     if Logger.log_enabled () then
       log_tact ("%a@\n" ^^ Color.red "%a") Proof.Goal.pp g Pretty.tactic tac;
-    ss, handle ss sym_pos prv ps tac, None
+    handle ss sym_pos prv ps tac, None
 
 (** [handle sym_pos prv r tac n] applies the tactic [tac] from the previous
    tactic output [r] and checks that the number of goals of the new proof
    state is compatible with the number [n] of subproofs. *)
-let handle : popt -> bool -> tac_output -> p_tactic -> int -> tac_output =
-  fun sym_pos prv (ss, ps, _) t nb_subproofs ->
-  let (_, ps', _) as a = handle ss sym_pos prv ps t in
+let handle :
+  Sig_state.t -> popt -> bool -> tac_output -> p_tactic -> int -> tac_output =
+  fun ss sym_pos prv (ps, _) t nb_subproofs ->
+  let (ps', _) as a = handle ss sym_pos prv ps t in
   let nb_goals_before = List.length ps.proof_goals in
   let nb_goals_after = List.length ps'.proof_goals in
   let nb_newgoals = nb_goals_after - nb_goals_before in

--- a/src/handle/why3_tactic.mli
+++ b/src/handle/why3_tactic.mli
@@ -1,7 +1,7 @@
 (** Calling a prover using Why3. *)
 
 open Common
-open Core open Term
+open Core
 open Timed
 
 (** [default_prover] contains the name of the current prover. Note that it can
@@ -12,8 +12,7 @@ val default_prover : string ref
     a proof. It can be changed with "set prover <int>". *)
 val timeout : int ref
 
-(** [handle ss pos ps prover_name g] runs the Why3 prover corresponding to the
-    name [prover_name] (if given or a default one otherwise) on the goal  [g].
-    If the prover succeeded to prove the goal, then this is reflected by a new
-    axiom that is added to signature [ss]. *)
-val handle: Sig_state.t -> Pos.popt -> string option -> Proof.goal_typ -> term
+(** [handle ss pos ps prover_name gt] runs the Why3 prover corresponding to
+    [prover_name] (if given or a default one otherwise) on the goal type [gt],
+    and fails if no proof is found. *)
+val handle: Sig_state.t -> Pos.popt -> string option -> Proof.goal_typ -> unit

--- a/src/pure/pure.ml
+++ b/src/pure/pure.ml
@@ -166,8 +166,7 @@ let handle_command : state -> Command.t -> command_result =
 let handle_tactic : proof_state -> Tactic.t -> int -> tactic_result =
   fun (_, ss, ps, finalize, prv, sym_pos) tac n ->
   try
-    let ss, ps, qres =
-      Handle.Tactic.handle sym_pos prv (ss, ps, None) tac n in
+    let ps, qres = Handle.Tactic.handle ss sym_pos prv (ps, None) tac n in
     let qres = Option.map (fun f -> f ()) qres in
     Tac_OK((Time.save (), ss, ps, finalize, prv, sym_pos), qres)
   with Fatal(p,m) -> Tac_Error(p,m)

--- a/tests/OK/FOL.lp
+++ b/tests/OK/FOL.lp
@@ -11,3 +11,8 @@ rule π (∀ $f) ↪ Π x, π ($f x);
 // Existential quantification
 
 constant symbol ∃ [a] : (τ a → Prop) → Prop; notation ∃ quantifier; // ?? or \exists
+
+constant symbol ∃ᵢ [a] p (x:τ a) : π (p x) → π (∃ p);
+symbol ∃ₑ [a] p : π (∃ p) → Π q, (Π x:τ a, π (p x) → π q) → π q;
+
+rule ∃ₑ _ (∃ᵢ _ $x $px) _ $f ↪ $f $x $px;

--- a/tests/OK/Nat.lp
+++ b/tests/OK/Nat.lp
@@ -10,3 +10,5 @@ builtin "+1" ≔ +1;
 constant symbol nat : Set;
 
 rule τ nat ↪ ℕ;
+
+symbol + : ℕ → ℕ → ℕ; notation + infix 20;

--- a/tests/OK/Set.lp
+++ b/tests/OK/Set.lp
@@ -5,3 +5,7 @@ constant symbol Set : TYPE;
 injective symbol τ : Set → TYPE; // `t or \tau
 
 builtin "T" ≔ τ;
+
+symbol ↦ : Set → Set → Set; notation ↦ infix 20;
+
+rule τ($a ↦ $b) ↪ τ $a → τ $b;

--- a/tests/OK/admit.lp
+++ b/tests/OK/admit.lp
@@ -18,7 +18,7 @@ symbol π_f: Prf (f _)
 begin
   admit
   // Adds an axiom [ax_?]
-admitted;
+end;
 
 // Two metas, one depending on the other
 symbol prop2: Prf prop1 → Prop;


### PR DESCRIPTION
- a tactic application does not need to generate a new sig_state since generated axioms do not need to be in scope
- Why3_tactic.handle does not generate axioms anymore: this is done in tactic.ml using tac_admit
- move FOL config in a separate file