### PR TITLE
pipeline: use version 23.11 of Nodejs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 'v23.11.0'
       - name: generate-vscode-extension
         run: |
           npm install -g @types/vscode


### PR DESCRIPTION
This PR fixes the pipeline (specifically the `vscode` job by using version `v23.11.0` of `Nodejs` instead of `latest` because it breaks the code of `@types/vsce` as discussed in issue #1252 

In the future, a Job for every combination of dependencies (`Nodejs, vsce, Vscode`, ...) will be run to check compatibilities. 