### PR TITLE
Fix Vscode extension : Prevent Goals panel to take focus when browsing proofs

### DIFF
--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -705,7 +705,7 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
         }
         // Take focus back if the goal panel lost it.
         if(!panel.active) {
-            panel.reveal(2, false);
+            panel.reveal(2, true);
         }
 
         updateTerminalText(goals.logs);

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -704,7 +704,6 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
             return;
         }
         // Take focus back if the goal panel lost it.
-        window.showErrorMessage("Going through Goals");
         if(!panel.active) {
             panel.reveal(2, false);
         }


### PR DESCRIPTION
As described in this discussion of issue #869, the Goals panel of the Vscode extension tends to take focus when user is executing commands in a Lambdapi file. This PR fixes this issue and removes a debugging message that is no more needed.