### PR TITLE
Fix #554

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -52,7 +52,7 @@ the Why3 platform.")
  (depends
   (ocaml (>= 4.08.0))
   (menhir (>= 20200624))
-  (sedlex (>= 2.2))
+  (sedlex (>= 3.2))
   (alcotest :with-test)
   (dedukti (and :with-test (>= 2.7)))
   (bindlib (>= 5.0.1))

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -50,7 +50,7 @@ depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.08.0"}
   "menhir" {>= "20200624"}
-  "sedlex" {>= "2.2"}
+  "sedlex" {>= "3.2"}
   "alcotest" {with-test}
   "dedukti" {with-test & >= "2.7"}
   "bindlib" {>= "6.0.0"}

--- a/src/parsing/parser.ml
+++ b/src/parsing/parser.ml
@@ -55,15 +55,6 @@ sig
   end
 = struct
 
-  (* Needed to workaround serious bug in sedlex, see #549 *)
-  let lexbuf_fixup lb fname =
-    let pos = Lexing.
-                { pos_fname = fname
-                ; pos_lnum = 1
-                ; pos_bol = 0
-                ; pos_cnum = 0 } in
-    Sedlexing.set_position lb pos
-
   let stream_of_lexbuf :
     grammar_entry:(LpLexer.token,'b) MenhirLib.Convert.traditional ->
     ?inchan:in_channel -> ?fname:string -> Sedlexing.lexbuf ->
@@ -71,7 +62,6 @@ sig
     'a Stream.t =
     fun ~grammar_entry ?inchan ?fname lb ->
       Option.iter (Sedlexing.set_filename lb) fname;
-      Option.iter (lexbuf_fixup lb) fname;
       let parse =
         MenhirLib.Convert.Simplified.traditional2revised
          grammar_entry


### PR DESCRIPTION
Bump sedlex to 3.2 which fixes its issue #96
https://github.com/ocaml-community/sedlex/issues/96.

I'm not sure the problem is fixed though: all I could see is that running
```command
$ lambdapi check tests/OK/natproof.lp --verbose 4
```
resulted in the same output before and after the commit in this pull request.