### PR TITLE
Vscode : release version 0.2.2 of the vscode extension

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           make build-vscode-extension
           make publish-vscode-extension
         env:
-          PAT: ${{secrets.VSCODE_PAT}}
+          PAT: ${{secrets.PAT}}
       - name: publish vscode extension
         uses: actions/upload-artifact@v4
         with: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           make build-vscode-extension
           make publish-vscode-extension
         env:
-          PAT: ${{secrets.PAT}}
+          PAT: ${{secrets.VSCODE_PAT}}
       - name: publish vscode extension
         uses: actions/upload-artifact@v4
         with: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           make publish-vscode-extension
         env:
           PAT: ${{ secrets.VSCODE_PAT }}
-      - name: publish vscode extension
+      - name: upload vscode extension
         uses: actions/upload-artifact@v4
         with: 
           name: assets-for-download

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
           make publish-vscode-extension
         env:
           PAT: ${{ secrets.VSCODE_PAT }}
+          REPONAME: ${{ GITHUB_REPOSITORY }}
       - name: publish vscode extension
         uses: actions/upload-artifact@v4
         with: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,6 @@ jobs:
           make publish-vscode-extension
         env:
           PAT: ${{ secrets.VSCODE_PAT }}
-          REPONAME: ${{ GITHUB_REPOSITORY }}
       - name: publish vscode extension
         uses: actions/upload-artifact@v4
         with: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           make build-vscode-extension
           make publish-vscode-extension
         env:
-          PAT: ${{secrets.VSCODE_PAT}}
+          PAT: ${{ secrets.VSCODE_PAT }}
       - name: publish vscode extension
         uses: actions/upload-artifact@v4
         with: 

--- a/Makefile
+++ b/Makefile
@@ -182,12 +182,22 @@ JQ = $(shell which jq)
 ifneq ($(VSCE),)
 ifneq ($(JQ),)
 EXT = $(shell vsce show --json deducteam.lambdapi 2>/dev/null | jq '.versions[0]' | jq '.version')
+
 .PHONY: publish-vscode-extension
 publish-vscode-extension:
 ifeq ($(EXT), $(shell cat editors/vscode/package.json | jq '.version'))
 	echo "extension already exists. Skip"
 else
+ifeq ($(PAT),)
+	echo "The \"PAT\" secret is not set. Please add a secret named \"PAT\" to be able to publish the Vscode extension."
+else
+ifeq ('master', $(GITHUB_REF_NAME))
 	cd editors/vscode && vsce publish -p ${PAT}
+else
+	echo "Env Variable \"GITHUB_REF_NAME\" is set to \"$(GITHUB_REF_NAME)\". Please set it to \"master\" to force publishing the extension"
 endif
+endif
+endif
+
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -188,14 +188,18 @@ publish-vscode-extension:
 ifeq ($(EXT), $(shell cat editors/vscode/package.json | jq '.version'))
 	echo "extension already exists. Skip"
 else
-	echo "repo name is $(GITHUB_REPOSITORY)" 
 ifeq ($(PAT),)
-	echo "The \"PAT\" secret is not set. Please add a secret named \"PAT\" to be able to publish the Vscode extension."
+	# Note, when pushing code from a fork of the Lambdapi repository, PAT secret is not "reachable". 
+	# The extension is only published when merge occurs.
+	echo "The \"PAT\" secret is not set. Please check a PAT exists with permissions to publish to Vscode market"
 else
 ifeq ('master', $(GITHUB_REF_NAME))
+	# The extension is only published when code is pushed to master to avoid publishing from feature branches
 	cd editors/vscode && vsce publish -p ${PAT}
 else
-	echo "Env Variable \"GITHUB_REF_NAME\" is set to \"$(GITHUB_REF_NAME)\". Please set it to \"master\" to force publishing the extension"
+	echo "Env Variable \"GITHUB_REF_NAME\" is set to \"$(GITHUB_REF_NAME)\"."
+	echo "Extension will only be published when pushing to master."
+	echo "If used manualy, please set Variable \"GITHUB_REF_NAME\" to \"master\" to force publishing the extension"
 endif
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ publish-vscode-extension:
 ifeq ($(EXT), $(shell cat editors/vscode/package.json | jq '.version'))
 	echo "extension already exists. Skip"
 else
+	echo "repo name is $(GITHUB_REPOSITORY)" 
 ifeq ($(PAT),)
 	echo "The \"PAT\" secret is not set. Please add a secret named \"PAT\" to be able to publish the Vscode extension."
 else

--- a/editors/vscode/CHANGES.md
+++ b/editors/vscode/CHANGES.md
@@ -3,9 +3,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.2]
 - code refactoring of the client for maintenability.
-- fix the bug that causes the proof navigation to malfunction when the Goals panel is closed by the user. Now the panel is recreated whenever needed.
+- fix the bug that causes the proof navigation to malfunction when the `Goals` panel is closed by the user. Now the panel is recreated whenever needed. If focus is taken away frol the `Goals` panel, focus is given back to it when user starts navigating proofs again.
+- fix bug related to navigating sub-goals : navigating next subgoal stops before `{` instead of after it so that next subgoal is correctly shown in the `Goals` panel.
+- change navigation with ``navigate until cursor`` : Navigation includes the command if the cursor is whithin its range instead of the line above. 
+- first command is no more systematically navigated. If the current command is the first one, navigating the previous command results in no command being navigated.
 
 ## [0.1.2] - 2020-12-10
 - use vscode configuration for lambdapi.path to call the lambdapi LSP server

--- a/editors/vscode/RELEASE.md
+++ b/editors/vscode/RELEASE.md
@@ -4,10 +4,10 @@ TODO list for a new release on the VSCode Marketplace
 
 The github DICD pipeline detects the existance of a new version of the Lambdapi extension for Vscode based on the `version` field in the `editors/vscode/package.json` file and publishes it on the Marketplace.
 
-Please note that a valid Azure Personal Access Token (PAT) is required for this operation. This PAT must be saved in the `PAT` environment variable as described [here](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+Please note that a valid Azure Personal Access Token (PAT) is required for this operation. This PAT must be saved in the `VSCODE_PAT` environment variable as described [here](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
 If the pipeline fails at publishing the extension, it may be due to the PAT being expired.
-Please generate a new one on [Azure](https://dev.azure.com/lambdapi/) and update the `PAT` env variable value as described in the link above.
+Please generate a new one on [Azure](https://dev.azure.com/lambdapi/) and update the `VSCODE_PAT` env variable value as described in the link above.
 
 **manual release**
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -8,7 +8,7 @@
     "François Lefoulon <francois.lefoulon@lilo.org>",
     "Ashish Barnawal <ashbrnwl.2000@gmail.com>"
   ],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "Deducteam",
   "engines": {
     "vscode": "^1.82.0"


### PR DESCRIPTION
This version implements the following changes/fixes :

- code refactoring of the client for maintenability.
- fix the bug that causes the proof navigation to malfunction when the `Goals` panel is closed by the user. Now the panel is recreated whenever needed. If focus is taken away frol the `Goals` panel, focus is given back to it when user starts navigating proofs again.
- fix bug related to navigating sub-goals : navigating next subgoal stops before `{` instead of after it so that next subgoal is correctly shown in the `Goals` panel.
- change navigation with ``navigate until cursor`` : Navigation includes the command if the cursor is whithin its range instead of the line above. 
- first command is no more systematically navigated. If the current command is the first one, navigating the previous command results in no command being navigated.

Note that the second point in the above list requires the last modifications in the Lambdapi server (currently in master) to work properly. However, the modifications do not seem to break anything if used with a previous version of Lambdapi (At least not the last released one from the market)