### PR TITLE
Remove outdated editors/emacs/lambdapi-mode-pkg.el

### DIFF
--- a/editors/emacs/lambdapi-mode-pkg.el
+++ b/editors/emacs/lambdapi-mode-pkg.el
@@ -1,5 +1,0 @@
-(define-package "lambdapi-mode" "1.1.0"
-  "A major mode to edit Lambdapi files."
-  '((eglot "1.6")
-    (math-symbol-lists "1.2.1")
-    (highlight "20190710.1527")))


### PR DESCRIPTION
The information in `<name>-pkg.el` did not agree with the information in `<name>.el`.  This pull-requests addresses that be removing the outdated `<name>-pkg.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.