### PR TITLE
Customize websearch server to work online

### DIFF
--- a/doc/options.rst
+++ b/doc/options.rst
@@ -170,6 +170,8 @@ websearch
 
 * ``-- require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can use used for example to specify implicit arguments for symbols used in the queries.
 
+* ``-- --descriptionfil <FILE.html>`` Reads the content of ``<FILE.html>`` and uses it as the header of the web page of the search engine. Optional. If no file is provided a default header is used.
+
 lsp
 -------
 

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -276,11 +276,20 @@ module DB = struct
   if l = [] then
    Lplib.Base.out fmt "Nothing found"
   else
+    let pp = fun ppf p ->
+      let relative_position =
+        let absolute_position = popt_to_string p in
+        try
+          let last_slash_index = String.rindex absolute_position '/' in
+          String.sub absolute_position (last_slash_index + 1)
+          (String.length absolute_position - last_slash_index - 1)
+        with Not_found -> absolute_position in
+      Lplib.Base.string ppf (relative_position) in
    Lplib.List.pp
     (fun ppf (((p,n),pos),(positions : answer)) ->
-     Lplib.Base.out ppf "%s%a.%s@%a%s%a%s%s%a%s%s@."
-      lisb (escaper.run Core.Print.path) p n (escaper.run Common.Pos.pp)
-      pos separator (generic_pp_of_position_list ~escaper ~sep) positions
+     Lplib.Base.out ppf "%s%a.<b>%s</b>@%a%s%a%s%s<code>%a</code>%s%s@."
+      lisb (escaper.run Core.Print.path) p n pp pos
+      separator (generic_pp_of_position_list ~escaper ~sep) positions
       separator preb
       (Common.Pos.print_file_contents ~escape ~delimiters)
       pos pree lise)

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -153,7 +153,8 @@ let show_form ~from ?(message="") ?output request =
 
 let start ss ~port () =
   (*Common.Logger.set_debug true "e" ;*)
-  Dream.run ~port
+  let interface = "0.0.0.0" in
+  Dream.run ~port ~interface
   @@ Dream.logger
   @@ Dream.memory_sessions
   @@ Dream.router [

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -33,6 +33,11 @@ let show_form_stream ?(message="") ?(output="") request response =
 let show_form ~from ?(message="") ?output request =
   <html>
   <style>
+    .snippet {
+      border: 2px solid grey;  /* Bordure grise */
+      color: red;              /* Texte en rouge */
+      /* padding: 10px;           Espace autour du texte à l'intérieur de la bordure */
+    }
     code {
       font-family: "Courier New", Courier, monospace;
       background-color:rgb(8, 8, 8);
@@ -120,7 +125,13 @@ let show_form ~from ?(message="") ?output request =
     The <b>search</b> button answers the query. Read the <a
     href="https://lambdapi.readthedocs.io/en/latest/query_language.html">query
     language specification</a> to learn about the query language.<br>
+    Examples of queries written in the query language are as follows :
     </p>
+    <ul>
+      <li><span class="snippet">hyp = (num → num) , hyp >= (Real)</span> searches for theorem that have an hypothesis <span class="snippet">num → num</span> and such that <span class="snippet">Real</span> occurs in some (other) hypothesis.
+      <li><span class="snippet">concl > real_of_num | HOLLight.theorems</span> searches for theorems having an hypothesis containing <span class="snippet">real_of_num</span> and located in a module whose path is a suffix of <span class="snippet">HOLLight.theorems</span></li>
+      <li><span class="snippet">name = num ; name = NUM</span> searches for symbols named either <span class="snippet">num</span> or <span class="snippet">NUM</span></li>
+    </ul>
 
     <form method="POST" action="/" id="form">
       <%s! Dream.csrf_tag request %>

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -1,103 +1,8 @@
-(*
-let show_form_stream ?(message="") ?(output="") request response =
-  %% response
-  <html>
-  <body>
 
-    <h1><a href="https://github.com/Deducteam/lambdapi">LambdaPi</a>
-     Search Engine</h1>
-
-    <p>
-    The <b>search</b> button answers the query. Read the <a
-    href="https://lambdapi.readthedocs.io/en/latest/query_language.html">query
-    language specification</a> to learn about the query language.<br>
-    </p>
-
-    <form method="POST" action="/">
-      <%s! Dream.csrf_tag request %>
-      <p>
-      <input type="search" required="true" size="100"
-        name="message" value="<%s message %>"
-        onfocus="this.select();" autofocus></p>
-      <p>
-      <input type="submit" value="search" name="search">
-      </p>
-    </form>
-
-    <%s! output %>
-
-  </body>
-  </html>
-*)
 
 let show_form ~from ?(message="") ?output request =
   <html>
-  <style>
-    .snippet {
-      border: 2px solid grey;  /* Bordure grise */
-      color: red;              /* Texte en rouge */
-      /* padding: 10px;           Espace autour du texte à l'intérieur de la bordure */
-    }
-    code {
-      font-family: "Courier New", Courier, monospace;
-      background-color:rgb(8, 8, 8);
-      padding: 2px 4px;
-      border-radius: 4px;
-      color:rgb(43, 230, 52);
-      font-size: 1.3em;
-      white-space: normal;
-    }
-    .header {
-      position: relative; /* Conteneur pour les liens */
-      width: 100%;
-      height: 80px;
-      background-color: #f1f1f1;
-    }
-    .top-right-link {
-      position: absolute;
-      top: 10px;
-      right: 10px;
-      text-decoration: none;
-      background-color: #007BFF;
-      color: white;
-      padding: 10px 20px;
-      border-radius: 5px;
-      font-size: 18px;
-      text-align: center;
-    }
-    .top-right-link span {
-      display: block;
-      font-size: 12px;
-    }
-    .top-right-link:hover {
-        background-color: #0056b3;
-    }
-    .top-left-link {
-      position: absolute;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      background-color: #007BFF;
-      color: white;
-      padding: 10px 20px;
-      border-radius: 5px;
-      font-size: 18px;
-      text-align: center;
-    }
-    .top-left-link span {
-      display: block;
-      font-size: 12px;
-    }
-    .top-left-link:hover {
-        background-color: #0056b3;
-    }
-  </style>
   <body>
-
-    <div class="header">
-      <a href="https://github.com/Deducteam/lambdapi/issues/new" target="_blank" class="top-right-link"><span>Something went wrong?</span>Open an issue</a>
-      <a href="https://github.com/Deducteam/lambdapi/discussions/1214" target="_blank" class="top-left-link"><span>Like this tool?</span>Join the discussion</a>
-      </div>
 
     <script>
     function incr(delta) {
@@ -106,32 +11,6 @@ let show_form ~from ?(message="") ?output request =
       document.getElementById("search").click();
     }
     </script>
-
-    <h1><a href="https://github.com/Deducteam/lambdapi">LambdaPi</a>
-     Search Engine</h1>
-     
-
-    <p>
-    This web page offers facilities to search objects in the <a href="https://github.com/Deducteam/lambdapi">HOL-Light</a> library translated and available in 
-    <a href="https://github.com/Deducteam/Dedukti/">Dedukti</a>,
-    <a href="https://github.com/Deducteam/lambdapi">Lambdapi</a>  and 
-    <a href="https://coq.inria.fr/">Coq/Rocq</a>.
-    </p>
-    <p>
-    The translation has been performed using the <a href="https://github.com/Deducteam/hol2dk">hol2dk</a> tool and the resulting theorems are gathered in the Opam package coq-hol-light available in the Coq Opam repository released.
-    It currently contains a translation of the Multivariate library with more than 20,000 theorems on arithmetic, wellfounded relations, lists, real numbers, integers, basic set theory, permutations, group theory, matroids, metric spaces, homology, vectors, determinants, topology, convex sets and functions, paths, polytopes, Brouwer degree, derivatives, Clifford algebra, integration, measure theory, complex numbers and analysis, transcendental numbers, real analysis, complex line integrals, etc.
-    </p>
-    <p>
-    The <b>search</b> button answers the query. Read the <a
-    href="https://lambdapi.readthedocs.io/en/latest/query_language.html">query
-    language specification</a> to learn about the query language.<br>
-    Examples of queries written in the query language are as follows :
-    </p>
-    <ul>
-      <li><span class="snippet">hyp = (num → num) , hyp >= (Real)</span> searches for theorem that have an hypothesis <span class="snippet">num → num</span> and such that <span class="snippet">Real</span> occurs in some (other) hypothesis.
-      <li><span class="snippet">concl > real_of_num | HOLLight.theorems</span> searches for theorems having an hypothesis containing <span class="snippet">real_of_num</span> and located in a module whose path is a suffix of <span class="snippet">HOLLight.theorems</span></li>
-      <li><span class="snippet">name = num ; name = NUM</span> searches for symbols named either <span class="snippet">num</span> or <span class="snippet">NUM</span></li>
-    </ul>
 
     <form method="POST" action="/" id="form">
       <%s! Dream.csrf_tag request %>
@@ -162,7 +41,7 @@ let show_form ~from ?(message="") ?output request =
   </body>
   </html>
 
-let start ss ~port () =
+let start description ss ~port () =
   (*Common.Logger.set_debug true "e" ;*)
   let interface = "0.0.0.0" in
   Dream.run ~port ~interface
@@ -172,7 +51,7 @@ let start ss ~port () =
 
     Dream.get  "/"
       (fun request ->
-        Dream.html (show_form ~from:0 request));
+        Dream.html (description ^ (show_form ~from:0 request)));
 
     Dream.post "/"
       (fun request ->

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -32,6 +32,27 @@ let show_form_stream ?(message="") ?(output="") request response =
 
 let show_form ~from ?(message="") ?output request =
   <html>
+  <style>
+    .top-right-link {
+        position: fixed; /* Fixe l'élément à un endroit spécifique sur la page */
+        top: 10px; /* 10 pixels du haut de la page */
+        right: 10px; /* 10 pixels du côté droit de la page */
+        text-decoration: none; /* Enlève la décoration du texte (le soulignement) */
+        background-color: #007BFF; /* Couleur de fond pour le bouton */
+        color: white; /* Couleur du texte */
+        padding: 10px 20px; /* Espaces autour du texte */
+        border-radius: 5px; /* Bords arrondis */
+        font-size: 18px; /* Taille du texte */
+        text-align: center;
+    }
+    .top-right-link span {
+      display: block;
+      font-size: 12px; /* Taille de police spécifique pour ce texte */
+    }
+    .top-right-link:hover {
+        background-color: #0056b3; /* Change la couleur de fond au survol */
+    }
+  </style>
   <body>
     <script>
     function incr(delta) {
@@ -43,6 +64,8 @@ let show_form ~from ?(message="") ?output request =
 
     <h1><a href="https://github.com/Deducteam/lambdapi">LambdaPi</a>
      Search Engine</h1>
+     
+    <a href="https://github.com/Deducteam/lambdapi/issues/new" class="top-right-link"><span>Something went wrong?</span>Open an issue</a>
 
     <p>
     This web page offers facilities to search objects in the <a href="https://github.com/Deducteam/lambdapi">HOL-Light</a> library translated and available in 
@@ -51,7 +74,7 @@ let show_form ~from ?(message="") ?output request =
     <a href="https://coq.inria.fr/">Coq/Rocq</a>.
     </p>
     <p>
-    The translation has been performed using the hol2dk tool and The resulting theorems are gathered in the Opam package coq-hol-light available in the Coq Opam repository released.
+    The translation has been performed using the <a href="https://github.com/Deducteam/hol2dk">hol2dk</a> tool and the resulting theorems are gathered in the Opam package coq-hol-light available in the Coq Opam repository released.
     It currently contains a translation of the Multivariate library with more than 20,000 theorems on arithmetic, wellfounded relations, lists, real numbers, integers, basic set theory, permutations, group theory, matroids, metric spaces, homology, vectors, determinants, topology, convex sets and functions, paths, polytopes, Brouwer degree, derivatives, Clifford algebra, integration, measure theory, complex numbers and analysis, transcendental numbers, real analysis, complex line integrals, etc.
     </p>
     <p>

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -33,24 +33,33 @@ let show_form_stream ?(message="") ?(output="") request response =
 let show_form ~from ?(message="") ?output request =
   <html>
   <style>
+    code {
+      font-family: "Courier New", Courier, monospace;
+      background-color:rgb(8, 8, 8);
+      padding: 2px 4px;
+      border-radius: 4px;
+      color:rgb(43, 230, 52);
+      font-size: 1.3em;
+      white-space: normal;
+    }
     .top-right-link {
-        position: fixed; /* Fixe l'élément à un endroit spécifique sur la page */
-        top: 10px; /* 10 pixels du haut de la page */
-        right: 10px; /* 10 pixels du côté droit de la page */
-        text-decoration: none; /* Enlève la décoration du texte (le soulignement) */
-        background-color: #007BFF; /* Couleur de fond pour le bouton */
-        color: white; /* Couleur du texte */
-        padding: 10px 20px; /* Espaces autour du texte */
-        border-radius: 5px; /* Bords arrondis */
-        font-size: 18px; /* Taille du texte */
-        text-align: center;
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      text-decoration: none;
+      background-color: #007BFF;
+      color: white;
+      padding: 10px 20px;
+      border-radius: 5px;
+      font-size: 18px;
+      text-align: center;
     }
     .top-right-link span {
       display: block;
-      font-size: 12px; /* Taille de police spécifique pour ce texte */
+      font-size: 12px;
     }
     .top-right-link:hover {
-        background-color: #0056b3; /* Change la couleur de fond au survol */
+        background-color: #0056b3;
     }
   </style>
   <body>

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -42,8 +42,14 @@ let show_form ~from ?(message="") ?output request =
       font-size: 1.3em;
       white-space: normal;
     }
+    .header {
+      position: relative; /* Conteneur pour les liens */
+      width: 100%;
+      height: 80px;
+      background-color: #f1f1f1;
+    }
     .top-right-link {
-      position: fixed;
+      position: absolute;
       top: 10px;
       right: 10px;
       text-decoration: none;
@@ -61,8 +67,33 @@ let show_form ~from ?(message="") ?output request =
     .top-right-link:hover {
         background-color: #0056b3;
     }
+    .top-left-link {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      background-color: #007BFF;
+      color: white;
+      padding: 10px 20px;
+      border-radius: 5px;
+      font-size: 18px;
+      text-align: center;
+    }
+    .top-left-link span {
+      display: block;
+      font-size: 12px;
+    }
+    .top-left-link:hover {
+        background-color: #0056b3;
+    }
   </style>
   <body>
+
+    <div class="header">
+      <a href="https://github.com/Deducteam/lambdapi/issues/new" target="_blank" class="top-right-link"><span>Something went wrong?</span>Open an issue</a>
+      <a href="https://github.com/Deducteam/lambdapi/discussions/1214" target="_blank" class="top-left-link"><span>Like this tool?</span>Join the discussion</a>
+      </div>
+
     <script>
     function incr(delta) {
       document.getElementById("from").value =
@@ -74,7 +105,6 @@ let show_form ~from ?(message="") ?output request =
     <h1><a href="https://github.com/Deducteam/lambdapi">LambdaPi</a>
      Search Engine</h1>
      
-    <a href="https://github.com/Deducteam/lambdapi/issues/new" class="top-right-link"><span>Something went wrong?</span>Open an issue</a>
 
     <p>
     This web page offers facilities to search objects in the <a href="https://github.com/Deducteam/lambdapi">HOL-Light</a> library translated and available in 

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -45,6 +45,16 @@ let show_form ~from ?(message="") ?output request =
      Search Engine</h1>
 
     <p>
+    This web page offers facilities to search objects in the <a href="https://github.com/Deducteam/lambdapi">HOL-Light</a> library translated and available in 
+    <a href="https://github.com/Deducteam/Dedukti/">Dedukti</a>,
+    <a href="https://github.com/Deducteam/lambdapi">Lambdapi</a>  and 
+    <a href="https://coq.inria.fr/">Coq/Rocq</a>.
+    </p>
+    <p>
+    The translation has been performed using the hol2dk tool and The resulting theorems are gathered in the Opam package coq-hol-light available in the Coq Opam repository released.
+    It currently contains a translation of the Multivariate library with more than 20,000 theorems on arithmetic, wellfounded relations, lists, real numbers, integers, basic set theory, permutations, group theory, matroids, metric spaces, homology, vectors, determinants, topology, convex sets and functions, paths, polytopes, Brouwer degree, derivatives, Clifford algebra, integration, measure theory, complex numbers and analysis, transcendental numbers, real analysis, complex line integrals, etc.
+    </p>
+    <p>
     The <b>search</b> button answers the query. Read the <a
     href="https://lambdapi.readthedocs.io/en/latest/query_language.html">query
     language specification</a> to learn about the query language.<br>

--- a/src/tool/websearch.mli
+++ b/src/tool/websearch.mli
@@ -1,1 +1,1 @@
-val start : Core.Sig_state.sig_state -> port:int -> unit -> unit
+val start : string -> Core.Sig_state.sig_state -> port:int -> unit -> unit


### PR DESCRIPTION
This PR modifies the websearch engine of Lambdapi so that it can be easily deployed and customized for online use. This includes the following points :
- Make the server listen to the all interfaces instead of localhost only.
- Read the header of the Lambdapi websearch webpage from an external file so that it can be customized to specific libraries (for instance, to include description of the HOL-Light library). This may include specific CCS styles also.
- Enhance the formatting of the search results.