### PR TITLE
fix remove tactic when there are let's

### DIFF
--- a/src/core/libTerm.ml
+++ b/src/core/libTerm.ml
@@ -151,6 +151,8 @@ let rec codom_binder : int -> term -> binder = fun n t ->
   match unfold t with
   | Prod(_,b) ->
       if n <= 0 then b else codom_binder (n-1) (subst b mk_Kind)
+  | LLet(_,t,b) ->
+      if n <= 0 then b else codom_binder (n-1) (subst b t)
   | _ -> assert false
 
 (** [eq_alpha a b] tests the equality modulo alpha of [a] and [b]. *)

--- a/src/core/libTerm.ml
+++ b/src/core/libTerm.ml
@@ -145,16 +145,6 @@ let sym_to_var : var StrMap.t -> term -> term = fun map ->
     let (x,b) = unbind b in bind_var x (to_var b)
   in fun t -> if StrMap.is_empty map then t else to_var t
 
-(** [codom_binder n t] returns the [n]-th binder of [t] if [t] is a product of
-    arith >= [n]. *)
-let rec codom_binder : int -> term -> binder = fun n t ->
-  match unfold t with
-  | Prod(_,b) ->
-      if n <= 0 then b else codom_binder (n-1) (subst b mk_Kind)
-  | LLet(_,t,b) ->
-      if n <= 0 then b else codom_binder (n-1) (subst b t)
-  | _ -> assert false
-
 (** [eq_alpha a b] tests the equality modulo alpha of [a] and [b]. *)
 let rec eq_alpha a b =
   match unfold a, unfold b with

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -571,9 +571,11 @@ let rec handle :
             let n = m.meta_arity - 1 in
             let a = cleanup !(m.meta_type) in (* cleanup necessary *)
             (* a = Π x0:A0, .., Π xn-1:An-1, B *)
-            (* [codom_binder i a] returns the binder
-               [xi:Ai --> Π xi+1:Ai+1, .., Π xn-1:An-1, B] with
-               [x0,..,xi-1] replaced by [mk_Kind]. *)
+            (* [codom_binder i a] returns the binder [xi:Ai --> Π xi+1:Ai+1,
+               .., Π xn-1:An-1, B] with [x0,..,xi-1] replaced by
+               [mk_Kind]. This replacement does not matter here because we are
+               only interested in knowing whether [xi] occurs in [Π xi+1:Ai+1,
+               .., Π xn-1:An-1, B]. *)
             let rec codom_binder i a =
               match unfold a with
               | Prod(_,b) ->

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -570,8 +570,22 @@ let rec handle :
             let m = gt.goal_meta in
             let n = m.meta_arity - 1 in
             let a = cleanup !(m.meta_type) in (* cleanup necessary *)
-            let b = LibTerm.codom_binder (n - k) a in
-            if binder_occur b then
+            (* a = Π x0:A0, .., Π xn-1:An-1, B *)
+            (* [codom_binder i a] returns the binder
+               [xi:Ai --> Π xi+1:Ai+1, .., Π xn-1:An-1, B] with
+               [x0,..,xi-1] replaced by [mk_Kind]. *)
+            let rec codom_binder i a =
+              match unfold a with
+              | Prod(_,b) ->
+                  if i <= 0 then b else codom_binder (i-1) (subst b mk_Kind)
+              | LLet(_,t,b) ->
+                  if i <= 0 then b else codom_binder (i-1) (subst b t)
+              | _ -> assert false
+            in
+            (* Because [env] is in reverse order compared to [a], we have [env
+               = [xn-1; ..; x0]] and the position [k] corresponds to
+               [xn-k]. *)
+            if binder_occur (codom_binder (n - k) a) then
               fatal id.pos "%s cannot be removed because of dependencies."
                 id.elt;
             let env' = List.filter (fun (s,_) -> s <> id.elt) env in


### PR DESCRIPTION
fix #1251 
- move LibTerm.codom_binder inside the code of remove because it is too specific (some variables are replaced by mk_Kind)
- add comments in the code of remove