### PR TITLE
Fix Dependabot/GitHub actions/actions/upload artifact 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: checking out lambdapi repo ...
         uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: latest
       - name: generate-vscode-extension

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
   workflow_dispatch:
 jobs:
-  build:
+  build_lambdapi:
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +34,13 @@ jobs:
           eval $(opam env)
           #why3 config detect
           make tests
+  build_vscode_extension:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: checking out lambdapi repo ...
+        uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Upgrading actions/upload-artifact@v2 to v4 breaks the generation the Vscode extension in the pipeline because this new version doesn't allow the artifacts exported by the pipeline to have the same name (previous was to replace existing artifacts).

To fix this, a separate job is dedicated to the generation of the Vscode extension independently from OCaml version which avoids multiple generations. 

Besides, the nodejs version has been upgrated to newest version (up to 20)