### PR TITLE
Fix location of symbol in logs when the object is not found whin a tactic

### DIFF
--- a/src/common/pos.ml
+++ b/src/common/pos.ml
@@ -99,18 +99,20 @@ let to_string : ?print_fname:bool -> pos -> string =
   else
     Printf.sprintf "%s%d:%d-%d" fname start_line start_col end_col
 
+let popt_to_string : ?print_fname:bool -> popt -> string =
+  fun ?(print_fname=true) pop ->
+  match pop with
+    | None -> "Unknown location "
+    | Some (p) -> to_string ~print_fname p ^ " "
+
 (** [pp ppf pos] prints the optional position [pos] on [ppf]. *)
 let pp : popt Lplib.Base.pp = fun ppf p ->
-  match p with
-  | None    -> string ppf "unknown location"
-  | Some(p) -> string ppf (to_string p)
+  string ppf (popt_to_string p)
 
 (** [short ppf pos] prints the optional position [pos] on [ppf]. *)
 let short : popt Lplib.Base.pp = fun ppf p ->
-  match p with
-  | None    -> string ppf "unknown location"
-  | Some(p) -> let print_fname=false in
-               string ppf (to_string ~print_fname p)
+  let print_fname=false in
+  string ppf (popt_to_string ~print_fname p)
 
 (** [map f loc] applies function [f] on the value of [loc] and keeps the
     position unchanged. *)

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -508,15 +508,8 @@ let scope_term :
       ?find_sym:find_sym -> ?typ:bool -> ?mok:(int -> meta option)
       -> bool -> sig_state -> env -> p_term -> term =
   fun ?find_sym ?(typ=false) ?(mok=fun _ -> None) m_term_prv ss env t ->
-  try
-    let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
-    Bindlib.unbox (scope ?find_sym ~typ 0 md ss env t)
-  with Fatal(Some p,    msg) ->
-    Console.out 3 (Color.red "[%a]") Pos.pp p;
-    (**  Get ride of the position because the error message is displayed here
-        There is no more need of the position and this avoids the message
-        to be displayed twice in [Error.handle_exceptions] *)
-    raise(Fatal(None,    msg))
+  let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
+  Bindlib.unbox (scope ?find_sym ~typ 0 md ss env t)
 
 (** [scope_search_pattern ~find_sym ~typ prv ss env t] turns a pterm [t] meant
     to be a search patter into a term in the signature state [ss]

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -512,9 +512,9 @@ let scope_term :
     let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
     Bindlib.unbox (scope ?find_sym ~typ 0 md ss env t)
   with Fatal(Some p,    msg) ->
-    Console.out 3 (Color.red "%a") Pos.pp p;
+    Console.out 3 (Color.red "[%a]") Pos.pp p;
     (**  Get ride of the position because the error message is displayed here
-        There is no more need of the position and this avoids the message 
+        There is no more need of the position and this avoids the message
         to be displayed twice in [Error.handle_exceptions] *)
     raise(Fatal(None,    msg))
 

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -508,8 +508,15 @@ let scope_term :
       ?find_sym:find_sym -> ?typ:bool -> ?mok:(int -> meta option)
       -> bool -> sig_state -> env -> p_term -> term =
   fun ?find_sym ?(typ=false) ?(mok=fun _ -> None) m_term_prv ss env t ->
-  let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
-  Bindlib.unbox (scope ?find_sym ~typ 0 md ss env t)
+  try
+    let md = M_Term {m_term_meta_of_key=mok; m_term_prv} in
+    Bindlib.unbox (scope ?find_sym ~typ 0 md ss env t)
+  with Fatal(Some p,    msg) ->
+    Console.out 3 (Color.red "%a") Pos.pp p;
+    (**  Get ride of the position because the error message is displayed here
+        There is no more need of the position and this avoids the message 
+        to be displayed twice in [Error.handle_exceptions] *)
+    raise(Fatal(None,    msg))
 
 (** [scope_search_pattern ~find_sym ~typ prv ss env t] turns a pterm [t] meant
     to be a search patter into a term in the signature state [ss]

--- a/src/pure/pure.ml
+++ b/src/pure/pure.ml
@@ -171,7 +171,9 @@ let handle_tactic : proof_state -> Tactic.t -> int -> tactic_result =
     let ps, qres = Handle.Tactic.handle ss sym_pos prv (ps, None) tac n in
     let qres = Option.map (fun f -> f ()) qres in
     Tac_OK((Time.save (), ss, ps, finalize, prv, sym_pos), qres)
-  with Fatal(p,m) -> Tac_Error(p,m)
+  with Fatal(Some p,m) ->
+    Console.out 3 (Color.red "%a") Pos.pp p;
+    Tac_Error(Some p,m)
 
 let end_proof : proof_state -> command_result =
   fun (_, ss, ps, finalize, _, _) ->

--- a/src/pure/pure.ml
+++ b/src/pure/pure.ml
@@ -163,7 +163,8 @@ let handle_command : state -> Command.t -> command_result =
         (t, ss, d.pdata_state, d.pdata_finalize, d.pdata_prv, d.pdata_sym_pos)
       in
         Cmd_Proof(ps, d.pdata_proof, d.pdata_sym_pos, d.pdata_end_pos)
-  with Fatal(p,m) -> Cmd_Error(p,m)
+  with Fatal(Some p,m) ->
+    Cmd_Error(Some p, Pos.popt_to_string p ^ m)
 
 let handle_tactic : proof_state -> Tactic.t -> int -> tactic_result =
   fun (_, ss, ps, finalize, prv, sym_pos) tac n ->
@@ -172,13 +173,13 @@ let handle_tactic : proof_state -> Tactic.t -> int -> tactic_result =
     let qres = Option.map (fun f -> f ()) qres in
     Tac_OK((Time.save (), ss, ps, finalize, prv, sym_pos), qres)
   with Fatal(Some p,m) ->
-    Console.out 3 (Color.red "%a") Pos.pp p;
-    Tac_Error(Some p,m)
+    Tac_Error(Some p, Pos.popt_to_string p ^ m)
 
 let end_proof : proof_state -> command_result =
   fun (_, ss, ps, finalize, _, _) ->
   try Cmd_OK((Time.save (), finalize ss ps), None)
-  with Fatal(p,m) -> Cmd_Error(p,m)
+  with Fatal(Some p,m) ->
+    Cmd_Error(Some p, Pos.popt_to_string p ^ m)
 
 let get_symbols : state -> Term.sym Extra.StrMap.t =
   fun (_, ss) -> ss.in_scope


### PR DESCRIPTION
Inside a proof, when the user uses a symbol in a tactic that Lambdapi cannot find, Lambdapi show the `Object not found.` message. this message should be preceded by the location where the symbol has been used. While this is the case in command line, Lambdapi, Lsp fail in showing the location message which results in a misleading information.

This behavior has been described in issue https://github.com/Deducteam/lambdapi/issues/1073

This PR fixes this by displaying the position message as soon as the corresponding exception is caught.