### PR TITLE
fix vsce@2.15.0 warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       - name: generate-vscode-extension
         run: |
           npm install -g @types/vscode
-          npm install -g vsce 
+          npm install -g @vscode/vsce 
           make build-vscode-extension
           make publish-vscode-extension
         env:


### PR DESCRIPTION
Replace `npm install vsce` by `npm install vscode/vsce` in the Makefile to get ride of the warnings displayed at install.