### PR TITLE
fix doc

### DIFF
--- a/doc/terms.rst
+++ b/doc/terms.rst
@@ -16,8 +16,9 @@ An identifier can be:
 **Remark:** for any regular identifier ``i``, ``{|i|}`` and ``i`` are
 identified.
 
-**Remark:** identifiers ending with a non-negative integer with
-leading zeros cannot be used for bound variable names.
+**Remark:** Escaped identifiers or regular identifiers ending with a
+non-negative integer with leading zeros cannot be used for bound
+variable names.
 
 **Convention:** identifiers starting with an uppercase letter denote
 types (e.g.  ``Nat``, ``List``), and identifiers starting with a


### PR DESCRIPTION
non-regular identifiers are not allowed for bound variable names