### PR TITLE
Customize the index DB file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Add tactic `set`.
 - Decimal notation for integers.
-- add the `search-db` flag to the `index`, `search` and `websearch` commands
+- add the `--db` option to the `index`, `search` and `websearch` commands
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Add tactic `set`.
 - Decimal notation for integers.
+- added the `search-db` flag to the `index`, `search` and `websearch` commands
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Add tactic `set`.
 - Decimal notation for integers.
-- added the `search-db` flag to the `index`, `search` and `websearch` commands
+- add the `search-db` flag to the `index`, `search` and `websearch` commands
 
 ### Fixed
 

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -146,7 +146,7 @@ index
 * ``--add`` tells lambdapi to not erase the index before adding new symbols and rules.
 
 * ``--rules <LPSearch.lp>`` tells lambdapi to normalize terms using the rules given in the file ``<LPSearch.lp>`` before indexing. Several files can be specified by using several ``--rules`` options. In these files, symbols must be fully qualified but no ``require`` command is needed. Moreover, the rules do not need to preserve typing. On the other hand, right hand-side of rules must contain implicit arguments.
-
+`
   For instance, to index the Matita library, you can use the following rules:
 
 ::
@@ -162,9 +162,9 @@ search
 
 * ``--rules <LPSearch.lp>`` tells lambdapi to normalize terms in the query using the rules given in the file ``<LPSearch.lp>``. Several files can be specified by using several ``--rules`` options. In these files, symbols must be fully qualified but no ``require`` command is needed. Moreover, the rules do not need to preserve typing. On the other hand, right hand-side of rules must contain implicit arguments. It is advised to use the same set of rules previously used during indexing.
 
-* ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
+* ``--require <FILE.lp>`` requires and open ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
 
-* ``--db <FILE.db>`` tells lambdapi to search in <FILE.db> instead of ~/.LPSearch.db.
+* ``--db <FILE.db>`` tells lambdapi to search in ``<FILE.db>`` instead of ``~/.LPSearch.db``.
 
 websearch
 ---------
@@ -175,7 +175,7 @@ websearch
 
 * ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
 
-* ``--db <FILE.db>`` tells the server to use <FILE.db> instead of ~/.LPSearch.db.
+* ``--db <FILE.db>`` tells the server to use ``<FILE.db>`` instead of ``~/.LPSearch.db``.
 
 * ``--header <FILE.html>`` uses <FILE.html> as header of the search engine web page.
 

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -154,7 +154,7 @@ index
    rule cic.Term _ $x ↪ $x;
    rule cic.lift _ _ $x ↪ $x;
 
-* ``--db-search <FILE.db>`` tells lambdapi to index symbols and rules in ``<FILE.db>`` instead of ``~/.LPSearch.db``.
+* ``--db <FILE.db>`` tells lambdapi to index symbols and rules in ``<FILE.db>`` instead of ``~/.LPSearch.db``.
 
 
 search
@@ -164,7 +164,7 @@ search
 
 * ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
 
-* ``--db-search <FILE.db>`` tells lambdapi to search in <FILE.db> instead of ~/.LPSearch.db.
+* ``--db <FILE.db>`` tells lambdapi to search in <FILE.db> instead of ~/.LPSearch.db.
 
 websearch
 ---------
@@ -175,7 +175,7 @@ websearch
 
 * ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can use used for example to specify implicit arguments for symbols used in the queries.
 
-* ``--db-search <FILE.db>`` tells the server to use <FILE.db> instead of ~/.LPSearch.db.
+* ``--db <FILE.db>`` tells the server to use <FILE.db> instead of ~/.LPSearch.db.
 
 lsp
 -------

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -156,7 +156,6 @@ index
 
 * ``--db <FILE.db>`` tells lambdapi to index symbols and rules in ``<FILE.db>`` instead of ``~/.LPSearch.db``.
 
-
 search
 ---------
 

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -154,7 +154,7 @@ index
    rule cic.Term _ $x ↪ $x;
    rule cic.lift _ _ $x ↪ $x;
 
-* ``--db-search <FILE.db>`` exports the index of symbols and rules to ``<FILE.db>`` instead of the default ``~/.LPSearch.db``
+* ``--db-search <FILE.db>`` tells lambdapi to index symbols and rules in ``<FILE.db>`` instead of ``~/.LPSearch.db``.
 
 
 search
@@ -164,7 +164,7 @@ search
 
 * ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
 
-* ``--db-search <FILE.db>`` tells the search engine to look for the index in ``<FILE.db>``. Optional. Default is ``~/.LPSearch.db``
+* ``--db-search <FILE.db>`` tells lambdapi to search in <FILE.db> instead of ~/.LPSearch.db.
 
 websearch
 ---------
@@ -175,7 +175,7 @@ websearch
 
 * ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can use used for example to specify implicit arguments for symbols used in the queries.
 
-* ``--db-search <FILE.db>`` tells the server to look for the index in ``<FILE.db>``. Optional. Default is ``~/.LPSearch.db``
+* ``--db-search <FILE.db>`` tells the server to use <FILE.db> instead of ~/.LPSearch.db.
 
 lsp
 -------

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -143,7 +143,7 @@ Examples of libraries exported to Coq:
 index
 -----
 
-* ``--add`` tells lambdapi to not erase ``~/.LPSearch.db`` before adding new symbols and rules.
+* ``--add`` tells lambdapi to not erase the index before adding new symbols and rules.
 
 * ``--rules <LPSearch.lp>`` tells lambdapi to normalize terms using the rules given in the file ``<LPSearch.lp>`` before indexing. Several files can be specified by using several ``--rules`` options. In these files, symbols must be fully qualified but no ``require`` command is needed. Moreover, the rules do not need to preserve typing. On the other hand, right hand-side of rules must contain implicit arguments.
 
@@ -154,12 +154,17 @@ index
    rule cic.Term _ $x ↪ $x;
    rule cic.lift _ _ $x ↪ $x;
 
+* ``--db-search <FILE.db>`` exports the index of symbols and rules to ``<FILE.db>`` instead of the default ``~/.LPSearch.db``
+
+
 search
 ---------
 
 * ``--rules <LPSearch.lp>`` tells lambdapi to normalize terms in the query using the rules given in the file ``<LPSearch.lp>``. Several files can be specified by using several ``--rules`` options. In these files, symbols must be fully qualified but no ``require`` command is needed. Moreover, the rules do not need to preserve typing. On the other hand, right hand-side of rules must contain implicit arguments. It is advised to use the same set of rules previously used during indexing.
 
-* ``-- require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
+* ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can be used for example to specify implicit arguments for symbols used in the queries.
+
+* ``--db-search <FILE.db>`` tells the search engine to look for the index in ``<FILE.db>``. Optional. Default is ``~/.LPSearch.db``
 
 websearch
 ---------
@@ -168,7 +173,9 @@ websearch
 
 * ``--rules <LPSearch.lp>`` tells lambdapi to normalize terms in the queries using the rules given in the file ``<LPSearch.lp>``. Several files can be specified by using several ``--rules`` options. In these files, symbols must be fully qualified but no ``require`` command is needed. Moreover, the rules do not need to preserve typing. On the other hand, right hand-side of rules must contain implicit arguments. It is advised to use the same set of rules previously used during indexing.
 
-* ``-- require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can use used for example to specify implicit arguments for symbols used in the queries.
+* ``--require <FILE.lp>`` requires and open the file ``<FILE.lp>`` when starting the search engine. The file can use used for example to specify implicit arguments for symbols used in the queries.
+
+* ``--db-search <FILE.db>`` tells the server to look for the index in ``<FILE.db>``. Optional. Default is ``~/.LPSearch.db``
 
 lsp
 -------

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -33,11 +33,12 @@ let sig_state_of_require =
   the path wrapped in it or a default value if None*)
 let dbpath custom_dbpath =
   match custom_dbpath with
-  | None -> (
+  | None ->
+  begin
     match Sys.getenv_opt "HOME" with
-    | Some s -> s ^ "/.LPSearch.db"
+    | Some s -> Filename.concat s "/.LPSearch.db"
     | None -> ".LPSearch.db"
-  )
+  end
   | Some path -> path
 
 let search_cmd cfg rules require s custom_dbpath =

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -29,21 +29,24 @@ let sig_state_of_require =
     Core.Sig_state.of_sign
      (Compile.compile (Parsing.Parser.path_of_string req))
 
+(**[dbpath custom_dbpath] reads a string option [custom_dbpath] and returns
+  the path wrapped in it or a default value if None*)
+let dbpath custom_dbpath =
+  match custom_dbpath with
+  | None -> (
+    match Sys.getenv_opt "HOME" with
+    | Some s -> s ^ "/.LPSearch.db"
+    | None -> ".LPSearch.db"
+  )
+  | Some path -> path
+
 let search_cmd cfg rules require s custom_dbpath =
  Config.init cfg;
  let run () =
   Tool.Indexing.load_rewriting_rules rules ;
   let ss = sig_state_of_require require in
-  let dbpath =
-    match custom_dbpath with
-    | None -> (
-      match Sys.getenv_opt "HOME" with
-      | Some s -> s ^ "/.LPSearch.db"
-      | None -> ".LPSearch.db"
-    )
-    | Some path -> path in
   out Format.std_formatter "%s@."
-   (Tool.Indexing.search_cmd_txt ss s dbpath) in
+   (Tool.Indexing.search_cmd_txt ss s (dbpath custom_dbpath)) in
  Error.handle_exceptions run
 
 let websearch_cmd cfg rules port require custom_dbpath =
@@ -51,15 +54,7 @@ let websearch_cmd cfg rules port require custom_dbpath =
  let run () =
   Tool.Indexing.load_rewriting_rules rules ;
   let ss = sig_state_of_require require in
-  let dbpath =
-    match custom_dbpath with
-    | None -> (
-      match Sys.getenv_opt "HOME" with
-      | Some s -> s ^ "/.LPSearch.db"
-      | None -> ".LPSearch.db"
-    )
-    | Some path -> path in
-  Tool.Websearch.start ss ~port dbpath () in
+  Tool.Websearch.start ss ~port (dbpath custom_dbpath) () in
  Error.handle_exceptions run
 
 let index_cmd cfg add_only rules files custom_dbpath=
@@ -75,15 +70,7 @@ let index_cmd cfg add_only rules files custom_dbpath=
    Tool.Indexing.load_rewriting_rules rules;
    Tool.Indexing.index_sign (no_wrn Compile.compile_file file) in
   List.iter handle files;
-  let dbpath =
-    match custom_dbpath with
-    | None -> (
-      match Sys.getenv_opt "HOME" with
-      | Some s -> s ^ "/.LPSearch.db"
-      | None -> ".LPSearch.db"
-    )
-    | Some path -> path in
-  Tool.Indexing.dump dbpath () in
+  Tool.Indexing.dump (dbpath custom_dbpath) () in
  Error.handle_exceptions run
 
 end

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -33,12 +33,7 @@ let sig_state_of_require =
   the path wrapped in it or a default value if None*)
 let dbpath custom_dbpath =
   match custom_dbpath with
-  | None ->
-  begin
-    match Sys.getenv_opt "HOME" with
-    | Some s -> Filename.concat s "/.LPSearch.db"
-    | None -> ".LPSearch.db"
-  end
+  | None -> Common.Path.default_dbpath
   | Some path -> path
 
 let search_cmd cfg rules require s custom_dbpath =

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -442,7 +442,7 @@ let require_arg : string option CLT.t =
 let custom_db_path : string option CLT.t =
   let doc =
     "Path to the search DB file." in
-  Arg.(value & opt (some string) None & info ["search-db"] ~docv:"PATH" ~doc)
+  Arg.(value & opt (some string) None & info ["db"] ~docv:"PATH" ~doc)
 
 let index_cmd =
  let doc = "Index the given files." in

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -100,7 +100,7 @@ let index_cmd cfg add_only rules files dbpath_opt =
    Tool.Indexing.index_sign (no_wrn Compile.compile_file file) in
   List.iter handle files;
   let dbpath = Option.get Path.default_dbpath dbpath_opt in
-  Tool.Indexing.dump dbpath () in
+  Tool.Indexing.dump ~dbpath () in
  Error.handle_exceptions run
 
 end

--- a/src/common/path.ml
+++ b/src/common/path.ml
@@ -25,7 +25,7 @@ module Map = Map.Make(Path)
 (** [ghost s] creates a module path that cannot be entered by a user. *)
 let ghost : string -> Path.t = fun s -> [""; s]
 
-(** [default_dbpath] Returns the default path of the index. *)
+(** [default_dbpath] returns the default path of the index. *)
 let default_dbpath : string =
   match Sys.getenv_opt "HOME" with
     | Some s -> Filename.concat s ".LPSearch.db"

--- a/src/common/path.ml
+++ b/src/common/path.ml
@@ -24,3 +24,9 @@ module Map = Map.Make(Path)
 
 (** [ghost s] creates a module path that cannot be entered by a user. *)
 let ghost : string -> Path.t = fun s -> [""; s]
+
+(** [default_dbpath] Returns the default path of the index. *)
+let default_dbpath : string =
+  match Sys.getenv_opt "HOME" with
+    | Some s -> Filename.concat s ".LPSearch.db"
+    | None -> ".LPSearch.db"

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -160,7 +160,8 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
   let ctxt = Env.to_ctxt env in
   let p = new_problem() in
   match elt with
-  | P_query_search s -> return string (Tool.Indexing.search_cmd_txt ss s)
+  | P_query_search s ->
+    return string (Tool.Indexing.search_cmd_txt ss s "~/.LPSearch.db")
   | P_query_debug(_,_)
   | P_query_verbose(_)
   | P_query_flag(_,_)

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -161,7 +161,8 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
   let p = new_problem() in
   match elt with
   | P_query_search s ->
-    return string (Tool.Indexing.search_cmd_txt ss s "~/.LPSearch.db")
+    return string (Tool.Indexing.search_cmd_txt ss s
+      Common.Path.default_dbpath)
   | P_query_debug(_,_)
   | P_query_verbose(_)
   | P_query_flag(_,_)

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -161,8 +161,8 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
   let p = new_problem() in
   match elt with
   | P_query_search s ->
-    return string (Tool.Indexing.search_cmd_txt ss s
-      Common.Path.default_dbpath)
+      let dbpath = Path.default_dbpath in
+      return string (Tool.Indexing.search_cmd_txt ss s ~dbpath)
   | P_query_debug(_,_)
   | P_query_verbose(_)
   | P_query_flag(_,_)

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -304,7 +304,7 @@ module DB = struct
 
  (* disk persistence *)
 
- let the_dbpath : string ref = ref ""
+ let the_dbpath : string ref = ref Path.default_dbpath
 
  let rwpaths = ref []
 

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -338,9 +338,9 @@ module DB = struct
   set_of_list ~generalize k
    (Index.search ~generalize (Lazy.force !db) k)
 
- let dump custom_dbpath () =
-  the_dbpath := custom_dbpath;
-  Index.dump_to ~filename:!the_dbpath (Lazy.force !db)
+ let dump ~dbpath () =
+  the_dbpath := dbpath;
+  Index.dump_to ~filename:dbpath (Lazy.force !db)
 
  let locate_name name =
   let k = Term.mk_Wild (* dummy, unused *) in

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -21,7 +21,7 @@ let name_of_sym s = (s.sym_path, s.sym_name)
      e.g. "pi x : T. x + x"  has as subterm "$x + $x"
 *)
 
-module Pure = struct
+module Index = struct
 
 type 'a index =
  | Leaf of 'a list
@@ -304,28 +304,28 @@ module DB = struct
 
  (* disk persistence *)
 
- let dbpath : string ref = ref ""
+ let the_dbpath : string ref = ref ""
 
  let rwpaths = ref []
 
  let restore_from_disk () =
-  try Pure.restore_from ~filename:!dbpath
+  try Index.restore_from ~filename:!the_dbpath
   with Sys_error msg ->
      Common.Error.wrn None "%s.\n\
       Type \"lambdapi index --help\" to learn how to create the index." msg ;
-     Pure.empty
+     Index.empty
 
- let db : (item * position list) Pure.db Lazy.t ref =
+ let db : (item * position list) Index.db Lazy.t ref =
    ref (lazy (restore_from_disk ()))
 
- let empty () = db := lazy Pure.empty
+ let empty () = db := lazy Index.empty
 
  let insert k v =
-   let db' = Pure.insert (Lazy.force !db) k v in
+   let db' = Index.insert (Lazy.force !db) k v in
    db := lazy db'
 
  let insert_name k v =
-   let db' = Pure.insert_name (Lazy.force !db) k v in
+   let db' = Index.insert_name (Lazy.force !db) k v in
    db := lazy db'
 
  let set_of_list ~generalize k l =
@@ -336,16 +336,16 @@ module DB = struct
 
  let search ~generalize k =
   set_of_list ~generalize k
-   (Pure.search ~generalize (Lazy.force !db) k)
+   (Index.search ~generalize (Lazy.force !db) k)
 
- let dump custom_db_path () =
-  dbpath := custom_db_path;
-  Pure.dump_to ~filename:!dbpath (Lazy.force !db)
+ let dump custom_dbpath () =
+  the_dbpath := custom_dbpath;
+  Index.dump_to ~filename:!the_dbpath (Lazy.force !db)
 
  let locate_name name =
   let k = Term.mk_Wild (* dummy, unused *) in
   set_of_list ~generalize:false k
-   (Pure.locate_name (Lazy.force !db) name)
+   (Index.locate_name (Lazy.force !db) name)
 
 end
 
@@ -675,14 +675,14 @@ module UserLevelQueries = struct
    | exn ->
       fail (Format.asprintf "Error: %s@." (Printexc.to_string exn))
 
- let search_cmd_html ss ~from ~how_many s custom_db_path =
-  dbpath := custom_db_path;
+ let search_cmd_html ss ~from ~how_many s ~dbpath =
+  the_dbpath := dbpath;
   search_cmd_gen ss ~from ~how_many
    ~fail:(fun x -> "<font color=\"red\">" ^ x ^ "</font>")
    ~pp_results:(html_of_results_list from) s
 
- let search_cmd_txt ss s custom_db_path =
-  dbpath := custom_db_path;
+ let search_cmd_txt ss s ~dbpath =
+  the_dbpath := dbpath;
   search_cmd_gen ss ~from:0 ~how_many:999999
    ~fail:(fun x -> Common.Error.fatal_no_pos "%s" x)
    ~pp_results:pp_results_list s

--- a/src/tool/indexing.mli
+++ b/src/tool/indexing.mli
@@ -1,13 +1,15 @@
+open Core
+
 (* indexing *)
 val empty : unit -> unit
 val load_rewriting_rules: string list -> unit
-val index_sign : Core.Sign.t -> unit
+val index_sign : Sign.t -> unit
 val dump : string -> unit -> unit
 
 (* search command used by cli *)
-val search_cmd_txt: Core.Sig_state.sig_state -> string -> string -> string
+val search_cmd_txt: Sig_state.sig_state -> string -> dbpath:string -> string
 
 (* search command used by websearch *)
 val search_cmd_html:
- Core.Sig_state.sig_state
-    -> from:int -> how_many:int -> string -> string -> string
+ Sig_state.sig_state
+  -> from:int -> how_many:int -> string -> dbpath:string -> string

--- a/src/tool/indexing.mli
+++ b/src/tool/indexing.mli
@@ -2,11 +2,12 @@
 val empty : unit -> unit
 val load_rewriting_rules: string list -> unit
 val index_sign : Core.Sign.t -> unit
-val dump : unit -> unit
+val dump : string -> unit -> unit
 
 (* search command used by cli *)
-val search_cmd_txt: Core.Sig_state.sig_state -> string -> string
+val search_cmd_txt: Core.Sig_state.sig_state -> string -> string -> string
 
 (* search command used by websearch *)
 val search_cmd_html:
- Core.Sig_state.sig_state -> from:int -> how_many:int -> string -> string
+ Core.Sig_state.sig_state
+    -> from:int -> how_many:int -> string -> string -> string

--- a/src/tool/indexing.mli
+++ b/src/tool/indexing.mli
@@ -4,7 +4,7 @@ open Core
 val empty : unit -> unit
 val load_rewriting_rules: string list -> unit
 val index_sign : Sign.t -> unit
-val dump : string -> unit -> unit
+val dump : dbpath:string -> unit -> unit
 
 (* search command used by cli *)
 val search_cmd_txt: Sig_state.sig_state -> string -> dbpath:string -> string

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -1,5 +1,4 @@
 
-
 let show_form ~from ?(message="") ?output request =
   <html>
   <body>
@@ -41,7 +40,7 @@ let show_form ~from ?(message="") ?output request =
   </body>
   </html>
 
-let start header ss ~port custom_dbpath () =
+let start ~header ss ~port ~dbpath () =
   (*Common.Logger.set_debug true "e" ;*)
   let interface = "0.0.0.0" in
   Dream.run ~port ~interface
@@ -51,7 +50,7 @@ let start header ss ~port custom_dbpath () =
 
     Dream.get  "/"
       (fun request ->
-        Dream.html (header ^ (show_form ~from:0 request)));
+        Dream.html (header ^ show_form ~from:0 request));
 
     Dream.post "/"
       (fun request ->
@@ -62,7 +61,7 @@ let start header ss ~port custom_dbpath () =
           Dream.log "from2 = %d" from ;
           let output =
             Indexing.search_cmd_html ss ~from ~how_many:100
-            message custom_dbpath in
+            message ~dbpath in
           Dream.html (show_form ~from ~message ~output request)
           (*Dream.stream (show_form_stream ~message ~output request)*)
         | _ ->

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -79,7 +79,7 @@ let show_form ~from ?(message="") ?output request =
   </body>
   </html>
 
-let start ss ~port () =
+let start ss ~port custom_dbpath () =
   (*Common.Logger.set_debug true "e" ;*)
   Dream.run ~port
   @@ Dream.logger
@@ -98,7 +98,8 @@ let start ss ~port () =
           let from = int_of_string from in (* XXX CSC exception XXX *)
           Dream.log "from2 = %d" from ;
           let output =
-            Indexing.search_cmd_html ss ~from ~how_many:100 message in
+            Indexing.search_cmd_html ss ~from ~how_many:100
+            message custom_dbpath in
           Dream.html (show_form ~from ~message ~output request)
           (*Dream.stream (show_form_stream ~message ~output request)*)
         | _ ->

--- a/src/tool/websearch.mli
+++ b/src/tool/websearch.mli
@@ -1,2 +1,2 @@
-val start : string -> Core.Sig_state.sig_state
-    -> port:int -> string -> unit -> unit
+val start : header:string -> Core.Sig_state.sig_state
+    -> port:int -> dbpath:string -> unit -> unit

--- a/src/tool/websearch.mli
+++ b/src/tool/websearch.mli
@@ -1,1 +1,1 @@
-val start : Core.Sig_state.sig_state -> port:int -> unit -> unit
+val start : Core.Sig_state.sig_state -> port:int -> string -> unit -> unit


### PR DESCRIPTION
This PR aims at making it possible to specify a different file to store the index DB (instead of `~/.LPsearch.db`)
Specifically, it would be possible to create an index and store it in a specific file with `--db` flag : 
`lambdapi index --db /path/to/index.db /path/to/lp_file.lp`

Or launch the webserver or the search engine with `--db` flag :
`lambdapi websearch --db /path/to/index.db` or
`lambdapi search --db /path/to/index.db`