### PR TITLE
Release minor version 0.2.2.1

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -8,7 +8,7 @@
     "François Lefoulon <francois.lefoulon@lilo.org>",
     "Ashish Barnawal <ashbrnwl.2000@gmail.com>"
   ],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "Deducteam",
   "engines": {
     "vscode": "^1.82.0"

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -705,7 +705,7 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
         }
         // Take focus back if the goal panel lost it.
         if(!panel.active) {
-            panel.reveal(2, false);
+            panel.reveal(2, true);
         }
 
         updateTerminalText(goals.logs);

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -704,7 +704,6 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
             return;
         }
         // Take focus back if the goal panel lost it.
-        window.showErrorMessage("Going through Goals");
         if(!panel.active) {
             panel.reveal(2, false);
         }


### PR DESCRIPTION
This PR sets the Vscode extension version to 0.2.2.1 to release minor revision that fixes the behavior of the Goals panel by bringing it to front whithout taking focus from the document being navigated