### PR TITLE
Fix highlighting of multi-line comments in vim

### DIFF
--- a/editors/vim/syntax/lambdapi.vim
+++ b/editors/vim/syntax/lambdapi.vim
@@ -13,6 +13,9 @@ endif
 syntax keyword Todo contained TODO FIXME NOTE
 syntax region Comment start="//\($\|[^/]\)" end="$" contains=Todo
 
+" Multi-line comments.
+syntax region Comment start="/\*" end="\*/" contains=Todo
+
 " Documentation comments (FIXME).
 syntax include @markdown syntax/markdown.vim
 syntax region Comment start="///" end="$" contains=@markdown


### PR DESCRIPTION
The vim syntax file provided in the repo did not correctly detect multi-line comments.