### PR TITLE
test dream versions (do not merge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-version: [4.12.1, 4.11.2, 4.10.2, 4.09.1] #5.3.0, 5.2.1, 5.1.1, 5.0.0, 4.14.2, 4.13.1
-        dream-pure: [1.0.0~alpha1 1.0.0~alpha2]
+        dream-pure-version: [1.0.0~alpha1 1.0.0~alpha2]
         dream-httpaf-version: [1.0.0~alpha1 1.0.0~alpha2 1.0.0~alpha3 1.0.0~alpha4]
         dream-version: [1.0.0~alpha1 1.0.0~alpha2 1.0.0~alpha3 1.0.0~alpha4 1.0.0~alpha5 1.0.0~alpha6 1.0.0~alpha7 1.0.0~alpha8]
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-version }}
       - name: install dream ...
         run: |
-          opam install dream.${{ matrix.dream-version }} dream-pure.${{ matrix.dream-pure-version }} dream-httpaf.${{ matrix.dream-httpaf-version }}
+          opam install dream-pure.${{ matrix.dream-pure-version }} dream-httpaf.${{ matrix.dream-httpaf-version }} dream.${{ matrix.dream-version }}
       - name: install lambdapi dependencies ...
         run: |
           opam pin add -n -k path lambdapi .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,73 +10,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: [5.3.0, 5.2.1, 5.1.1, 5.0.0, 4.14.2, 4.13.1, 4.12.1, 4.11.2, 4.10.2, 4.09.1]
+        ocaml-version: [4.12.1, 4.11.2, 4.10.2, 4.09.1] #5.3.0, 5.2.1, 5.1.1, 5.0.0, 4.14.2, 4.13.1
+        dream-pure: [1.0.0~alpha1 1.0.0~alpha2]
+        dream-httpaf-version: [1.0.0~alpha1 1.0.0~alpha2 1.0.0~alpha3 1.0.0~alpha4]
+        dream-version: [1.0.0~alpha1 1.0.0~alpha2 1.0.0~alpha3 1.0.0~alpha4 1.0.0~alpha5 1.0.0~alpha6 1.0.0~alpha7 1.0.0~alpha8]
     runs-on: ubuntu-latest
     steps:
-      - name: checking out lambdapi repo ...
+      - name: check out lambdapi ...
         uses: actions/checkout@v4
-      # - name: recovering cached opam files ...
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.opam
-      #     key: ${{ runner.os }}-ocaml-${{ matrix.ocaml-version }}
-      - name: setting up opam ...
+      - name: set up opam ...
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
-      - name: installing dependencies ...
+      - name: install dream ...
         run: |
-          opam update
-          opam upgrade
+          opam install dream.${{ matrix.dream-version }} dream-pure.${{ matrix.dream-pure-version }} dream-httpaf.${{ matrix.dream-httpaf-version }}
+      - name: install lambdapi dependencies ...
+        run: |
           opam pin add -n -k path lambdapi .
           opam install --deps-only -d -t lambdapi
-      - name: running tests ...
+      - name: compile lambdapi ...
         run: |
-          make sanity_check
           eval $(opam env)
-          #why3 config detect
-          make tests
-  vscode:
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    steps:
-      - name: checking out lambdapi repo ...
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-      - name: generate-vscode-extension
-        run: |
-          npm install -g @types/vscode
-          npm install -g @vscode/vsce 
-          make build-vscode-extension
-          make publish-vscode-extension
-        env:
-          PAT: ${{ secrets.VSCODE_PAT }}
-      - name: upload vscode extension
-        uses: actions/upload-artifact@v4
-        with: 
-          name: assets-for-download
-          path: editors/vscode/extensionFolder
-  # lint-fmt:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout tree
-  #       uses: actions/checkout@v4
-  #     - name: Set-up OCaml
-  #       uses: ocaml/setup-ocaml@v3
-  #       with:
-  #         ocaml-compiler: 5
-  #     - uses: ocaml/setup-ocaml/lint-fmt@v3
-  # lint-opam:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout tree
-  #       uses: actions/checkout@v4
-  #     - name: Set-up OCaml
-  #       uses: ocaml/setup-ocaml@v3
-  #       with:
-  #         ocaml-compiler: 5
-  #     - uses: ocaml/setup-ocaml/lint-opam@v3
+          dune build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-version: [4.12.1, 4.11.2, 4.10.2, 4.09.1] #5.3.0, 5.2.1, 5.1.1, 5.0.0, 4.14.2, 4.13.1
-        dream-pure-version: [1.0.0~alpha1 1.0.0~alpha2]
-        dream-httpaf-version: [1.0.0~alpha1 1.0.0~alpha2 1.0.0~alpha3 1.0.0~alpha4]
-        dream-version: [1.0.0~alpha1 1.0.0~alpha2 1.0.0~alpha3 1.0.0~alpha4 1.0.0~alpha5 1.0.0~alpha6 1.0.0~alpha7 1.0.0~alpha8]
+        dream-pure-version: [1.0.0~alpha1, 1.0.0~alpha2]
+        dream-httpaf-version: [1.0.0~alpha1, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha4]
+        dream-version: [1.0.0~alpha1, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha4, 1.0.0~alpha5, 1.0.0~alpha6, 1.0.0~alpha7, 1.0.0~alpha8]
     runs-on: ubuntu-latest
     steps:
       - name: check out lambdapi ...

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -36,7 +36,6 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
   "lwt_ppx" {>= "1.0.0"}
-  "dream" {>= "1.0.0~alpha3"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Following https://github.com/aantron/dream/issues/390, here are the versions of ocaml, dream-pure, dream-httpaf, dream that work on 29/04/25 (https://github.com/Deducteam/lambdapi/actions/runs/14729052162/job/41338640657):
```
4.09.1, 1.0.0~alpha1, 1.0.0~alpha1, 1.0.0~alpha3
4.09.1, 1.0.0~alpha2, 1.0.0~alpha1, 1.0.0~alpha4
4.09.1, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha5
4.09.1, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha6
4.09.1, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha5
4.09.1, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha6

4.10.2, 1.0.0~alpha2, 1.0.0~alpha1, 1.0.0~alpha4
4.10.2, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha5
4.10.2, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha6
4.10.2, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha5
4.10.2, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha6

4.11.2, 1.0.0~alpha1, 1.0.0~alpha1, 1.0.0~alpha3
4.11.2, 1.0.0~alpha2, 1.0.0~alpha1, 1.0.0~alpha4
4.11.2, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha5
4.11.2, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha6
4.11.2, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha6

4.12.1, 1.0.0~alpha1, 1.0.0~alpha1, 1.0.0~alpha3
4.12.1, 1.0.0~alpha2, 1.0.0~alpha1, 1.0.0~alpha4
4.12.1, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha5
4.12.1, 1.0.0~alpha2, 1.0.0~alpha2, 1.0.0~alpha6
4.12.1, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha5
4.12.1, 1.0.0~alpha2, 1.0.0~alpha3, 1.0.0~alpha6
```