### PR TITLE
Document Macos shortcuts

### DIFF
--- a/doc/vscode.rst
+++ b/doc/vscode.rst
@@ -23,17 +23,27 @@ Make sure you have a `lambdapi.pkg <https://lambdapi.readthedocs.io/en/latest/mo
 
 Goals are visualised in a panel on the right side of the editor. You can
 navigate in proof with the following key-bindings:
+***Linux and Windows***
+- ``Ctrl+Right``: go one step forward
+- ``Ctrl+Left``: go one step backward
+- ``Ctrl+Up``: go to the previous proof (or the beginning)
+- ``Ctrl+Down``: go to the next proof (or the end)
+- ``Ctrl+Enter``: go to the position of the cursor
+- ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
+- ``Ctrl+Alt+w``: toggle follow mode (proof highligsht is always centered in the window when keybindings are pressed)
+- ``Shift+Alt+w``: center proof highlight in the current window
 
--  ``Ctrl+Right``: go one step forward
--  ``Ctrl+Left``: go one step backward
--  ``Ctrl+Up``: go to the previous proof (or the beginning)
--  ``Ctrl+Down``: go to the next proof (or the end)
--  ``Ctrl+Enter``: go to the position of the cursor
--  ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the
-   cursor or not)
--  ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always
-   centered in the window when keybindings are pressed)
--  ``Shift+Alt+w``: center proof highlight in the current window
+***Mac OS X***
+- ``Ctrl+fn+Right``: go one step forward
+- ``Ctrl+fn+Left``: go one step backward
+- ``Ctrl+Alt+Up``: go to the previous proof (or the beginning)
+- ``Ctrl+Alt+Down``: go to the next proof (or the end)
+- ``Ctrl+Enter``: go to the position of the cursor
+- ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
+- ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always centered in the window when keybindings are pressed)
+- ``Shift+Alt+w``: center proof highlight in the current window
+
+Please note that these key-bindings can be changed in Code->Preferences->keyboard shortcuts (also reachable with Ctrl+K Ctrl+S or Command+K Command+S in Mac OS X).
 
 **Hover and go-to-definition**
 

--- a/editors/vscode/CHANGES.md
+++ b/editors/vscode/CHANGES.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+### Fixed
+
+### Changed
+- Changed the `go to the previous/next proof` commands shortcuts for Mac OS X operating system because previous ones are used by Mac OS.
+
 ## [0.2.2]
 - code refactoring of the client for maintenability.
 - fix the bug that causes the proof navigation to malfunction when the `Goals` panel is closed by the user. Now the panel is recreated whenever needed. If focus is taken away frol the `Goals` panel, focus is given back to it when user starts navigating proofs again.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,8 +6,6 @@ Goals are visualised in a panel on the right side of the editor.
 You can navigate in proof with the following key-bindings:
 
 ***Linux and Windows***
-
-
 - ``Ctrl+Right`` (``Ctrl+fn+Right`` in `Mac OS X`): go one step forward
 - ``Ctrl+Left`` (``Ctrl+fn+Left`` in `Mac OS X`): go one step backward
 - ``Ctrl+Up``: go to the previous proof <sup>*</sup> (or the beginning)
@@ -25,7 +23,7 @@ You can navigate in proof with the following key-bindings:
 - ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always centered in the window when keybindings are pressed)
 - ``Shift+Alt+w``: center proof highlight in the current window
 
-For `go to the previous proof` and `go to the next proof` Key bindings need to be changed in Code->Preferences->keyboard shortcuts (also reachable with Command+K Command+S) because default ones are used by Mac OS X
+For `go to the previous proof` and `go to the next proof`, Key bindings need to be changed in Code->Preferences->keyboard shortcuts (also reachable with Command+K Command+S) because default ones are used by Mac OS X
 
 **Hover and go-to-definition**
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -18,14 +18,14 @@ You can navigate in proof with the following key-bindings:
 ***Mac OS X***
 - ``Ctrl+fn+Right``: go one step forward
 - ``Ctrl+fn+Left``: go one step backward
-- ``Ctrl+Up``: go to the previous proof (or the beginning)
-- ``Ctrl+Down``: go to the next proof (or the end)
+- ``Ctrl+Alt+Up``: go to the previous proof (or the beginning)
+- ``Ctrl+Alt+Down``: go to the next proof (or the end)
 - ``Ctrl+Enter``: go to the position of the cursor
 - ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
 - ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always centered in the window when keybindings are pressed)
 - ``Shift+Alt+w``: center proof highlight in the current window
 
-Please note that these key bindings can be changed in Code->Preferences->keyboard shortcuts (also reachable with Ctrl+K Ctrl+S or Command+K Command+S in Mac OS X).
+Please note that these key-bindings can be changed in Code->Preferences->keyboard shortcuts (also reachable with Ctrl+K Ctrl+S or Command+K Command+S in Mac OS X).
 
 **Hover and go-to-definition**
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,8 +6,8 @@ Goals are visualised in a panel on the right side of the editor.
 You can navigate in proof with the following key-bindings:
 
 ***Linux and Windows***
-- ``Ctrl+Right`` (``Ctrl+fn+Right`` in `Mac OS X`): go one step forward
-- ``Ctrl+Left`` (``Ctrl+fn+Left`` in `Mac OS X`): go one step backward
+- ``Ctrl+Right``: go one step forward
+- ``Ctrl+Left``: go one step backward
 - ``Ctrl+Up``: go to the previous proof <sup>*</sup> (or the beginning)
 - ``Ctrl+Down``: go to the next proof <sup>*</sup> (or the end)
 - ``Ctrl+Enter``: go to the position of the cursor

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -8,8 +8,8 @@ You can navigate in proof with the following key-bindings:
 ***Linux and Windows***
 - ``Ctrl+Right``: go one step forward
 - ``Ctrl+Left``: go one step backward
-- ``Ctrl+Up``: go to the previous proof <sup>*</sup> (or the beginning)
-- ``Ctrl+Down``: go to the next proof <sup>*</sup> (or the end)
+- ``Ctrl+Up``: go to the previous proof (or the beginning)
+- ``Ctrl+Down``: go to the next proof (or the end)
 - ``Ctrl+Enter``: go to the position of the cursor
 - ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
 - ``Ctrl+Alt+w``: toggle follow mode (proof highligsht is always centered in the window when keybindings are pressed)
@@ -18,12 +18,14 @@ You can navigate in proof with the following key-bindings:
 ***Mac OS X***
 - ``Ctrl+fn+Right``: go one step forward
 - ``Ctrl+fn+Left``: go one step backward
+- ``Ctrl+Up``: go to the previous proof (or the beginning)
+- ``Ctrl+Down``: go to the next proof (or the end)
 - ``Ctrl+Enter``: go to the position of the cursor
 - ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
 - ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always centered in the window when keybindings are pressed)
 - ``Shift+Alt+w``: center proof highlight in the current window
 
-For `go to the previous proof` and `go to the next proof`, Key bindings need to be changed in Code->Preferences->keyboard shortcuts (also reachable with Command+K Command+S) because default ones are used by Mac OS X
+Please note that these key bindings can be changed in Code->Preferences->keyboard shortcuts (also reachable with Ctrl+K Ctrl+S or Command+K Command+S in Mac OS X).
 
 **Hover and go-to-definition**
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -5,14 +5,16 @@ This extension provides support for the [Lambdapi](https://github.com/Deducteam/
 Goals are visualised in a panel on the right side of the editor.
 You can navigate in proof with the following key-bindings:
 
-- ``Ctrl+Right``: go one step forward
-- ``Ctrl+Left``: go one step backward
-- ``Ctrl+Up``: go to the previous proof (or the beginning)
-- ``Ctrl+Down``: go to the next proof (or the end)
+- ``Ctrl+Right`` (``Ctrl+fn+Right`` in `Mac OS X`): go one step forward
+- ``Ctrl+Left`` (``Ctrl+fn+left`` in `Mac OS X`): go one step backward
+- ``Ctrl+Up``: go to the previous proof <sup>*</sup> (or the beginning)
+- ``Ctrl+Down``: go to the next proof <sup>*</sup> (or the end)
 - ``Ctrl+Enter``: go to the position of the cursor
 - ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
 - ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always centered in the window when keybindings are pressed)
 - ``Shift+Alt+w``: center proof highlight in the current window
+  
+  <sup> *</sup> In `Mac OS X`, ``Ctrl+Up/Down/Down`` are the shortcuts for switching between workspaces. We recommand the definition of new key bindings for `go to the previous/next proof` in ``Code->Preferences->keyboard shortcuts`` (also reachable with `Command+K Command+S`). The advised shortcuts  are `Ctrl+Option+Up` and `Ctrl+Option+Down`
 
 **Hover and go-to-definition**
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -5,16 +5,27 @@ This extension provides support for the [Lambdapi](https://github.com/Deducteam/
 Goals are visualised in a panel on the right side of the editor.
 You can navigate in proof with the following key-bindings:
 
+***Linux and Windows***
+
+
 - ``Ctrl+Right`` (``Ctrl+fn+Right`` in `Mac OS X`): go one step forward
-- ``Ctrl+Left`` (``Ctrl+fn+left`` in `Mac OS X`): go one step backward
+- ``Ctrl+Left`` (``Ctrl+fn+Left`` in `Mac OS X`): go one step backward
 - ``Ctrl+Up``: go to the previous proof <sup>*</sup> (or the beginning)
 - ``Ctrl+Down``: go to the next proof <sup>*</sup> (or the end)
 - ``Ctrl+Enter``: go to the position of the cursor
 - ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
+- ``Ctrl+Alt+w``: toggle follow mode (proof highligsht is always centered in the window when keybindings are pressed)
+- ``Shift+Alt+w``: center proof highlight in the current window
+
+***Mac OS X***
+- ``Ctrl+fn+Right``: go one step forward
+- ``Ctrl+fn+Left``: go one step backward
+- ``Ctrl+Enter``: go to the position of the cursor
+- ``Ctrl+Alt+c``: toggle cursor mode (proof highlight follows the cursor or not)
 - ``Ctrl+Alt+w``: toggle follow mode (proof highlight is always centered in the window when keybindings are pressed)
 - ``Shift+Alt+w``: center proof highlight in the current window
-  
-  <sup> *</sup> In `Mac OS X`, ``Ctrl+Up/Down/Down`` are the shortcuts for switching between workspaces. We recommand the definition of new key bindings for `go to the previous/next proof` in ``Code->Preferences->keyboard shortcuts`` (also reachable with `Command+K Command+S`). The advised shortcuts  are `Ctrl+Option+Up` and `Ctrl+Option+Down`
+
+For `go to the previous proof` and `go to the next proof` Key bindings need to be changed in Code->Preferences->keyboard shortcuts (also reachable with Command+K Command+S) because default ones are used by Mac OS X
 
 **Hover and go-to-definition**
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -138,12 +138,22 @@
       {
         "key": "ctrl+up",
         "command": "extension.lambdapi.pv",
-        "when": "editorTextFocus && editorLangId == lp"
+        "when": "editorTextFocus && editorLangId == lp && (isWindows || isLinux)"
       },
       {
         "key": "ctrl+down",
         "command": "extension.lambdapi.nx",
-        "when": "editorTextFocus && editorLangId == lp"
+        "when": "editorTextFocus && editorLangId == lp && (isWindows || isLinux)"
+      },
+      {
+        "key": "ctrl+alt+up",
+        "command": "extension.lambdapi.pv",
+        "when": "editorTextFocus && editorLangId == lp && isMac"
+      },
+      {
+        "key": "ctrl+alt+down",
+        "command": "extension.lambdapi.nx",
+        "when": "editorTextFocus && editorLangId == lp && isMac"
       }
     ],
     "snippets": [

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -8,7 +8,7 @@
     "François Lefoulon <francois.lefoulon@lilo.org>",
     "Ashish Barnawal <ashbrnwl.2000@gmail.com>"
   ],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "Deducteam",
   "engines": {
     "vscode": "^1.82.0"

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -705,7 +705,7 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
         }
         // Take focus back if the goal panel lost it.
         if(!panel.active) {
-            panel.reveal(2, false);
+            panel.reveal(2, true);
         }
 
         updateTerminalText(goals.logs);

--- a/editors/vscode/src/client.ts
+++ b/editors/vscode/src/client.ts
@@ -704,7 +704,6 @@ function sendGoalsRequest(position: Position, panel: WebviewPanel, docUri: Uri, 
             return;
         }
         // Take focus back if the goal panel lost it.
-        window.showErrorMessage("Going through Goals");
         if(!panel.active) {
             panel.reveal(2, false);
         }


### PR DESCRIPTION
This PR Modifies the README.md of the Vscode extension to document the shortcuts of Lambdapi extension in Mac OS X as discussed in #869 

TODO:
- [x] fix doc/vscode.rst
- [x] fix editors/vscode/README.md
- [x] fix CHANGES.md