### PR TITLE
Vscode : use latest version of vscode-languageclient and update dependant libraries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,4 @@ jobs:
           eval $(opam env)
           #why3 config detect
           make tests
+          make build-vscode-extension

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,4 +43,8 @@ jobs:
           npm install -g @types/vscode
           npm install -g vsce 
           make build-vscode-extension
-          
+      - name: publish vscode extension
+        uses: actions/upload-artifact@v2
+        with: 
+          name: assets-for-download
+          path: editors/vscode/extensionFolder

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,13 @@ jobs:
           eval $(opam env)
           #why3 config detect
           make tests
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      - name: generate-vscode-extension
+        run: |
+          npm install -g @types/vscode
+          npm install -g vsce 
           make build-vscode-extension
+          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: latest
       - name: generate-vscode-extension
         run: |
           npm install -g @types/vscode

--- a/Makefile
+++ b/Makefile
@@ -168,5 +168,5 @@ uninstall_vim_mode:
 
 .PHONY: build-vscode-extension
 build-vscode-extension:
-	cd editors/vscode && make
+	cd editors/vscode && make && vsce package
 	

--- a/Makefile
+++ b/Makefile
@@ -165,3 +165,8 @@ uninstall_vim_mode:
 	rm -f $(VIMDIR)/syntax/lambdapi.vim
 	rm -f $(VIMDIR)/ftdetect/dedukti.vim
 	rm -f $(VIMDIR)/ftdetect/lambdapi.vim
+
+.PHONY: build-vscode-extension
+build-vscode-extension:
+	cd editors/vscode && make
+	

--- a/Makefile
+++ b/Makefile
@@ -168,5 +168,5 @@ uninstall_vim_mode:
 
 .PHONY: build-vscode-extension
 build-vscode-extension:
-	cd editors/vscode && make && vsce package
+	cd editors/vscode && make && mkdir extensionFolder && vsce package -o extensionFolder
 	

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -8,15 +8,15 @@
       "name": "lambdapi",
       "version": "0.2.1",
       "dependencies": {
-        "@vscode/vsce": "^2.20.0",
+        "@vscode/vsce": "^2.21.1",
         "fs-extra": "^9.0.1",
-        "vscode-languageclient": "5.2.1"
+        "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
         "@types/mocha": "^2.2.42",
-        "@types/node": "^10.14.15",
-        "@types/vscode": "^1.37",
-        "typescript": "^3.3.1"
+        "@types/node": "^18.18.1",
+        "@types/vscode": "^1.75.0",
+        "typescript": "^5.2.2"
       },
       "engines": {
         "vscode": "^1.37.0"
@@ -29,26 +29,29 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.49.tgz",
-      "integrity": "sha512-PGaJNs5IZz5XgzwJvL/1zRfZB7iaJ5BydZ8/Picm+lUNYoNO9iVTQkVy5eUh0dZDrx3rBOIs3GCbCRmMuYyqwg==",
-      "dev": true
+      "version": "18.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.18.tgz",
+      "integrity": "sha512-80CP7B8y4PzZF0GWx15/gVWRrB5y/bIjNI84NK3cmQJu0WZwvmj2WMA5LcofQFVfLqqCSp545+U2LsrVzX36Zg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.86.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
+      "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
       "dev": true
     },
     "node_modules/@vscode/vsce": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.20.0.tgz",
-      "integrity": "sha512-FR8Tq2WgGRi/Py5/9WUFG2DCxdqaHXyuhHXSP8hsNc1FsxNzAkqKqfvOUUGxA7gOytmc9s/000QA7wKVukMDbQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.24.0.tgz",
+      "integrity": "sha512-p6CIXpH5HXDqmUkgFXvIKTjZpZxy/uDx4d/UsfhS9vQUun43KDNUbYeZocyAHgqcJlPEurgArHz9te1PPiqPyA==",
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.9",
-        "commander": "^6.1.0",
+        "commander": "^6.2.1",
         "glob": "^7.0.6",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
@@ -1183,16 +1186,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -1204,6 +1207,12 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "1.0.0",
@@ -1225,38 +1234,72 @@
       "optional": true
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-      "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "dependencies": {
-        "semver": "^5.5.0",
-        "vscode-languageserver-protocol": "3.14.1"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.30"
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageserver-types": "3.14.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -1314,26 +1357,29 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.49.tgz",
-      "integrity": "sha512-PGaJNs5IZz5XgzwJvL/1zRfZB7iaJ5BydZ8/Picm+lUNYoNO9iVTQkVy5eUh0dZDrx3rBOIs3GCbCRmMuYyqwg==",
-      "dev": true
+      "version": "18.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.18.tgz",
+      "integrity": "sha512-80CP7B8y4PzZF0GWx15/gVWRrB5y/bIjNI84NK3cmQJu0WZwvmj2WMA5LcofQFVfLqqCSp545+U2LsrVzX36Zg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.86.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
+      "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
       "dev": true
     },
     "@vscode/vsce": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.20.0.tgz",
-      "integrity": "sha512-FR8Tq2WgGRi/Py5/9WUFG2DCxdqaHXyuhHXSP8hsNc1FsxNzAkqKqfvOUUGxA7gOytmc9s/000QA7wKVukMDbQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.24.0.tgz",
+      "integrity": "sha512-p6CIXpH5HXDqmUkgFXvIKTjZpZxy/uDx4d/UsfhS9vQUun43KDNUbYeZocyAHgqcJlPEurgArHz9te1PPiqPyA==",
       "requires": {
         "azure-devops-node-api": "^11.0.1",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.9",
-        "commander": "^6.1.0",
+        "commander": "^6.2.1",
         "glob": "^7.0.6",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
@@ -2151,9 +2197,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "uc.micro": {
@@ -2165,6 +2211,12 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "universalify": {
       "version": "1.0.0",
@@ -2183,32 +2235,59 @@
       "optional": true
     },
     "vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
     },
     "vscode-languageclient": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-      "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "requires": {
-        "semver": "^5.5.0",
-        "vscode-languageserver-protocol": "3.14.1"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "requires": {
-        "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageserver-types": "3.14.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
   "version": "0.2.1",
   "publisher": "Deducteam",
   "engines": {
-    "vscode": "^1.37.0"
+    "vscode": "^1.82.0"
   },
   "categories": [
     "Programming Languages"
@@ -161,13 +161,13 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
-    "@types/node": "^10.14.15",
-    "@types/vscode": "^1.37",
-    "typescript": "^3.3.1"
+    "@types/node": "^18.18.1",
+    "@types/vscode": "^1.75.0",
+    "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@vscode/vsce": "^2.20.0",
+    "@vscode/vsce": "^2.21.1",
     "fs-extra": "^9.0.1",
-    "vscode-languageclient": "5.2.1"
+    "vscode-languageclient": "^9.0.1"
   }
 }

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -1,7 +1,31 @@
 // VSCode extension for https://github.com/Deducteam/lambdapi
 // a proof assistant based on the λΠ-calculus modulo rewriting
 
-import { workspace, ExtensionContext, Position, Uri, commands, window, WebviewPanel, ViewColumn, TextEditor, TextDocument, SnippetString, Range, TextEditorDecorationType, Pseudoterminal, EventEmitter, TreeItemCollapsibleState, WebviewViewProvider, CancellationToken, WebviewView, WebviewViewResolveContext, TextDocumentChangeEvent, Diagnostic, languages } from 'vscode';
+import { 
+    workspace, 
+    ExtensionContext, 
+    Position, 
+    Uri, 
+    commands, 
+    window, 
+    WebviewPanel, 
+    ViewColumn, 
+    TextEditor, 
+    TextDocument, 
+    SnippetString, 
+    Range, 
+    TextEditorDecorationType, 
+    Pseudoterminal, 
+    EventEmitter, 
+    TreeItemCollapsibleState, 
+    WebviewViewProvider, 
+    CancellationToken, 
+    WebviewView, 
+    WebviewViewResolveContext, 
+    TextDocumentChangeEvent, 
+    Diagnostic, 
+    languages 
+} from 'vscode';
 
 // Insiders API, disabled
 // import { WebviewEditorInset } from 'vscode';
@@ -9,14 +33,12 @@ import { workspace, ExtensionContext, Position, Uri, commands, window, WebviewPa
 import {
     LanguageClient,
     LanguageClientOptions,
-    ServerOptions,
-    TransportKind,
     RequestType,
     NotificationType,
     TextDocumentIdentifier,
     RegistrationRequest,
     DocumentSymbolRequest,
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 
 import { assert, time } from 'console';
 
@@ -92,7 +114,7 @@ export function activate(context: ExtensionContext) {
             clientOptions
         );
 
-        client.onReady().then( () => {
+        client.start().then( () => {
 
             // Create and show panel for proof goals
             const panel = window.createWebviewPanel(
@@ -152,7 +174,7 @@ export function activate(context: ExtensionContext) {
 
         });
 
-        context.subscriptions.push(client.start());
+        context.subscriptions.push(client);
     };
     
     commands.registerCommand('extension.lambdapi.restart', restart);
@@ -571,7 +593,7 @@ function sendGoalsRequest(position: Position, panel : WebviewPanel, docUri : Uri
 
     let doc = {uri : docUri.toString()}
     let cursor = {textDocument : doc, position : position};
-    const req = new RequestType<ParamsGoals, GoalResp, void, void>("proof/goals");
+    const req = new RequestType<ParamsGoals, GoalResp, void>("proof/goals");
     client.sendRequest(req, cursor).then((goals) => {
         
         updateTerminalText(goals.logs);


### PR DESCRIPTION
This PR updates the following dependencies : 

- vscode engine from 1.37 to 1.82
- @types/node from 10.14.15 to 18.18.1
- @types/vscode from 1.37 to 1.75.0
- typescript from 3.3.1 to 5.2.2
- @vscode/vsce from 2.20.0 to 2.21.1
- vscode-languageclient from 5.2.1 to 9.0.1

Besides, it adds the building instructions of the Vscode extension to the Github pipeline.
