### PR TITLE
fix printing of bound variable names

### DIFF
--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -57,10 +57,10 @@ module D = struct
     out ppf "["; iter f m; out ppf "]"
 
   let strmap : 'a pp -> 'a StrMap.t pp = fun elt ->
-    map StrMap.iter string ", " elt "; "
+    map StrMap.iter string "," elt ";"
 
   let intmap : 'a pp -> 'a IntMap.t pp = fun elt ->
-    map IntMap.iter int ", " elt "; "
+    map IntMap.iter int "," elt ";"
 
   let iter ?sep:(sep = Format.pp_print_cut) iter elt ppf v =
     let is_first = ref true in

--- a/src/common/dune
+++ b/src/common/dune
@@ -2,5 +2,5 @@
  (name common)
  (public_name lambdapi.common)
  (modules :standard)
- (libraries camlp-streams timed lambdapi.lplib)
+ (libraries camlp-streams str timed lambdapi.lplib)
  (flags -w +3))

--- a/src/common/name.ml
+++ b/src/common/name.ml
@@ -1,0 +1,62 @@
+open Lplib open Base open Extra
+open Debug
+
+(** If [s] ends with some digits, then [root_and_index s = (root,i)] such that
+    [i] is the biggest integer such that [s = root^string_of_int
+    i]. Otherwise, [root_and_index s = (s,-1)].*)
+let root_and_index =
+  let re = Str.regexp "[^0-9][0-9]+$" in
+  fun s ->
+  (*print_endline("root_and_index "^s);*)
+  let n = String.length s in
+  try let i = 1 + Str.search_backward re s (n-1) in
+      (* skip leading zeros *)
+      let i =
+        if s.[i] <> '0' then i
+        else
+          begin
+            let j = ref (i+1) in
+            while !j < n && s.[!j] = '0' do incr j done;
+            !j - 1
+          end
+      in
+      (*print_endline("search_backward = "^string_of_int i);*)
+      String.sub s 0 i, int_of_string(String.sub s i (n-i))
+  with Not_found -> s, -1
+
+(* unit tests *)
+let _ =
+  assert (root_and_index "x" = ("x",-1));
+  assert (root_and_index "x0" = ("x",0));
+  assert (root_and_index "xy0" = ("xy",0));
+  assert (root_and_index "x0y" = ("x0y",-1));
+  assert (root_and_index "x00" = ("x0",0));
+  assert (root_and_index "x000" = ("x00",0))
+
+(*let strings (idmap:int StrMap.t) : StrSet.t =
+  StrMap.fold (fun p i set -> if i < 0 then p else p^string_of_int i)
+    idmap StrSet.empty*)
+
+let add_name s idmap = let r,i = root_and_index s in StrMap.add r i idmap
+
+(** Assume that [root_and_index p = (r,i)]. If [i<0] then [get_safe_prefix p
+    idmap] returns [p,StrMap.add p (-1) idmap] and, for all non-negative
+    integer [k], [StrSet.mem (p^string_of_int k) (strings
+    idmap')=false]. Otherwise, [get_safe_prefix p idmap] returns
+    [r^string_of_int k,StrMap.add r k idmap], where [k] is greater than or
+    equal to [i] and 1 + the index of [r] in [idmap]. *)
+let get_safe_prefix (s:string) (idmap: int StrMap.t): string * int StrMap.t =
+  let r,i = root_and_index s in
+  match StrMap.find_opt r idmap with
+  | None -> s, StrMap.add r i idmap
+  | Some j -> let k = max i j + 1 in r^string_of_int k, StrMap.add r k idmap
+
+(* unit tests *)
+let _ =
+  let idmap = StrMap.(add "x" 1 (add "x0" 0 empty)) in
+  let test s1 s2 = assert (fst (get_safe_prefix s1 idmap) = s2) in
+  test "y" "y";
+  test "x" "x2";
+  test "x0" "x2";
+  test "x00" "x01";
+  test "xy" "xy"

--- a/src/core/ctxt.ml
+++ b/src/core/ctxt.ml
@@ -3,6 +3,7 @@
 open Term
 open Lplib open Extra
 open Timed
+open Common open Name
 
 (** [type_of x ctx] returns the type of [x] in the context [ctx] when it
     appears in it, and

--- a/src/core/env.ml
+++ b/src/core/env.ml
@@ -2,7 +2,7 @@
 
 open Lplib open Base
 open Term
-open Common open Extra
+open Common open Extra open Name
 open Print
 
 (** Type of an environment, used in scoping to associate names to

--- a/src/handle/inductive.ml
+++ b/src/handle/inductive.ml
@@ -11,7 +11,7 @@
 
 open Lplib
 open Timed
-open Common open Pos open Error
+open Common open Pos open Error open Name
 open Core open Term open Print
 open Parsing open Syntax
 

--- a/src/handle/proof.ml
+++ b/src/handle/proof.ml
@@ -127,7 +127,7 @@ let goals : proof_state pp = fun ppf ps ->
   | g::gs ->
       let goal ppf i g = out ppf "%d. %a@," (i+1) Goal.pp_no_hyp g in
       let goals ppf = List.iteri (goal ppf) in
-      out ppf "@[<v>%a%a@]" Goal.pp g goals gs
+      out ppf "@[<v>%a@.%a@]" Goal.pp g goals gs
 
 (** [remove_solved_goals ps] removes from the proof state [ps] the typing
    goals that are solved. *)

--- a/src/lplib/base.ml
+++ b/src/lplib/base.ml
@@ -10,6 +10,7 @@ type 'a outfmt = ('a, Format.formatter, unit) format
 type ('a, 'b) koutfmt = ('a, Format.formatter, unit, unit, unit, 'b) format6
 
 let out = Format.fprintf
+let std = Format.std_formatter
 
 let (++) (p1: 'a pp) (p2: 'b pp) : ('a * 'b) pp = fun ppf (arg1, arg2) ->
   out ppf "%a%a" p1 arg1 p2 arg2

--- a/src/lplib/extra.ml
+++ b/src/lplib/extra.ml
@@ -10,68 +10,6 @@ module StrMap = Map.Make (String)
 (** Functional sets of strings. *)
 module StrSet = Set.Make (String)
 
-(** If [s] ends by a sequence of digits with no useless leading zeros then
-    [root_and_index s = (root,i)] such that [i] is the biggest integer such
-    that [s = root^string_of_int i]. Otherwise, [root_and_index s = (s,-1)].*)
-let root_and_index =
-  let re = Str.regexp "[^0-9][0-9]+$" in
-  fun s ->
-  (*print_endline("root_and_index "^s);*)
-  let n = String.length s in
-  try let i = 1 + Str.search_backward re s (n-1) in
-      (* skip leading zeros *)
-      let i =
-        if s.[i] <> '0' then i
-        else
-          begin
-            let j = ref (i+1) in
-            while !j < n && s.[!j] = '0' do incr j done;
-            !j - 1
-          end
-      in
-      (*print_endline("search_backward = "^string_of_int i);*)
-      String.sub s 0 i, int_of_string(String.sub s i (n-i))
-  with Not_found -> s, -1
-
-(* unit tests *)
-let _ =
-  assert (root_and_index "x" = ("x",-1));
-  assert (root_and_index "x0" = ("x",0));
-  assert (root_and_index "xy0" = ("xy",0));
-  assert (root_and_index "x0y" = ("x0y",-1));
-  assert (root_and_index "x00" = ("x0",0));
-  assert (root_and_index "x000" = ("x00",0))
-
-(*let strings (idmap:int StrMap.t) : StrSet.t =
-  StrMap.fold (fun p i set -> if i < 0 then p else p^string_of_int i)
-    idmap StrSet.empty*)
-
-let add_name s idmap = let r,i = root_and_index s in StrMap.add r i idmap
-
-(** Assume that [root_and_index p = (r,i)]. If [i<0] then [get_safe_prefix p
-    idmap] returns [p,StrMap.add p (-1) idmap] and, for all non-negative
-    integer [k], [StrSet.mem (p^string_of_int k) (strings
-    idmap')=false]. Otherwise, [get_safe_prefix p idmap] returns
-    [r^string_of_int k,StrMap.add r k idmap], where [k] is greater than or
-    equal to [i] and 1 + the index of [r] in [idmap]. *)
-let get_safe_prefix (s:string) (idmap: int StrMap.t): string * int StrMap.t =
-  (*print_endline("get_safe_prefix "^s^" in");
-    StrSet.iter print_endline idmap;*)
-  let r,i = root_and_index s in
-  match StrMap.find_opt r idmap with
-  | None -> s, StrMap.add r i idmap
-  | Some j -> let k = max i j + 1 in r^string_of_int k, StrMap.add r k idmap
-
-(* unit tests *)
-let _ =
-  let idmap = StrMap.(add "x" 1 (add "x0" 0 empty)) in
-  let test s1 s2 = assert (fst (get_safe_prefix s1 idmap) = s2) in
-  test "y" "y";
-  test "x" "x2";
-  test "x0" "x2";
-  test "x00" "x01";
-  test "xy" "xy"
-
 (** [time f x] times the application of [f] to [x], and returns the evaluation
     time in seconds together with the result of the application. *)
 let time : ('a -> 'b) -> 'a -> float * 'b =


### PR DESCRIPTION
Printing functions were not using distinct bound variable names. This PR hopefully solves this problem. The problem was mainly that the idmap argument was not properly passed in recursive calls.

Also get_safe_prefix and related functions are moved from lplib/extra.ml to common/name.ml.

