### PR TITLE
fix issue#638 : show log message when symbol is defined

### DIFF
--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -515,8 +515,7 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
             (* Add the symbol in the signature with a warning. *)
             (* Keep the definition only if the symbol is not opaque. *)
             let d =
-              if opaq then None
-              else
+              if opaq then None else
                 Option.map (fun m -> unfold (mk_Meta(m,[||]))) ps.proof_term
             in
             (* Add the symbol in the signature. *)

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -511,7 +511,6 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
             in
             List.iter admit_goal ps.proof_goals;
             (* Add the symbol in the signature with a warning. *)
-            Console.out 2 (Color.red "symbol %a : %a") uid id term a;
             wrn pe.pos "Proof admitted.";
             (* Keep the definition only if the symbol is not opaque. *)
             let d =
@@ -531,10 +530,10 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
                 Option.map (fun m -> unfold (mk_Meta(m,[||]))) ps.proof_term
             in
             (* Add the symbol in the signature. *)
-            Console.out 2 (Color.red "symbol %a : %a") uid id term a;
             fst (Sig_state.add_symbol
                    ss expo prop mstrat opaq p_sym_nam declpos a impl d)
       in
+      
       (* Create the proof state. *)
       let pdata_state =
         let proof_goals = Proof.add_goals_of_problem p [] in
@@ -555,10 +554,15 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
       in
       if p_sym_prf = None && not (finished pdata_state) then wrn pos
         "Some metavariables could not be solved: a proof must be given";
+      let ffff = match pe.elt with
+      | P_proof_abort -> Format.ifprintf Stdlib.(!(Stdlib.ref Format.std_formatter)) ("%s" ^^ "@.") "Print nothing!"
+      | P_proof_admitted -> Console.out 2 (Color.red "symbol %a : %a") uid id term a
+      | P_proof_end -> Console.out 2 (Color.red "symbol %a : %a") uid id term a
+      in ffff;
       { pdata_sym_pos=p_sym_nam.pos; pdata_state; pdata_proof
       ; pdata_finalize; pdata_end_pos=pe.pos; pdata_prv }
     in
-    (ss, Some pdata, None)
+      (ss, Some pdata, None)
 
 (** [too_long] indicates the duration after which a warning should be given to
     indicate commands that take too long to execute. *)

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -106,6 +106,7 @@ let process_cmd _file (nodes,st,dg,logs) ast =
       | Cmd_OK (st, qres)   ->
         let qres = match qres with None -> "OK" | Some x -> x in
         let pg = qed_loc, 4, qres, None in
+        let logs = ((3, buf_get_and_clear lp_logger), cmd_loc) :: logs in
         st, pg :: dg_proof, logs
       | Cmd_Error(_loc,msg) ->
         let pg = qed_loc, 1, msg, None in


### PR DESCRIPTION
As described in issue#638, log messages are sometimes not shown at the right moment when a symbol is defined and proofs are navigated. This PR fixes this issue.

TODO:
- [x] make sure that `make sanity_check` passes