### PR TITLE
fix printing of positive integers in print.ml

### DIFF
--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -123,13 +123,13 @@ let nat_of_term : term -> int = fun t ->
 let pos_of_term : term -> int = fun t ->
   let one = builtin "pos_one" and dbl = builtin "pos_double"
   and suc_dbl = builtin "pos_succ_double" in
-  let rec pos acc = fun t ->
+  let rec pos = fun t ->
     match get_args t with
-    | (Symb s, [u]) when s == dbl -> pos (2*acc) u
-    | (Symb s, [u]) when s == suc_dbl -> pos (2*acc+1) u
-    | (Symb s,  []) when s == one -> acc
+    | (Symb s, [u]) when s == dbl -> 2 * (pos u)
+    | (Symb s, [u]) when s == suc_dbl -> (2 * pos u) + 1
+    | (Symb s,  []) when s == one -> 1
     | _ -> raise Not_a_nat
-  in pos 1 t
+  in pos t
 
 (** [int_of_term t] converts a term into a positive number.
     @raise Not_a_nat if this is not possible. *)


### PR DESCRIPTION
fixing bugged printing of positive integers due to of weird tail-recursion in `pos_of_term`.
e.g., currently `compute (I (O H))` incorrectly prints as `6` rather than `5`.

now we just use recursion which is maybe less efficient????