### PR TITLE
feat/vscode: publish vscode extension if a new version is detected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,9 @@ jobs:
           npm install -g @types/vscode
           npm install -g vsce 
           make build-vscode-extension
+          make publish-vscode-extension
+        env:
+          PAT: ${{secrets.VSCODE_PAT}}
       - name: publish vscode extension
         uses: actions/upload-artifact@v4
         with: 

--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,11 @@ uninstall_vim_mode:
 .PHONY: build-vscode-extension
 build-vscode-extension:
 	cd editors/vscode && make && mkdir extensionFolder && vsce package -o extensionFolder
+
+.PHONY: publish-vscode-extension
+publish-vscode-extension:
+ifeq ($(shell vsce show --json deducteam.lambdapi | jq '.versions[0]' | jq '.version'), $(shell cat editors/vscode/package.json | jq '.version'))
+	echo "extension already exists. Skip"
+else
+	cd editors/vscode && vsce publish -p ${PAT}
+endif


### PR DESCRIPTION
This PR makes it possible to publish the Lambdapi extension for Vscode from the build pipeline when a new version (as documented in the editors/vscode/package.json file) is detected