### PR TITLE
fix order of parameters in the type of generated induction principles

### DIFF
--- a/src/handle/inductive.ml
+++ b/src/handle/inductive.ml
@@ -209,7 +209,7 @@ let fold_cons_type
     | _ -> fatal pos "The type of %a is not supported" sym cons_sym
   in
   let _, t = Env.of_prod_using [] vs !(cons_sym.sym_type) in
-  fold (List.mapi inj_var (Array.to_list vs)) 0 init t
+  fold (List.rev_mapi inj_var (Array.to_list vs)) 0 init t
 
 (** [gen_rec_type c pos ind_list vs env ind_pred_map x_str] generates the
    induction principles for each type in the inductive definition [ind_list]

--- a/tests/OK/989.lp
+++ b/tests/OK/989.lp
@@ -1,0 +1,23 @@
+symbol Prop : TYPE;
+injective symbol Prf : Prop → TYPE;
+builtin "Prop" ≔ Prop;
+builtin "P" ≔ Prf;
+
+symbol Set : TYPE; 
+injective symbol τ : Set → TYPE;
+injective symbol τ' : Prop → TYPE;
+
+(a:Set) inductive L:TYPE ≔
+| nil : L a
+| cons : τ a → L a → L a;
+
+/*
+debug +sriu;
+verbose 3;
+flag "print_meta_types" on;
+flag "print_implicits" on;
+*/
+
+(a:Set) (b:Prop) inductive 𝕃:TYPE ≔
+| □  : 𝕃 a b
+| ⸬  : τ a → τ' b → 𝕃 a b → 𝕃 a b;

--- a/tests/OK/remove.lp
+++ b/tests/OK/remove.lp
@@ -2,7 +2,7 @@ symbol A:TYPE;
 symbol B:A → TYPE;
 symbol C a:B a → TYPE;
 
-debug +t;
+//debug +t;
 
 opaque symbol lemma : A → A ≔
 begin


### PR DESCRIPTION
fix #989 