### PR TITLE
Reopen the goals panel if closed when navigating proofs

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "vscode": "^1.37.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/@types/mocha": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -153,7 +153,7 @@
       }
     ]
   },
-  "main": "out/src/client.js",
+  "main": "out/src/browser.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -1,18 +1,18 @@
-import { ExtensionContext } from "vscode";
-import { LanguageClient } from "vscode-languageclient/browser";
-import { activateClientLSP, ClientFactoryType, deactivateClientLSP} from "./client";
+import { ExtensionContext, window } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { activateClientLSP, ClientFactoryType, deactivateClientLSP } from "./client";
 
 export function activate(context: ExtensionContext): void {
-  const cf: ClientFactoryType = (context, clientOptions, wsConfig) => {
-    // Pending on having the API to fetch the worker file.
-    throw "Worker not found";
-    let worker = new Worker("");
+  const cf: ClientFactoryType = (context, clientOptions, wsConfig, lspServerPath) => {
+    let serverOptions = {
+      command: lspServerPath,
+      args: ['lsp']
+    };
     return new LanguageClient(
       "lambdapi",
       "lambdapi language server",
-      clientOptions,
-      worker
-    );
+      serverOptions,
+      clientOptions);
   };
   activateClientLSP(context, cf);
 }

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -1,0 +1,22 @@
+import { ExtensionContext } from "vscode";
+import { LanguageClient } from "vscode-languageclient/browser";
+import { activateClientLSP, deactivateClientLSP} from "./client"; //, ClientFactoryType
+
+export function activate(context: ExtensionContext): void {
+  // const cf: ClientFactoryType = (context, clientOptions, wsConfig) => {
+  //   // Pending on having the API to fetch the worker file.
+  //   throw "Worker not found";
+  //   let worker = new Worker("");
+  //   return new LanguageClient(
+  //     "lambdapi",
+  //     "lambdapi language server",
+  //     clientOptions,
+  //     worker
+  //   );
+  // };
+  activateClientLSP(context);
+}
+
+export function deactivate() {
+  deactivateClientLSP();
+}

--- a/editors/vscode/src/browser.ts
+++ b/editors/vscode/src/browser.ts
@@ -1,20 +1,20 @@
 import { ExtensionContext } from "vscode";
 import { LanguageClient } from "vscode-languageclient/browser";
-import { activateClientLSP, deactivateClientLSP} from "./client"; //, ClientFactoryType
+import { activateClientLSP, ClientFactoryType, deactivateClientLSP} from "./client";
 
 export function activate(context: ExtensionContext): void {
-  // const cf: ClientFactoryType = (context, clientOptions, wsConfig) => {
-  //   // Pending on having the API to fetch the worker file.
-  //   throw "Worker not found";
-  //   let worker = new Worker("");
-  //   return new LanguageClient(
-  //     "lambdapi",
-  //     "lambdapi language server",
-  //     clientOptions,
-  //     worker
-  //   );
-  // };
-  activateClientLSP(context);
+  const cf: ClientFactoryType = (context, clientOptions, wsConfig) => {
+    // Pending on having the API to fetch the worker file.
+    throw "Worker not found";
+    let worker = new Worker("");
+    return new LanguageClient(
+      "lambdapi",
+      "lambdapi language server",
+      clientOptions,
+      worker
+    );
+  };
+  activateClientLSP(context, cf);
 }
 
 export function deactivate() {

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -44,7 +44,7 @@ import { assert, time } from 'console';
 
 let client: LanguageClient;
 
-export function activate(context: ExtensionContext) {
+export function activateClientLSP(context: ExtensionContext) {
 
     workspace.onDidChangeTextDocument((e)=>{
         lpDocChangeHandler(e, context);
@@ -611,7 +611,7 @@ function sendGoalsRequest(position: Position, panel : WebviewPanel, docUri : Uri
 }
 
 
-export function deactivate(): Thenable<void> | undefined {
+export function deactivateClientLSP(): Thenable<void> | undefined {
     if (!client) {
         return undefined;
     }

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -24,16 +24,23 @@ import {
     WebviewViewResolveContext, 
     TextDocumentChangeEvent, 
     Diagnostic, 
-    languages 
+    languages,
+    WorkspaceConfiguration
 } from 'vscode';
 
 // Insiders API, disabled
 // import { WebviewEditorInset } from 'vscode';
 
 import {
-    LanguageClient,
+    BaseLanguageClient,
     LanguageClientOptions,
     RequestType,
+    RevealOutputChannelOn,
+    VersionedTextDocumentIdentifier,
+  } from "vscode-languageclient";
+
+import {
+    LanguageClient,
     NotificationType,
     TextDocumentIdentifier,
     RegistrationRequest,
@@ -42,9 +49,17 @@ import {
 
 import { assert, time } from 'console';
 
-let client: LanguageClient;
+let client: BaseLanguageClient;
 
-export function activateClientLSP(context: ExtensionContext) {
+// Client Factory types
+export type ClientFactoryType = (
+    context: ExtensionContext,
+    clientOptions: LanguageClientOptions,
+    wsConfig: WorkspaceConfiguration
+  ) => BaseLanguageClient;
+
+export function activateClientLSP(context: ExtensionContext,
+    clientFactory: ClientFactoryType) {
 
     workspace.onDidChangeTextDocument((e)=>{
         lpDocChangeHandler(e, context);
@@ -107,7 +122,10 @@ export function activateClientLSP(context: ExtensionContext) {
             client.stop();
         }
 
-        client = new LanguageClient(
+        const wsConfig = workspace.getConfiguration("lambdapi");
+
+        // client = clientFactory(context, clientOptions, wsConfig);
+        client =  new LanguageClient(
             'lambdapi',
             'lambdapi language server',
             serverOptions,

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -351,16 +351,20 @@ export function activateClientLSP(context: ExtensionContext,
             resolve(client);
         });
 
-        window.showInformationMessage("client created");
+        // window.showInformationMessage("client created");
         cP.then((client) => client.start().then(() => {
-            window.showInformationMessage("client started");
+            // window.showInformationMessage("client started");
             // Create and show panel for proof goals
-            const panel = window.createWebviewPanel(
+            let panel : WebviewPanel | null = window.createWebviewPanel(
                 'goals',
                 'Goals',
                 ViewColumn.Two,
                 {}
             );
+            panel.onDidDispose(() => {
+                window.showInformationMessage("Panel has been disposed");
+                panel = null;
+            })
             context.workspaceState.update('panel', panel);
         })
         )

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -67,7 +67,7 @@ export function activateClientLSP(context: ExtensionContext,
 
 
 
-function goToProofState(context: ExtensionContext) {
+function goToProofState() {
 
     const proofState: Position | undefined = context.workspaceState.get('proofState');
     if (!proofState) {
@@ -78,7 +78,7 @@ function goToProofState(context: ExtensionContext) {
     commands.executeCommand('revealLine', { lineNumber: proofState.line, at: 'center' });
 }
 
-function toggleCursorMode(context: ExtensionContext): boolean {
+function toggleCursorMode(): boolean {
     let cursorMode: boolean = context.workspaceState.get('cursorMode') ?? false;
 
     cursorMode = !cursorMode;
@@ -90,7 +90,7 @@ function toggleCursorMode(context: ExtensionContext): boolean {
 
         //By default, follow mode is disabled in cursor mode (because it may be nausea-inducing)
         if (context.workspaceState.get('follow'))
-            toggleFollowMode(context);
+            toggleFollowMode();
     }
 
     else {
@@ -99,13 +99,13 @@ function toggleCursorMode(context: ExtensionContext): boolean {
 
         //By default, follow mode is enabled when cursor mode is off (because it is more practical)
         if (!context.workspaceState.get('follow'))
-            toggleFollowMode(context);
+            toggleFollowMode();
     }
 
     return cursorMode;
 }
 
-function toggleFollowMode(context: ExtensionContext): boolean {
+function toggleFollowMode(): boolean {
     let follow: boolean = context.workspaceState.get('follow') ?? false;
 
     follow = !follow;
@@ -121,7 +121,7 @@ function toggleFollowMode(context: ExtensionContext): boolean {
     return follow;
 }
 
-function checkProofForward(context: ExtensionContext) {
+function checkProofForward() {
 
     //Checking workspace
     const openEditor: TextEditor | undefined = window.activeTextEditor;
@@ -140,7 +140,7 @@ function checkProofForward(context: ExtensionContext) {
         lpRefresh(context, newPos, panel, openEditor);
 }
 
-function checkProofBackward(context: ExtensionContext) {
+function checkProofBackward() {
 
     //Checking workspace
     const openEditor: TextEditor | undefined = window.activeTextEditor;
@@ -161,7 +161,7 @@ function checkProofBackward(context: ExtensionContext) {
         lpRefresh(context, newPos, panel, openEditor);
 }
 
-function checkProofUntilCursor(context: ExtensionContext) {
+function checkProofUntilCursor() {
 
     //Checking workspace
     const openEditor: TextEditor | undefined = window.activeTextEditor;
@@ -291,29 +291,29 @@ function checkProofUntilCursor(context: ExtensionContext) {
                 if (!cursorMode)
                     return;
 
-                checkProofUntilCursor(context);
+                checkProofUntilCursor();
             });
 
             /*Toggle cursor mode (defaults to false)
                 *if true, the "Proof" panel is updated when the cursor is moved
                 *if false, updated when keybindings are pressed
             */
-            commands.registerCommand('extension.lambdapi.cursor', () => toggleCursorMode(context));
+            commands.registerCommand('extension.lambdapi.cursor', () => toggleCursorMode());
 
             //Navigate proof : step forward in a proof 
-            commands.registerCommand('extension.lambdapi.fw', () => checkProofForward(context));
+            commands.registerCommand('extension.lambdapi.fw', () => checkProofForward());
 
             //Navigate proof : step backward in a proof
-            commands.registerCommand('extension.lambdapi.bw', () => checkProofBackward(context));
+            commands.registerCommand('extension.lambdapi.bw', () => checkProofBackward());
 
             //Navigate proof : move proof highlight to cursor
-            commands.registerCommand('extension.lambdapi.tc', () => checkProofUntilCursor(context));
+            commands.registerCommand('extension.lambdapi.tc', () => checkProofUntilCursor());
 
             //Window follows proof or not
-            commands.registerCommand('extension.lambdapi.reveal', () => toggleFollowMode(context))
+            commands.registerCommand('extension.lambdapi.reveal', () => toggleFollowMode())
 
             //Center window on proof state
-            commands.registerCommand('extension.lambdapi.center', () => goToProofState(context));
+            commands.registerCommand('extension.lambdapi.center', () => goToProofState());
 
             //Go to next/previous proof
             commands.registerCommand('extension.lambdapi.nx', () => nextProof(context, true));

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -1,29 +1,29 @@
 // VSCode extension for https://github.com/Deducteam/lambdapi
 // a proof assistant based on the λΠ-calculus modulo rewriting
 
-import { 
-    workspace, 
-    ExtensionContext, 
-    Position, 
-    Uri, 
-    commands, 
-    window, 
-    WebviewPanel, 
-    ViewColumn, 
-    TextEditor, 
-    TextDocument, 
-    SnippetString, 
-    Range, 
-    TextEditorDecorationType, 
-    Pseudoterminal, 
-    EventEmitter, 
-    TreeItemCollapsibleState, 
-    WebviewViewProvider, 
-    CancellationToken, 
-    WebviewView, 
-    WebviewViewResolveContext, 
-    TextDocumentChangeEvent, 
-    Diagnostic, 
+import {
+    workspace,
+    ExtensionContext,
+    Position,
+    Uri,
+    commands,
+    window,
+    WebviewPanel,
+    ViewColumn,
+    TextEditor,
+    TextDocument,
+    SnippetString,
+    Range,
+    TextEditorDecorationType,
+    Pseudoterminal,
+    EventEmitter,
+    TreeItemCollapsibleState,
+    WebviewViewProvider,
+    CancellationToken,
+    WebviewView,
+    WebviewViewResolveContext,
+    TextDocumentChangeEvent,
+    Diagnostic,
     languages,
     WorkspaceConfiguration
 } from 'vscode';
@@ -37,7 +37,7 @@ import {
     RequestType,
     RevealOutputChannelOn,
     VersionedTextDocumentIdentifier,
-  } from "vscode-languageclient";
+} from "vscode-languageclient";
 
 import {
     LanguageClient,
@@ -56,26 +56,26 @@ export type ClientFactoryType = (
     context: ExtensionContext,
     clientOptions: LanguageClientOptions,
     wsConfig: WorkspaceConfiguration
-  ) => BaseLanguageClient;
+) => BaseLanguageClient;
 
 export function activateClientLSP(context: ExtensionContext,
     clientFactory: ClientFactoryType) {
 
-    workspace.onDidChangeTextDocument((e)=>{
+    workspace.onDidChangeTextDocument((e) => {
         lpDocChangeHandler(e, context);
     })
 
     //___Declaration of workspace variables___
 
     //Position of the proof cursor : colored highlights show until which point the proof was surveyed
-    let proofState : Position = new Position(0, 0);
+    let proofState: Position = new Position(0, 0);
     context.workspaceState.update('proofState', proofState);
 
     //Cursor mode (proof cursor is the regular cursor) activated or not
     context.workspaceState.update('cursorMode', false);
 
     //The range of text to highlight
-    let range : Range = new Range(new Position(0, 0), proofState);
+    let range: Range = new Range(new Position(0, 0), proofState);
     context.workspaceState.update('range', range);
 
     //The highlight parameters
@@ -87,7 +87,7 @@ export function activateClientLSP(context: ExtensionContext,
             backgroundColor: '#08883555' //highlight color for a dark theme
         },
         rangeBehavior: 1 // ClosedClosed
-      });
+    });
     const errorDecoration = window.createTextEditorDecorationType({
         light: {
             backgroundColor: '#FF000055' //highlight color for a light theme
@@ -96,19 +96,19 @@ export function activateClientLSP(context: ExtensionContext,
             backgroundColor: '#FF000055' //highlight color for a dark theme
         },
         rangeBehavior: 1 // ClosedClosed
-      });
+    });
     context.workspaceState.update('proofDecoration', proofDecoration);
     context.workspaceState.update('errorDecoration', errorDecoration);
 
     //Following mode : whether the window follows proofState automatically or not
     context.workspaceState.update('follow', true);
-    
+
     const lspServerPath = workspace.getConfiguration('lambdapi').path;
     console.log(lspServerPath);
 
     let serverOptions = {
         command: lspServerPath,
-        args: [ 'lsp' ]
+        args: ['lsp']
         // args: [ '--std' ]
     };
 
@@ -125,14 +125,14 @@ export function activateClientLSP(context: ExtensionContext,
         const wsConfig = workspace.getConfiguration("lambdapi");
 
         // client = clientFactory(context, clientOptions, wsConfig);
-        client =  new LanguageClient(
+        client = new LanguageClient(
             'lambdapi',
             'lambdapi language server',
             serverOptions,
             clientOptions
         );
 
-        client.start().then( () => {
+        client.start().then(() => {
 
             // Create and show panel for proof goals
             const panel = window.createWebviewPanel(
@@ -145,10 +145,10 @@ export function activateClientLSP(context: ExtensionContext,
 
             window.onDidChangeActiveTextEditor(e => {
 
-                const proofState : Position | undefined = context.workspaceState.get('proofState');
-                const panel : WebviewPanel | undefined = context.workspaceState.get('panel');
+                const proofState: Position | undefined = context.workspaceState.get('proofState');
+                const panel: WebviewPanel | undefined = context.workspaceState.get('panel');
 
-                if (!proofState || !panel) {
+                if (!proofState || !panel) {
                     console.log('onDidChangeActiveTextEditor : workspace variables are not properly defined');
                     return;
                 }
@@ -156,10 +156,10 @@ export function activateClientLSP(context: ExtensionContext,
                 refreshGoals(panel, e, proofState, context);
             });
 
-            window.onDidChangeTextEditorSelection(e => { 
+            window.onDidChangeTextEditorSelection(e => {
 
-                const cursorMode : boolean = context.workspaceState.get('cursorMode') ?? false;
-                if(!cursorMode)
+                const cursorMode: boolean = context.workspaceState.get('cursorMode') ?? false;
+                if (!cursorMode)
                     return;
 
                 checkProofUntilCursor(context);
@@ -170,16 +170,16 @@ export function activateClientLSP(context: ExtensionContext,
                 *if false, updated when keybindings are pressed
             */
             commands.registerCommand('extension.lambdapi.cursor', () => toggleCursorMode(context));
- 
+
             //Navigate proof : step forward in a proof 
             commands.registerCommand('extension.lambdapi.fw', () => checkProofForward(context));
-            
+
             //Navigate proof : step backward in a proof
             commands.registerCommand('extension.lambdapi.bw', () => checkProofBackward(context));
 
             //Navigate proof : move proof highlight to cursor
             commands.registerCommand('extension.lambdapi.tc', () => checkProofUntilCursor(context));
-            
+
             //Window follows proof or not
             commands.registerCommand('extension.lambdapi.reveal', () => toggleFollowMode(context))
 
@@ -194,38 +194,38 @@ export function activateClientLSP(context: ExtensionContext,
 
         context.subscriptions.push(client);
     };
-    
+
     commands.registerCommand('extension.lambdapi.restart', restart);
-    
+
     restart();
 }
 
-function lpDocChangeHandler(event : TextDocumentChangeEvent, context: ExtensionContext) {
+function lpDocChangeHandler(event: TextDocumentChangeEvent, context: ExtensionContext) {
 
-    if(event.document != window.activeTextEditor?.document){
+    if (event.document != window.activeTextEditor?.document) {
         // should not happen
         console.log("Changes not on the active TextEditor");
         return;
     }
-    let proofPos : Position | undefined = context.workspaceState.get('proofState');
+    let proofPos: Position | undefined = context.workspaceState.get('proofState');
     if (!proofPos) proofPos = new Position(0, 0);
 
-    let firstChange : Position | undefined = undefined;
-    for(let i = 0; i < event.contentChanges.length; i++){
+    let firstChange: Position | undefined = undefined;
+    for (let i = 0; i < event.contentChanges.length; i++) {
         let change = event.contentChanges[i];
-        let changeStart : Position = change.range.start;
-        if(firstChange != undefined) 
+        let changeStart: Position = change.range.start;
+        if (firstChange != undefined)
             firstChange = changeStart.isBefore(firstChange) ? changeStart : firstChange;
-        else 
+        else
             firstChange = changeStart;
     }
 
-    if(firstChange && firstChange.isBefore(proofPos)){
+    if (firstChange && firstChange.isBefore(proofPos)) {
         // region inside proved region is changed
         // update the proofState
         let newPos = stepCommand(event.document, firstChange, false);
 
-        const panel : WebviewPanel | undefined = context.workspaceState.get('panel');
+        const panel: WebviewPanel | undefined = context.workspaceState.get('panel');
         if (!panel) {
             console.log('lpDocChangeHandler : workspace variables are not properly defined');
             return;
@@ -236,57 +236,57 @@ function lpDocChangeHandler(event : TextDocumentChangeEvent, context: ExtensionC
     }
 }
 
-function getFirstError(uri : Uri, before? : Position){
-    let diags : Diagnostic[] = languages.getDiagnostics(uri);
-    let firstError : Position | undefined = undefined;
+function getFirstError(uri: Uri, before?: Position) {
+    let diags: Diagnostic[] = languages.getDiagnostics(uri);
+    let firstError: Position | undefined = undefined;
     let ind = 0;
-    for (let diag of diags){
+    for (let diag of diags) {
         if (diag.severity == 0) {//check if error
-            if(firstError){
+            if (firstError) {
                 firstError = diag.range.start.isBefore(firstError) ? diag.range.start : firstError;
             } else {
                 firstError = diag.range.start;
             }
         }
     }
-    if(before){
-        if(firstError && firstError.isBefore(before)) return firstError;
+    if (before) {
+        if (firstError && firstError.isBefore(before)) return firstError;
         else return undefined;
-    } else { 
+    } else {
         return firstError;
     }
 }
 
-function highlight(context : ExtensionContext, newProofState : Position, openEditor : TextEditor) {
+function highlight(context: ExtensionContext, newProofState: Position, openEditor: TextEditor) {
 
 
     //Highlighting text
-    const proofDecoration : TextEditorDecorationType | undefined = context.workspaceState.get('proofDecoration');
-    const errorDecoration : TextEditorDecorationType | undefined = context.workspaceState.get('errorDecoration');
+    const proofDecoration: TextEditorDecorationType | undefined = context.workspaceState.get('proofDecoration');
+    const errorDecoration: TextEditorDecorationType | undefined = context.workspaceState.get('errorDecoration');
 
     const firstError = getFirstError(openEditor.document.uri, newProofState);
     const zeroPos = new Position(0, 0);
 
-    if(!proofDecoration || !errorDecoration)
+    if (!proofDecoration || !errorDecoration)
         console.log('Highlights/decorations are not properly defined');
-    else{
-        if(firstError){
+    else {
+        if (firstError) {
             decorate(openEditor, new Range(zeroPos, firstError), proofDecoration);
             decorate(openEditor, new Range(firstError, newProofState), errorDecoration);
         } else {
             decorate(openEditor, null, errorDecoration);
             decorate(openEditor, new Range(zeroPos, newProofState), proofDecoration);
         }
-        
+
     }
     //Scroll until last highlight (if follow mode is toggled)
     const follow: boolean | undefined = context.workspaceState.get('follow');
 
-    if(follow)
-        commands.executeCommand('revealLine', {lineNumber: newProofState.line, at: 'center'});
+    if (follow)
+        commands.executeCommand('revealLine', { lineNumber: newProofState.line, at: 'center' });
 }
 
-function lpRefresh(context : ExtensionContext, proofPos : Position, panel : WebviewPanel, openEditor : TextEditor) {
+function lpRefresh(context: ExtensionContext, proofPos: Position, panel: WebviewPanel, openEditor: TextEditor) {
 
     context.workspaceState.update('proofState', proofPos);
 
@@ -295,110 +295,110 @@ function lpRefresh(context : ExtensionContext, proofPos : Position, panel : Webv
     highlight(context, proofPos, openEditor);
 }
 
-function nextProof(context : ExtensionContext, direction : boolean) {
+function nextProof(context: ExtensionContext, direction: boolean) {
 
     //Checking workspace
-    const openEditor : TextEditor | undefined = window.activeTextEditor;
-    if(!openEditor) {
+    const openEditor: TextEditor | undefined = window.activeTextEditor;
+    if (!openEditor) {
         console.log("No editor opened");
         return;
     }
-    
-    const proofState : Position | undefined = context.workspaceState.get('proofState');
-    const panel : WebviewPanel | undefined = context.workspaceState.get('panel');
 
-    if (!proofState || !panel) {
+    const proofState: Position | undefined = context.workspaceState.get('proofState');
+    const panel: WebviewPanel | undefined = context.workspaceState.get('panel');
+
+    if (!proofState || !panel) {
         console.log('nextProof : workspace variables are not properly defined');
         return;
     }
 
     //The position of the next proof
-    let nextProofPos : Position = stepCommand(openEditor.document, proofState, direction, ['begin']);
-    
+    let nextProofPos: Position = stepCommand(openEditor.document, proofState, direction, ['begin']);
+
     context.workspaceState.update('proofState', nextProofPos); //proof state is set to the position of the next proof keyword
-    
+
     refreshGoals(panel, openEditor, nextProofPos, context); //Goals panel is refreshed
 
     highlight(context, nextProofPos, openEditor);
 }
 
-function goToProofState(context : ExtensionContext){
-    
-    const proofState : Position | undefined = context.workspaceState.get('proofState');
-    if(!proofState) {
+function goToProofState(context: ExtensionContext) {
+
+    const proofState: Position | undefined = context.workspaceState.get('proofState');
+    if (!proofState) {
         console.log("goToProofState : proofState workspace variable not set properly");
         return;
     }
 
-    commands.executeCommand('revealLine', {lineNumber: proofState.line, at: 'center'});
+    commands.executeCommand('revealLine', { lineNumber: proofState.line, at: 'center' });
 }
 
-function toggleCursorMode(context : ExtensionContext) : boolean {
-    let cursorMode : boolean = context.workspaceState.get('cursorMode') ?? false;
+function toggleCursorMode(context: ExtensionContext): boolean {
+    let cursorMode: boolean = context.workspaceState.get('cursorMode') ?? false;
 
     cursorMode = !cursorMode;
     context.workspaceState.update('cursorMode', cursorMode);
 
-    if(cursorMode) {
-        
+    if (cursorMode) {
+
         window.showInformationMessage("Cursor navigation enabled");
 
         //By default, follow mode is disabled in cursor mode (because it may be nausea-inducing)
-        if( context.workspaceState.get('follow') )
+        if (context.workspaceState.get('follow'))
             toggleFollowMode(context);
     }
-    
+
     else {
 
         window.showInformationMessage("Cursor navigation disabled");
 
         //By default, follow mode is enabled when cursor mode is off (because it is more practical)
-        if( !context.workspaceState.get('follow') )
+        if (!context.workspaceState.get('follow'))
             toggleFollowMode(context);
     }
-    
+
     return cursorMode;
 }
 
-function toggleFollowMode(context : ExtensionContext) : boolean {
-    let follow : boolean = context.workspaceState.get('follow') ?? false;
+function toggleFollowMode(context: ExtensionContext): boolean {
+    let follow: boolean = context.workspaceState.get('follow') ?? false;
 
     follow = !follow;
     context.workspaceState.update('follow', follow);
 
 
-    if(follow)
+    if (follow)
         window.showInformationMessage("Window follows highlights");
-    
+
     else
         window.showInformationMessage("Window doesn't follow highlights");
 
     return follow;
 }
 
-function decorate(openEditor : TextEditor, range : Range | null, decorationType : TextEditorDecorationType) {
-    if(range)
+function decorate(openEditor: TextEditor, range: Range | null, decorationType: TextEditorDecorationType) {
+    if (range)
         openEditor.setDecorations(decorationType, [range]);
     else
         openEditor.setDecorations(decorationType, []);
 }
 
 // returns the Position of next or previous command
-function stepCommand(document: TextDocument, currentPos: Position, forward: boolean, terminators?: string[]){
+function stepCommand(document: TextDocument, currentPos: Position, forward: boolean, terminators?: string[]) {
 
-    if(terminators === undefined || terminators === null)
+    if (terminators === undefined || terminators === null)
         terminators = [';', 'begin', '{'];
 
-    let docBegin : Position = document.positionAt(0);
-    let docEnd : Position = new Position(document.lineCount, 0);
+    let docBegin: Position = document.positionAt(0);
+    let docEnd: Position = new Position(document.lineCount, 0);
 
-    const minPos = (a : Position, b : Position) => a.compareTo(b) < 0 ? a : b;
-    const maxPos = (a : Position, b : Position) => a.compareTo(b) > 0 ? a : b;
+    const minPos = (a: Position, b: Position) => a.compareTo(b) < 0 ? a : b;
+    const maxPos = (a: Position, b: Position) => a.compareTo(b) > 0 ? a : b;
     const termRegex = new RegExp(terminators.join("|"), 'gi');
 
     let termPositions = [...document.getText().matchAll(termRegex)]
         .map(rm => rm.index ? rm.index + rm[0].length : undefined)
-        .filter((x) : x is number => x !== undefined) // remove undefined
+        .filter((x): x is number => x !== undefined) // remove undefined
         .map(x => document.positionAt(x));
 
     let nextCmdPos = termPositions
@@ -408,35 +408,35 @@ function stepCommand(document: TextDocument, currentPos: Position, forward: bool
     return nextCmdPos;
 }
 
-function checkProofForward(context : ExtensionContext) {
+function checkProofForward(context: ExtensionContext) {
 
     //Checking workspace
-    const openEditor : TextEditor | undefined = window.activeTextEditor;
-    if(!openEditor)
+    const openEditor: TextEditor | undefined = window.activeTextEditor;
+    if (!openEditor)
         return;
-    
-    const proofState : Position | undefined = context.workspaceState.get('proofState');
-    const panel : WebviewPanel | undefined = context.workspaceState.get('panel');
-    if (!proofState || !panel) {
+
+    const proofState: Position | undefined = context.workspaceState.get('proofState');
+    const panel: WebviewPanel | undefined = context.workspaceState.get('panel');
+    if (!proofState || !panel) {
         console.log('checkProofForward : Workspace variables are not properly defined');
         return;
     }
 
     let newPos = stepCommand(openEditor.document, proofState, true);
-    if(newPos)
+    if (newPos)
         lpRefresh(context, newPos, panel, openEditor);
 }
 
-function checkProofBackward(context : ExtensionContext) {
+function checkProofBackward(context: ExtensionContext) {
 
     //Checking workspace
-    const openEditor : TextEditor | undefined = window.activeTextEditor;
-    if(!openEditor)
+    const openEditor: TextEditor | undefined = window.activeTextEditor;
+    if (!openEditor)
         return;
 
-    const proofState : Position | undefined = context.workspaceState.get('proofState');
-    const panel : WebviewPanel | undefined = context.workspaceState.get('panel');
-    if (!proofState || !panel) {
+    const proofState: Position | undefined = context.workspaceState.get('proofState');
+    const panel: WebviewPanel | undefined = context.workspaceState.get('panel');
+    if (!proofState || !panel) {
         console.log('checkProofBackward : Workspace variables are not properly defined');
         return;
     }
@@ -444,101 +444,101 @@ function checkProofBackward(context : ExtensionContext) {
     let newPos = stepCommand(openEditor.document, proofState, false);
 
     //Case the end has not been reached
-    if(newPos)
+    if (newPos)
         lpRefresh(context, newPos, panel, openEditor);
 }
 
-function checkProofUntilCursor(context : ExtensionContext) {
+function checkProofUntilCursor(context: ExtensionContext) {
 
     //Checking workspace
-    const openEditor : TextEditor | undefined = window.activeTextEditor;
-    if(!openEditor)
+    const openEditor: TextEditor | undefined = window.activeTextEditor;
+    if (!openEditor)
         return;
-    
-    const proofState : Position | undefined = context.workspaceState.get('proofState');
-    const panel : WebviewPanel | undefined = context.workspaceState.get('panel');
 
-    if (!proofState || !panel) {
+    const proofState: Position | undefined = context.workspaceState.get('proofState');
+    const panel: WebviewPanel | undefined = context.workspaceState.get('panel');
+
+    if (!proofState || !panel) {
         console.log('checkProofUntilCursor : workspace variables are not properly defined');
         return;
     }
-    
+
     //The current position of the cursor
-    let cursorPosition : Position =  openEditor.selection.active;    
-    if (proofState.line == cursorPosition.line) 
+    let cursorPosition: Position = openEditor.selection.active;
+    if (proofState.line == cursorPosition.line)
         return;
-    
+
     //To simplify the code, proof states are always at the beggining of the highlighted line
     //So must be the cursor position since it is the new proof state
     if (cursorPosition.character != 0)
         cursorPosition = new Position(cursorPosition.line, 0);
-    
+
     context.workspaceState.update('proofState', cursorPosition); //proof state is set to the cursor position
-    
+
     refreshGoals(panel, openEditor, cursorPosition, context); //Goals panel is refreshed
 
     highlight(context, cursorPosition, openEditor);
 }
 
-function refreshGoals(panel : WebviewPanel, editor : TextEditor | undefined, proofState : Position, context : ExtensionContext) {
+function refreshGoals(panel: WebviewPanel, editor: TextEditor | undefined, proofState: Position, context: ExtensionContext) {
 
-    if(!editor)
+    if (!editor)
         return;
-    
+
     const styleUri = panel.webview.asWebviewUri(Uri.joinPath(context.extensionUri, 'media', 'styles.css'))
     sendGoalsRequest(proofState, panel, editor.document.uri, styleUri);
 }
 
 // returns the HTML code of goals environment
-function getGoalsEnvContent(goals : Goal[]){
+function getGoalsEnvContent(goals: Goal[]) {
 
-    if(goals.length == 0)
+    if (goals.length == 0)
         return "No goals";
 
     return goals.map((curGoal, itr) => {
         let goalStr = curGoal.typeofgoal == "Typ" ? (curGoal as TypGoal).type : (curGoal as UnifGoal).constr;
         return '<div class="hypothesis">' +
-                curGoal.hyps.map((hyp) => {
-                    return `<label class="hname">${hyp.hname}</label>` +
-                        `<label class="sep"> : </label>` +
-                        `<span class="htype">${hyp.htype}</span><br/>`;
-                }).reduce((acc, cur) => acc + cur, "") +
-                '</div>' +
-                '<hr/>' +
-                `<div class="pp_goals">` +
-                    `<label class="numGoal">${itr}</label>` +
+            curGoal.hyps.map((hyp) => {
+                return `<label class="hname">${hyp.hname}</label>` +
                     `<label class="sep"> : </label>` +
-                    `<span class="goal">${goalStr}</span>` +
-                    `<label class ="sep"></label><br/><br/>` +
-                `</div>`;
+                    `<span class="htype">${hyp.htype}</span><br/>`;
+            }).reduce((acc, cur) => acc + cur, "") +
+            '</div>' +
+            '<hr/>' +
+            `<div class="pp_goals">` +
+            `<label class="numGoal">${itr}</label>` +
+            `<label class="sep"> : </label>` +
+            `<span class="goal">${goalStr}</span>` +
+            `<label class ="sep"></label><br/><br/>` +
+            `</div>`;
     }).reduce((acc, cur) => acc + cur, "");
 }
 
 // number of write operations todo on the pseudoterminal
 let ptyWriteCnt = 0;
 
-function updateTerminalText(logstr: string){
+function updateTerminalText(logstr: string) {
     logstr = logstr.replace(/^[\n \t\r]*(\u001b\[[0-9]+m)[\n \t\r]*/g, "$1")
-                   .replace(/[\n \t\r]*(\u001b\[[0-9]+m)[\n \t\r]*$/g, "$1");
+        .replace(/[\n \t\r]*(\u001b\[[0-9]+m)[\n \t\r]*$/g, "$1");
     const termName = "Lambdapi Debug";
     const clearTextSeq = '\x1b[2J\x1b[3J\x1b[;H';
 
     let term = window.terminals.find((t) => t.name == termName);
-    if(!term){
+    if (!term) {
         const writeEmitter = new EventEmitter<string>();
-        const pty : Pseudoterminal = {
+        const pty: Pseudoterminal = {
             onDidWrite: writeEmitter.event,
-            open: () => {},
-            close: () => {},
+            open: () => { },
+            close: () => { },
             handleInput: (data: string) => {
-                if(ptyWriteCnt > 0){
+                if (ptyWriteCnt > 0) {
                     ptyWriteCnt--;
                     data = data.replace(/\r/g, '\r\n');
                     writeEmitter.fire(data);
                 }
             }
         };
-        term = window.createTerminal({name: termName, pty});
+        term = window.createTerminal({ name: termName, pty });
         term.show(true);
     }
 
@@ -548,12 +548,12 @@ function updateTerminalText(logstr: string){
 }
 
 // Returns the HTML code of the panel and the inset ccontent
-function buildGoalsContent(goals : Goal[], styleUri : Uri) {
-    
-    let header, footer : String;
+function buildGoalsContent(goals: Goal[], styleUri: Uri) {
+
+    let header, footer: String;
 
     // get the HTML code of goals environment
-    let codeEnvGoals : String = getGoalsEnvContent(goals);
+    let codeEnvGoals: String = getGoalsEnvContent(goals);
 
     // Use #FA8072 color too?
 
@@ -574,54 +574,54 @@ function buildGoalsContent(goals : Goal[], styleUri : Uri) {
     </html>`;
 }
 
-export interface TextDocumentIdent{
-    uri : String
+export interface TextDocumentIdent {
+    uri: String
 }
 
 export interface ParamsGoals {
-    textDocument : TextDocumentIdent // current text document
-    position : Position         // position to get goals
+    textDocument: TextDocumentIdent // current text document
+    position: Position         // position to get goals
 }
 
 export interface Env {
-	hname : String // hypothesis name
-	htype : String // hypothesis type
+    hname: String // hypothesis name
+    htype: String // hypothesis type
 }
 
 export interface Goal {
-    typeofgoal : String // type of goal, values defined in lsp_base.ml
-    hyps : Env[] // hypotheses
+    typeofgoal: String // type of goal, values defined in lsp_base.ml
+    hyps: Env[] // hypotheses
 }
 
 export interface UnifGoal extends Goal {
-    constr : String
+    constr: String
 }
 
 export interface TypGoal extends Goal {
-	gid :  String // goal id
-	type : String // goals
+    gid: String // goal id
+    type: String // goals
 }
 
 export interface GoalResp {
-    goals : Goal[]
-    logs : string
+    goals: Goal[]
+    logs: string
 }
 
-function sendGoalsRequest(position: Position, panel : WebviewPanel, docUri : Uri, styleUri : Uri) {
+function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, styleUri: Uri) {
 
-    let doc = {uri : docUri.toString()}
-    let cursor = {textDocument : doc, position : position};
+    let doc = { uri: docUri.toString() }
+    let cursor = { textDocument: doc, position: position };
     const req = new RequestType<ParamsGoals, GoalResp, void>("proof/goals");
     client.sendRequest(req, cursor).then((goals) => {
-        
+
         updateTerminalText(goals.logs);
 
-        if(goals.goals) {
+        if (goals.goals) {
             let goal_render = buildGoalsContent(goals.goals, styleUri);
             panel.webview.html = goal_render
             // Disabled as this is experimental
-	    // let wb = window.createWebviewTextEditorInset(window.activeTextEditor, line, height);
-	    // wb.webview.html = panel.webview.html;
+            // let wb = window.createWebviewTextEditorInset(window.activeTextEditor, line, height);
+            // wb.webview.html = panel.webview.html;
         } else {
             panel.webview.html = buildGoalsContent([], styleUri);
         }

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -383,7 +383,7 @@ function createInfoPanel(context: ExtensionContext) {
     let panel: WebviewPanel | null = window.createWebviewPanel(
         'goals',
         'Goals',
-        ViewColumn.Two,
+        { preserveFocus: true, viewColumn: ViewColumn.Two },
         {}
     );
     panel.onDidDispose(() => {

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -1,0 +1,62 @@
+import { DocumentSelector, ExtensionContext, workspace } from "vscode";
+
+export interface LspServerConfig {
+  client_version: string;
+  eager_diagnostics: boolean;
+  goal_after_tactic: boolean;
+  show_info_messages: boolean;
+  show_notices_as_diagnostics: boolean;
+  admit_on_bad_qed: boolean;
+  debug: boolean;
+  unicode_completion: "off" | "normal" | "extended";
+  max_errors: number;
+  pp_type: 0 | 1 | 2;
+  show_stats_on_hover: boolean;
+  show_loc_info_on_hover: boolean;
+  check_only_on_request: boolean;
+}
+
+export namespace LspServerConfig {
+  export function create(
+    client_version: string,
+    wsConfig: any
+  ): LspServerConfig {
+    return {
+      client_version: client_version,
+      eager_diagnostics: wsConfig.eager_diagnostics,
+      goal_after_tactic: wsConfig.goal_after_tactic,
+      show_info_messages: wsConfig.show_info_messages,
+      show_notices_as_diagnostics: wsConfig.show_notices_as_diagnostics,
+      admit_on_bad_qed: wsConfig.admit_on_bad_qed,
+      debug: wsConfig.debug,
+      unicode_completion: wsConfig.unicode_completion,
+      max_errors: wsConfig.max_errors,
+      pp_type: wsConfig.pp_type,
+      show_stats_on_hover: wsConfig.show_stats_on_hover,
+      show_loc_info_on_hover: wsConfig.show_loc_info_on_hover,
+      check_only_on_request: wsConfig.check_only_on_request,
+    };
+  }
+}
+
+export enum ShowGoalsOnCursorChange {
+  Never = 0,
+  OnMouse = 1,
+  OnMouseAndKeyboard = 2,
+  OnMouseKeyboardCommand = 3,
+}
+
+export interface LspClientConfig {
+  show_goals_on: ShowGoalsOnCursorChange;
+}
+
+export namespace LspClientConfig {
+  export function create(wsConfig: any): LspClientConfig {
+    let obj: LspClientConfig = { show_goals_on: wsConfig.show_goals_on };
+    return obj;
+  }
+}
+export const LSPDocumentSelector: DocumentSelector = [
+  { language: "lambdapi" },
+  { language: "markdown", pattern: "**/*.lp" },
+];

--- a/editors/vscode/src/tsconfig.json
+++ b/editors/vscode/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+//  "extends": "../tsconfig-base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ESNext"
+  },
+
+  "files": [
+    "client.ts",
+    "browser.ts"
+  ],
+ // "include": ["**/*.ts", "../lib/**/*.ts"]
+}

--- a/editors/vscode/tsconfig-base.json
+++ b/editors/vscode/tsconfig-base.json
@@ -1,0 +1,11 @@
+{
+   "compilerOptions": {
+    "sourceMap": true,
+    "strict": true,
+    "rootDir": ".",
+    "outDir": "out",
+    // "composite": true,
+    // "noEmit": true,
+   "skipLibCheck": true
+  }
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -5,10 +5,12 @@
     "outDir": "out",
     "sourceMap": true,
     "strict": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "skipLibCheck": true
   },
   "files": [
-    "src/client.ts"
+    "src/client.ts",
+    "src/browser.ts"
   ],
   // Default if not specified is node_modules, out, etc...
   "exclude": [


### PR DESCRIPTION
Currently, if the use closes the Goals panel, it is not possible to navigate the proofs unless the lambdapi vscode extension is restarted.

This is not the desired behaviour. Instead the Goal panel should be reopened as soon as the user navigates the proofs.

This PR fixes this issue 