### PR TITLE
fix set tactic

### DIFF
--- a/tests/OK/1247.lp
+++ b/tests/OK/1247.lp
@@ -1,0 +1,30 @@
+symbol Prop: TYPE;
+symbol π: Prop → TYPE;
+symbol Set: TYPE;
+constant symbol τ: Set → TYPE;
+builtin "T" ≔ τ;
+builtin "P" ≔ π;
+
+symbol = [a:Set] : τ a → τ a → Prop;
+
+notation = infix 10;
+
+constant symbol eq_refl [a:Set] (x:τ a) : π (x = x);
+constant symbol ind_eq [a:Set] [x y:τ a] : π (x = y) → Π p, π (p y) → π (p x);
+
+builtin "eq"    ≔ =;
+builtin "refl"  ≔ eq_refl;
+builtin "eqind" ≔ ind_eq;
+
+symbol S: Set;
+symbol a: τ S;
+symbol cset [T]: (τ T → Prop) → τ S;
+
+symbol th: π (a = a) ≔
+begin
+  flag "print_implicits" on;
+  flag "print_domains" on;
+  set E ≔ @cset S (λ x, @= S x x);
+  have h:π (E = `cset x:τ S, x = x) { reflexivity };
+  reflexivity
+end;

--- a/tests/OK/262_pair_ex_1.lp
+++ b/tests/OK/262_pair_ex_1.lp
@@ -3,7 +3,7 @@ symbol Pair : TYPE;
 
 symbol pair : A → A → Pair;
 
-// Use example: public [pair] reduces to private [_pair]
+// Use example: public [pair] reduces to protected [_pair]
 protected symbol _pair : A → Pair;
 
 rule pair $X _ ↪ _pair $X;

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -52,7 +52,7 @@ do
         # "as"
         729);;
         # "notation"
-        xor|Set|quant*|Prop|prefix|parametricCoercions|opaque|nat_id*|michael|max-suc-alg|lpparse|861|infix|infer|indrec|implicitArgs[34]|group|cr_qu|cp*|coercions|plus_ac|693|693_assume|679|665|655|655b|649_fo_27|595_and_elim|584_c_slow|579_or_elim_long|579_long_no_duplicate|359|328|245|245b|244|1026|991|706|1101|1190b|1190c|1120);;
+        xor|Set|quant*|Prop|prefix|parametricCoercions|opaque|nat_id*|michael|max-suc-alg|lpparse|861|infix|infer|indrec|implicitArgs[34]|group|cr_qu|cp*|coercions|plus_ac|693|693_assume|679|665|655|655b|649_fo_27|595_and_elim|584_c_slow|579_or_elim_long|579_long_no_duplicate|359|328|245|245b|244|1026|991|706|1101|1190b|1190c|1120|1247);;
         # "quantifier"
         683|650|573|565|430);;
         # nested module name


### PR DESCRIPTION
The new metavariables generated by the typing of the term argument of the set tactic are 1) not resolved, and 2) forgotten! This PR fixes this issue.

fix #1247