### PR TITLE
Cleanup syntax highlighting file for vscode

### DIFF
--- a/editors/vscode/syntaxes/lp.tmLanguage.json
+++ b/editors/vscode/syntaxes/lp.tmLanguage.json
@@ -40,7 +40,7 @@
     },
 
     "tactics": {
-      "match": "\\b(apply|assume|fail|focus|generalize|have|induction|orelse|refine|reflexivity|remove|repeat|rewrite|set|simplify|solve|symmetry|try|why3)\\b",
+      "match": "\\b(apply|assume|focus|generalize|have|induction|orelse|refine|reflexivity|remove|repeat|rewrite|set|simplify|solve|symmetry|try|why3)\\b",
       "name": "keyword.control.tactics.lp"
     },
 

--- a/editors/vscode/syntaxes/lp.tmLanguage.json
+++ b/editors/vscode/syntaxes/lp.tmLanguage.json
@@ -24,10 +24,6 @@
     }
   ],
   "repository": {
-    "commands": {
-      "match": "\\b(abort|admit|admitted|apply|as|assert|assertnot|associative|assume|begin|builtin|coerce_rule|commutative|compute|constant|debug|end|fail|flag|focus|generalize|have|in|induction|inductive|infix|injective|left|let|notation|off|on|open|opaque|orelse|postfix|prefix|print|private|proofterm|protected|prover|prover_timeout|quantifier|refine|reflexivity|remove|repeat|require|rewrite|rule|search|sequential|set|simplify|symbol|symmetry|try|type|TYPE|unif_rule|why3|with)\\b",
-      "name": "keyword.control.lp"
-    },
     "comments": {
       "patterns": [
         {


### PR DESCRIPTION
The syntax highlighting file for vscode (`editors/vscode/syntaxes/lp.tmLanguage.json`) contains information for the tokenization and syntax coloring of Lambdapi files under Vscode. 
This file contains the keywords of the Lambdapi language and their "syntactic categories" which are matched to "coloring categories".
Currently, some keywords appear in different categories at the same time and one category (`commands`) duplicates all the keywords that are in other categories which is confusing and can be source of errors/inconsistencies in the future.
Thus, this PR cleans up this file.