### PR TITLE
use dune 3.7

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 ; Add project-wide flags here.
 (env
- (dev     (flags :standard))
- (release (flags :standard)))
+ (dev     (flags :standard -warn-error -69))
+ (release (flags :standard -warn-error -69)))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 3.7)
 
 (generate_opam_files false)
 

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -47,7 +47,7 @@ homepage: "https://github.com/Deducteam/lambdapi"
 bug-reports: "https://github.com/Deducteam/lambdapi/issues"
 dev-repo: "git+https://github.com/Deducteam/lambdapi.git"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.7"}
   "ocaml" {>= "4.08.0"}
   "menhir" {>= "20200624"}
   "sedlex" {>= "2.2"}

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -127,13 +127,15 @@ let link : t -> unit = fun sign ->
   in
   StrMap.iter f !(sign.sign_symbols);
   let f mp sm =
-    let sign = Path.Map.find mp !loaded in
-    let g n rs =
-      let s = find sign n in
-      s.sym_rules := !(s.sym_rules) @ List.map link_rule rs;
-      Tree.update_dtree s []
-    in
-    StrMap.iter g sm
+    if sm <> Extra.StrMap.empty then
+      let sign =
+        try Path.Map.find mp !loaded with Not_found -> assert false in
+      let g n rs =
+        let s = try find sign n with Not_found -> assert false in
+        s.sym_rules := !(s.sym_rules) @ List.map link_rule rs;
+        Tree.update_dtree s []
+      in
+      StrMap.iter g sm
   in
   Path.Map.iter f !(sign.sign_deps);
   sign.sign_builtins := StrMap.map link_symb !(sign.sign_builtins);

--- a/src/lplib/rangeMap.mli
+++ b/src/lplib/rangeMap.mli
@@ -10,5 +10,5 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-module Make (R : Range_intf.S) : RangeMap_intf.S
+module Make : Range_intf.S -> RangeMap_intf.S
 include RangeMap_intf.S with module Range = Range


### PR DESCRIPTION
Fix https://github.com/Deducteam/lambdapi/issues/958.
It seems that `:standard` flags are not the same between dune 2.7 and dune 3.7.