### PR TITLE
coq export: add mappings of erasing.lp in rmap if possible

### DIFF
--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -97,7 +97,9 @@ let set_erasing : string -> unit = fun f ->
         let id = snd lp_qid.elt in
         if Logger.log_enabled() then log "erase %s" id;
         erase := StrSet.add id !erase;
-        map_erased_qid_coq := QidMap.add lp_qid.elt coq_id !map_erased_qid_coq
+        map_erased_qid_coq := QidMap.add lp_qid.elt coq_id !map_erased_qid_coq;
+        if fst lp_qid.elt = [] && id <> coq_id then
+          rmap := StrMap.add id coq_id !rmap
     | {pos;_} -> fatal pos "Invalid command."
   in
   Stream.iter consume (Parser.parse_file f)


### PR DESCRIPTION
add mappings of erasing.lp in rmap if possible so that renamings defined in erasing.lp are also applied on variable names
the problem is that the translation is done after parsing but better scoping so that we don't know which identifiers are variables or symbols
this avoids duplicating some renamings between erasing.lp and renaming.lp