### PR TITLE
Fix colors in terminal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- add export format `raw_dk`
+- Add export format `raw_dk`
+- Fix of the color of the text in command line when console.out is used.
+- Use black text instead of red when diplaying queries answers.
 
 ## 2.5.0 (2024-02-25)
 

--- a/src/common/console.ml
+++ b/src/common/console.ml
@@ -20,6 +20,7 @@ let set_default_verbose : int -> unit = fun i ->
     [lvl] is strictly greater than the current verbosity level.  Note that the
     output channel is automatically flushed if logging modes are enabled. *)
 let out : int -> 'a outfmt -> 'a = fun lvl fmt ->
+  Color.update_with_color Stdlib.(!out_fmt);
   let out = Format.(if lvl > !verbose then ifprintf else fprintf) in
   out Stdlib.(!out_fmt) (fmt ^^ "@.")
 

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -55,7 +55,7 @@ type result = (unit -> string) option
 (** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose
    level 1 and returns a function for printing [x] on a string using [pp]. *)
 let return : 'a pp -> 'a -> result = fun pp x ->
-  Console.out 1 (Color.red "%a") pp x;
+  Console.out 1 "%a" pp x;
   Some (fun () -> Format.asprintf "%a" pp x)
 
 (** [handle_query ss ps q] *)


### PR DESCRIPTION
This PR fixes the color of the queries answers in terminal whether in command line Lambdapi or in Lsp Lambdapi.
As explained in [this issue](https://github.com/Deducteam/lambdapi/issues/1002), color should be black instead of red.

Besides, This PR fix an issue that has been uncounted with command line Lambdapi when Console.out was used in the code (The coloring of the displayed text was ignored).