### PR TITLE
reverts the configuration of eglot-move-to-column-function introduced in 0883cce9

### DIFF
--- a/editors/emacs/lambdapi-mode.el
+++ b/editors/emacs/lambdapi-mode.el
@@ -194,9 +194,6 @@
    '(lambdapi-mode . ("lambdapi" "lsp" "--standard-lsp")))
   (eglot-ensure)
 
-  ;; set column offsets for lambdapi's LSP server
-  (setq-local eglot-move-to-column-function #'eglot-move-to-column)
-
   ;; Hooks for goals
   (add-hook 'post-command-hook #'lambdapi-update-line-number nil :local)
   ;; Hook binding line change to re-execution of proof/goals


### PR DESCRIPTION
The workaround introduced in 0883cce9 to circumvent the utf8/utf16 problem explained in #452,  breaks now the lambdapi-mode plugin for emacs ( at least with recent versions of eglot which is now a emacs builtin plugin ).

Many stuff changed since we talked about that (10/2020)  : lambdapi lexer (sedlex), parser (menhir/pratter), syntax (ending  tactic with semicolon, removed set builtin, ...)

I don't know what should be done :  just remove this line ?

```elisp
(setq eglot-move-to-column-function 'eglot-move-to-column)
```

@fblanqui @firewall2142 @gabrielhdt @ejgallego @joaotavora

Are there interesting stuffs to "backport" from ejgallego/coq-lsp#193 ?