### PR TITLE
Show the Goal panel if it has lost focus

### DIFF
--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -664,6 +664,15 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
     let cursor = { textDocument: doc, position: position };
     const req = new RequestType<ParamsGoals, GoalResp, void>("proof/goals");
     client.sendRequest(req, cursor).then((goals) => {
+        // If uri is not a lambdapi/dedukti file, do nothing
+        if(goals.goals == null){
+            return;
+        }
+        // Take focus back if the goal panel lost it.
+        window.showErrorMessage("Going through Goals");
+        if(!panel.active) {
+            panel.reveal(2, false);
+        }
 
         updateTerminalText(goals.logs);
 

--- a/src/lsp/lp_lsp.ml
+++ b/src/lsp/lp_lsp.ml
@@ -238,7 +238,7 @@ let get_node_at_pos doc line pos =
 let rec get_goals ~doc ~line ~pos =
   let node = get_node_at_pos doc line pos in
   let goals = match node with
-    | None -> None
+    | None -> Some([], None)
     | Some n ->
         closest_before (line+1, pos) n.goals in
   match goals with
@@ -526,7 +526,14 @@ let process_input ofmt (com : J.t) =
   | exn ->
     let bt = Printexc.get_backtrace () in
     LIO.log_error "[BT]" bt;
-    LIO.log_error "process_input" (Printexc.to_string exn)
+    LIO.log_error "process_input" (Printexc.to_string exn);
+    (*Send an "empty" answer with Null goals that will be treated specifically by the client*)
+    let id     = oint_field "id" (U.to_assoc com) in
+    let goals = None in
+    let logs = "" in
+    let result = LSP.json_of_goals goals ~logs in
+    let msg = LSP.mk_reply ~id ~result in
+    LIO.send_json ofmt msg
 
 let main std log_file =
 

--- a/src/lsp/lp_lsp.ml
+++ b/src/lsp/lp_lsp.ml
@@ -527,7 +527,7 @@ let process_input ofmt (com : J.t) =
     let bt = Printexc.get_backtrace () in
     LIO.log_error "[BT]" bt;
     LIO.log_error "process_input" (Printexc.to_string exn);
-    (*Send an "empty" answer with Null goals that will be treated specifically by the client*)
+    (*Send an "empty" answer with Null goals when exception occurs*)
     let id     = oint_field "id" (U.to_assoc com) in
     let goals = None in
     let logs = "" in


### PR DESCRIPTION
In Vscode, if the Goal panel looses focus (typically, because user selected another panel) Goals are updated in this panel when the user navigates them in the lp file but he can't see them unless clicking on this panel to bring it in front again.

This PR, gives back focus to the Goals panel to bring it back as soon as the user navigates goals without having to clicking the panel himself.

TODO:
- [ ] test with emacs