### PR TITLE
Fix green cursor position in the presence of opening bracket

### DIFF
--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -509,7 +509,11 @@ function stepCommand(document: TextDocument, currentPos: Position, forward: bool
     const termRegex = new RegExp(terminators.join("|"), 'gi');
 
     let termPositions = [...document.getText().matchAll(termRegex)]
-        .map(rm => rm.index ? rm.index + rm[0].length : undefined)
+        .map(rm => { 
+            if (rm[0] === ";") {
+                return rm.index ? rm.index + rm[0].length : undefined
+            }
+            else return rm.index ? rm.index : undefined })
         .filter((x): x is number => x !== undefined) // remove undefined
         .map(x => document.positionAt(x));
 


### PR DESCRIPTION
When Proofs are navigated in Vscode (specifically with the step forward and backward commands) and in the presence of an opening bracket, the green zone is delimited by the opening bracket included. However, this results in erroneous subgoals displaying as described in [this issue](https://github.com/Deducteam/lambdapi/issues/1049#issuecomment-2072085474)

To fix that, this PR make the green zone end just before the opening bracket (and the `begin` keyword) so that the Lsp server correctly answers with the subgoals following the green zone.