### PR TITLE
Emacs/del outdated files

### DIFF
--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -22,7 +22,6 @@ $(NAME)-$(VERSION).tar: $(SRC)
 	cp *.el "$(NAME)-$(VERSION)"
 	tar -cf "$(NAME)-$(VERSION)".tar "$(NAME)-$(VERSION)"
 
-.PHONY: lambdapi-mode-pkg.el
 lambdapi-mode-pkg.el: lambdapi-mode.el
 	$(eval description := "A major mode for editing Lambdapi source code.")
 	$(eval requirements := $(shell grep ";; Package-Requires: " lambdapi-mode.el | sed 's/"/\\"/g' | cut -d' ' -f5-))

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 LAMBDAPI_FILE = lambdapi-mode.el
 VERSION = $(shell cat $(LAMBDAPI_FILE) | grep ";; Version:" | sed "s/;; Version: \(.*\)/\1/")
-NAME = $(shell cat $(LAMBDAPI_FILE) | grep "provide " | grep -v legacy | sed "s/(provide '\(.*\))/\1/")
+NAME = $(shell cat $(LAMBDAPI_FILE) | grep "^(provide" | grep ")" | grep -v "legacy" | sed "s/(provide '\(.*\))/\1/")
 # The path to lambdapi built by dune
 LAMBDAPI = ../../_build/install/default/bin/lambdapi
 
@@ -22,8 +22,6 @@ $(NAME)-$(VERSION).tar: $(SRC)
 	mkdir -p "$(NAME)-$(VERSION)"
 	cp *.el "$(NAME)-$(VERSION)"
 	tar -cf "$(NAME)-$(VERSION)".tar "$(NAME)-$(VERSION)"
-
-FILENAME = $(shell head @<)
 
 .PHONY: lambdapi-mode-pkg.el
 lambdapi-mode-pkg.el: $(LAMBDAPI_FILE)

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -42,6 +42,4 @@ check: dist
 
 .PHONY: clean
 clean:
-	rm -f "$(NAME)-$(VERSION)".tar
-	rm -rf "$(NAME)-$(VERSION)"
-	rm -f lambdapi-mode-pkg.el
+	rm -fr "$(NAME)-$(VERSION)".tar "$(NAME)-$(VERSION)" lambdapi-mode-pkg.el

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -30,10 +30,11 @@ lambdapi-mode-pkg.el: lambdapi-mode.el
 	$(eval packageName := $(shell cat $< | grep "provide " | grep -v legacy | sed "s/(provide '\(.*\))/\1/"))
 	$(eval packageVersion := $(shell cat $< | grep ";; Version:" | sed "s/;; Version: \(.*\)/\1/"))
 	$(eval description := $(shell cat $< | grep ";;; lambdapi-mode.el ---" | sed "s/;;; lambdapi-mode.el --- \(.*\)-\*- lexical-binding:.*/\1/"))
-	$(eval requirements := $(shell cat lambdapi-mode.el | grep ";; Package-Requires: " | sed "s/;; Package-Requires: \(.*\)/\1/"))
+	$(eval requirements := $(shell cat lambdapi-mode.el | grep ";; Package-Requires: " | sed "s/;; Package-Requires: \(.*\)/\1/" | sed 's/"/\\"/g' | cut -d' ' -f3-100))
 	echo "(define-package \"$(packageName)\" \"$(packageVersion)\"" > $@
 	echo "  \"$(description)\"" >> $@
-	echo "  '$(requirements))" >> $@
+	echo "  '($(requirements))" >> $@
+
 
 .PHONY: install
 install:

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -1,7 +1,6 @@
 .POSIX:
-LAMBDAPI_FILE = lambdapi-mode.el
-VERSION = $(shell awk '/^;; Version: /{print $$3;exit}' $(LAMBDAPI_FILE))
-NAME = $(shell grep "^(provide" $(LAMBDAPI_FILE) | grep ")" | grep -v "legacy" | sed "s/(provide '\(.*\))/\1/")
+VERSION = $(shell awk '/^;; Version: /{print $$3;exit}' lambdapi-mode.el)
+NAME = lambdapi-mode
 # The path to lambdapi built by dune
 LAMBDAPI = ../../_build/install/default/bin/lambdapi
 
@@ -12,7 +11,7 @@ SRC += lambdapi-abbrev.el
 SRC += lambdapi-capf.el
 SRC += lambdapi-input.el
 SRC += lambdapi-layout.el
-SRC += $(LAMBDAPI_FILE)
+SRC += lambdapi-mode.el
 SRC += lambdapi-mode-pkg.el
 SRC += lambdapi-proofs.el
 SRC += lambdapi-smie.el
@@ -24,9 +23,9 @@ $(NAME)-$(VERSION).tar: $(SRC)
 	tar -cf "$(NAME)-$(VERSION)".tar "$(NAME)-$(VERSION)"
 
 .PHONY: lambdapi-mode-pkg.el
-lambdapi-mode-pkg.el: $(LAMBDAPI_FILE)
+lambdapi-mode-pkg.el: lambdapi-mode.el
 	$(eval description := "A major mode for editing Lambdapi source code.")
-	$(eval requirements := $(shell grep ";; Package-Requires: " $(LAMBDAPI_FILE) | sed 's/"/\\"/g' | cut -d' ' -f5-))
+	$(eval requirements := $(shell grep ";; Package-Requires: " lambdapi-mode.el | sed 's/"/\\"/g' | cut -d' ' -f5-))
 	@echo "(define-package \"$(NAME)\" \"$(VERSION)\"" > $@
 	@echo "  \"$(description)\"" >> $@
 	@echo "  '($(requirements))" >> $@
@@ -45,3 +44,4 @@ check: dist
 clean:
 	rm -f "$(NAME)-$(VERSION)".tar
 	rm -rf "$(NAME)-$(VERSION)"
+	rm -f lambdapi-mode-pkg.el

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
-
-VERSION = 1.1.0
-NAME = lambdapi-mode
+LAMBDAPI_FILE = lambdapi-mode.el
+VERSION = $(shell cat $(LAMBDAPI_FILE) | grep ";; Version:" | sed "s/;; Version: \(.*\)/\1/")
+NAME = $(shell cat $(LAMBDAPI_FILE) | grep "provide " | grep -v legacy | sed "s/(provide '\(.*\))/\1/")
 # The path to lambdapi built by dune
 LAMBDAPI = ../../_build/install/default/bin/lambdapi
 
@@ -12,7 +12,7 @@ SRC += lambdapi-abbrev.el
 SRC += lambdapi-capf.el
 SRC += lambdapi-input.el
 SRC += lambdapi-layout.el
-SRC += lambdapi-mode.el
+SRC += $(LAMBDAPI_FILE)
 SRC += lambdapi-mode-pkg.el
 SRC += lambdapi-proofs.el
 SRC += lambdapi-smie.el
@@ -26,15 +26,12 @@ $(NAME)-$(VERSION).tar: $(SRC)
 FILENAME = $(shell head @<)
 
 .PHONY: lambdapi-mode-pkg.el
-lambdapi-mode-pkg.el: lambdapi-mode.el
-	$(eval packageName := $(shell cat $< | grep "provide " | grep -v legacy | sed "s/(provide '\(.*\))/\1/"))
-	$(eval packageVersion := $(shell cat $< | grep ";; Version:" | sed "s/;; Version: \(.*\)/\1/"))
-	$(eval description := $(shell cat $< | grep ";;; lambdapi-mode.el ---" | sed "s/;;; lambdapi-mode.el --- \(.*\)-\*- lexical-binding:.*/\1/"))
-	$(eval requirements := $(shell cat lambdapi-mode.el | grep ";; Package-Requires: " | sed "s/;; Package-Requires: \(.*\)/\1/" | sed 's/"/\\"/g' | cut -d' ' -f3-100))
-	echo "(define-package \"$(packageName)\" \"$(packageVersion)\"" > $@
-	echo "  \"$(description)\"" >> $@
-	echo "  '($(requirements))" >> $@
-
+lambdapi-mode-pkg.el: $(LAMBDAPI_FILE)
+	$(eval description := $(shell cat $< | grep ";;; $(LAMBDAPI_FILE) ---" | sed "s/;;; $(LAMBDAPI_FILE) --- \(.*\)-\*- lexical-binding:.*/\1/"))
+	$(eval requirements := $(shell cat $(LAMBDAPI_FILE) | grep ";; Package-Requires: " | sed "s/;; Package-Requires: \(.*\)/\1/" | sed 's/"/\\"/g' | cut -d' ' -f3-100))
+	@echo "(define-package \"$(NAME)\" \"$(VERSION)\"" > $@
+	@echo "  \"$(description)\"" >> $@
+	@echo "  '($(requirements))" >> $@
 
 .PHONY: install
 install:

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 LAMBDAPI_FILE = lambdapi-mode.el
-VERSION = $(shell cat $(LAMBDAPI_FILE) | grep ";; Version:" | sed "s/;; Version: \(.*\)/\1/")
-NAME = $(shell cat $(LAMBDAPI_FILE) | grep "^(provide" | grep ")" | grep -v "legacy" | sed "s/(provide '\(.*\))/\1/")
+VERSION = $(shell awk '/^;; Version: /{print $$3;exit}' $(LAMBDAPI_FILE))
+NAME = $(shell grep "^(provide" $(LAMBDAPI_FILE) | grep ")" | grep -v "legacy" | sed "s/(provide '\(.*\))/\1/")
 # The path to lambdapi built by dune
 LAMBDAPI = ../../_build/install/default/bin/lambdapi
 
@@ -25,8 +25,8 @@ $(NAME)-$(VERSION).tar: $(SRC)
 
 .PHONY: lambdapi-mode-pkg.el
 lambdapi-mode-pkg.el: $(LAMBDAPI_FILE)
-	$(eval description := $(shell cat $< | grep ";;; $(LAMBDAPI_FILE) ---" | sed "s/;;; $(LAMBDAPI_FILE) --- \(.*\)-\*- lexical-binding:.*/\1/"))
-	$(eval requirements := $(shell cat $(LAMBDAPI_FILE) | grep ";; Package-Requires: " | sed "s/;; Package-Requires: \(.*\)/\1/" | sed 's/"/\\"/g' | cut -d' ' -f3-100))
+	$(eval description := "A major mode for editing Lambdapi source code.")
+	$(eval requirements := $(shell grep ";; Package-Requires: " $(LAMBDAPI_FILE) | sed 's/"/\\"/g' | cut -d' ' -f5-))
 	@echo "(define-package \"$(NAME)\" \"$(VERSION)\"" > $@
 	@echo "  \"$(description)\"" >> $@
 	@echo "  '($(requirements))" >> $@

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -31,16 +31,6 @@ lambdapi-mode-pkg.el: $(LAMBDAPI_FILE)
 	@echo "  \"$(description)\"" >> $@
 	@echo "  '($(requirements))" >> $@
 
-.PHONY: install
-install:
-	@echo "See https://lambdapi.readthedocs.io/en/latest/emacs.html \
-	for instructions on how to install the lambdapi mode for Emacs. \
-	If you know what you're doing, you can install the development version with" \
-	| fmt
-	@echo "$$ make dist"
-	@echo "and in emacs"
-	@echo "M-x package-install-file RET $(NAME)-$(VERSION).tar RET"
-
 .PHONY: dist
 dist: $(NAME)-$(VERSION).tar
 

--- a/editors/emacs/Makefile
+++ b/editors/emacs/Makefile
@@ -23,6 +23,18 @@ $(NAME)-$(VERSION).tar: $(SRC)
 	cp *.el "$(NAME)-$(VERSION)"
 	tar -cf "$(NAME)-$(VERSION)".tar "$(NAME)-$(VERSION)"
 
+FILENAME = $(shell head @<)
+
+.PHONY: lambdapi-mode-pkg.el
+lambdapi-mode-pkg.el: lambdapi-mode.el
+	$(eval packageName := $(shell cat $< | grep "provide " | grep -v legacy | sed "s/(provide '\(.*\))/\1/"))
+	$(eval packageVersion := $(shell cat $< | grep ";; Version:" | sed "s/;; Version: \(.*\)/\1/"))
+	$(eval description := $(shell cat $< | grep ";;; lambdapi-mode.el ---" | sed "s/;;; lambdapi-mode.el --- \(.*\)-\*- lexical-binding:.*/\1/"))
+	$(eval requirements := $(shell cat lambdapi-mode.el | grep ";; Package-Requires: " | sed "s/;; Package-Requires: \(.*\)/\1/"))
+	echo "(define-package \"$(packageName)\" \"$(packageVersion)\"" > $@
+	echo "  \"$(description)\"" >> $@
+	echo "  '$(requirements))" >> $@
+
 .PHONY: install
 install:
 	@echo "See https://lambdapi.readthedocs.io/en/latest/emacs.html \

--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -1,0 +1,4 @@
+For instructions on how to install the lambdapi mode for Emacs please see https://lambdapi.readthedocs.io/en/latest/emacs.html.
+
+To install the devellopment version of lambdapi mode for Emacs please run on the current directory, `make dist`. This will generate a `$(NAME)-$(VERSION).tar` file. 
+Then, in emacs run `M-x package-install-file RET /PATH/TO/TAR/FILE/$(NAME)-$(VERSION).tar RET`

--- a/editors/emacs/lambdapi-mode-pkg.el
+++ b/editors/emacs/lambdapi-mode-pkg.el
@@ -1,5 +1,0 @@
-(define-package "lambdapi-mode" "1.1.0"
-  "A major mode to edit Lambdapi files."
-  '((eglot "1.6")
-    (math-symbol-lists "1.2.1")
-    (highlight "20190710.1527")))


### PR DESCRIPTION
This PR subsumes #1170 by @tarsius.

The information in <name>-pkg.el did not agree with the information in <name>.el. This pull-requests addresses that be removing the outdated <name>-pkg.el.

However, since <name>-pkg.el is necessary to install the package locally for debugging, an entry is added to the make file to generate it and include it to the `tar` file for local testing only.

