### PR TITLE
Emacs : fix version of Emacs in requirements

### DIFF
--- a/editors/emacs/CHANGES.md
+++ b/editors/emacs/CHANGES.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 01/02/2025
 
 ### Added
 - Auto scroll to the first goal in the `Goals` buffer in case of many hypothesis
@@ -11,6 +11,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Show the error at the end of file if any. That was not working because navigation stoped at the location of last command and not further (see issue #1111)
-
-
-### Changed

--- a/editors/emacs/lambdapi-mode.el
+++ b/editors/emacs/lambdapi-mode.el
@@ -8,8 +8,8 @@
 ;; SPDX-License-Identifier: CECILL-2.1
 ;; Homepage: https://github.com/Deducteam/lambdapi
 ;; Keywords: languages
-;; Compatibility: GNU Emacs 28.1
-;; Package-Requires: ((emacs "28.1") (eglot "1.6") (math-symbol-lists "1.2.1") (highlight "20190710.1527"))
+;; Compatibility: GNU Emacs 27.1
+;; Package-Requires: ((emacs "27.1") (eglot "1.6") (math-symbol-lists "1.2.1") (highlight "20190710.1527"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
This PR uses version 27.1 instead of version 28.1 of Emacs in the Lambdapi extension requirements since this extension has been tested successfully with version 27.1 of Emacs.