### PR TITLE
Run the Vscode job with different Nodejs, vsce and @types/vscode version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,8 @@ jobs:
         types_vscode-version: [\@1.99.0, \@1.99.1, '' ]
         vscode_vsce-version: [\@3.3.3-2,  \@3.3.3-3, '' ]
     runs-on: ubuntu-latest
+    env:
+        latestVersions: ${{ matrix.types_vscode-version == '' && matrix.vscode_vsce-version == '' &&  matrix.node-version == 'latest' }}
     steps:
       - name: checking out lambdapi repo ...
         uses: actions/checkout@v4
@@ -61,18 +63,19 @@ jobs:
           make build-vscode-extension
 
       - name: publish-vscode-extension
-        if: ${{ matrix.types_vscode-version == '' && matrix.vscode_vsce-version == '' &&  matrix.node-version == 'v23.11.0' }} 
+        if: ${{ env.latestVersions }}
         run:
           make publish-vscode-extension
         env:
           PAT: ${{ secrets.VSCODE_PAT }}
           
       - name: upload vscode extension
-        if: ${{ matrix.types_vscode-version == '' && matrix.vscode_vsce-version == '' &&  matrix.node-version == 'v23.11.0' }} 
+        if: ${{ env.latestVersions }} 
         uses: actions/upload-artifact@v4
         with: 
           name: assets-for-download
           path: editors/vscode/extensionFolder
+          
   # lint-fmt:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,10 @@ jobs:
   vscode:
     strategy:
       fail-fast: false
+      matrix:
+        node-version: [latest, v23.11.0]
+        types_vscode-version: [\@1.99.0, \@1.99.1, '' ]
+        vscode_vsce-version: [\@3.3.3-2,  \@3.3.3-3, '' ]
     runs-on: ubuntu-latest
     steps:
       - name: checking out lambdapi repo ...
@@ -46,16 +50,25 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'v23.11.0'
-      - name: generate-vscode-extension
+          node-version: ${{ matrix.node-version }}
+      - name: install-dependencies
         run: |
-          npm install -g @types/vscode
-          npm install -g @vscode/vsce 
+          npm install -g @types/vscode${{ matrix.types_vscode-version }}
+          npm install -g @vscode/vsce${{ matrix.vscode_vsce-version }}
+
+      - name: generate-vscode-extension
+        run:
           make build-vscode-extension
+
+      - name: publish-vscode-extension
+        if: ${{ matrix.types_vscode-version == '' && matrix.vscode_vsce-version == '' &&  matrix.node-version == 'v23.11.0' }} 
+        run:
           make publish-vscode-extension
         env:
           PAT: ${{ secrets.VSCODE_PAT }}
+          
       - name: upload vscode extension
+        if: ${{ matrix.types_vscode-version == '' && matrix.vscode_vsce-version == '' &&  matrix.node-version == 'v23.11.0' }} 
         uses: actions/upload-artifact@v4
         with: 
           name: assets-for-download


### PR DESCRIPTION
This PR, modifies the github pipiline to build the VScode extension with different versions of Nodejs, vsce and @types/vscode.

THIS IS A DRAFT.

Before merging it should also :
- refactor main.yml to resuse the same condition instead of rewriting it twice
- Decide what versions we want to test the pipeline with
-  trigger the jobs (lambdapi/Vscode) only if corresponding files have been changed