### PR TITLE
fix and factorize rewrite tactic code

### DIFF
--- a/src/core/libTerm.ml
+++ b/src/core/libTerm.ml
@@ -192,3 +192,21 @@ let fold (x:var) (t:term): term -> term =
       | _ -> u
   in
   aux
+
+(** Free variables of a term. *)
+let rec free_vars (t:term): VarSet.t =
+  match unfold t with
+  | Vari x -> VarSet.add x VarSet.empty
+  | Appl(u,v) -> VarSet.union (free_vars u) (free_vars v)
+  | Abst(a,b)
+  | Prod(a,b) ->
+      VarSet.union (free_vars a)
+        (let x,b = unbind b in VarSet.remove x (free_vars b))
+  | LLet(a,t,b) ->
+      VarSet.union (free_vars a)
+        (VarSet.union (free_vars t)
+           (let x,b = unbind b in VarSet.remove x (free_vars b)))
+  | Meta(_,ts) ->
+      Array.fold_right
+        (fun t acc -> VarSet.union acc (free_vars t)) ts VarSet.empty
+  | _ -> VarSet.empty

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -572,13 +572,14 @@ let _ =
   assert (eq (left_aliens s left) [t1; t2; t3]);
   assert (eq (right_aliens s right) [t3; t2; t1])
 
-(** [is_abst t] returns [true] iff [t] is of the form [Abst(_)]. *)
-let is_abst : term -> bool = fun t ->
-  match unfold t with Abst(_) -> true | _ -> false
+(** [is_abst t] returns [true] iff [t] is of the form [Abst _]. *)
+let is_abst t = match unfold t with Abst _ -> true | _ -> false
 
-(** [is_prod t] returns [true] iff [t] is of the form [Prod(_)]. *)
-let is_prod : term -> bool = fun t ->
-  (match unfold t with Prod(_) -> true | _ -> false)
+(** [is_prod t] returns [true] iff [t] is of the form [Prod _]. *)
+let is_prod t = match unfold t with Prod _ -> true | _ -> false
+
+(** [is_tref t] returns [true] iff [t] is of the form [TRef _]. *)
+let is_TRef t = match unfold t with TRef _ -> true | _ -> false
 
 (** [iter_atoms db f g t] applies f to every occurrence of a variable in t,
     g to every occurrence of a symbol, and db to every occurrence of a

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -312,6 +312,9 @@ val is_abst : term -> bool
 (** [is_prod t] returns [true] iff [t] is of the form [Prod(_)]. *)
 val is_prod : term -> bool
 
+(** [is_tref t] returns [true] iff [t] is of the form [TRef _]. *)
+val is_TRef : term -> bool
+
 (** [is_symb s t] tests whether [t] is of the form [Symb(s)]. *)
 val is_symb : sym -> term -> bool
 

--- a/src/handle/rewrite.ml
+++ b/src/handle/rewrite.ml
@@ -215,15 +215,48 @@ let matches : term -> term -> bool =
   in
   if Logger.log_enabled() then log "matches result: %b" r; r
 
+let no_match ?(subterm=false) pos g_env (vars,p) t =
+  let f idmap x =
+    let name, idmap = Name.get_safe_prefix (base_name x) idmap in
+    idmap, mk_Vari (new_var name)
+  in
+  let ts = snd (Array.fold_left_map f (Env.names g_env) vars) in
+  if subterm then fatal pos "No subterm of [%a] matches [%a]."
+                    term t term (msubst (bind_mvar vars p) ts)
+  else fatal pos "[%a] doesn't match [%a]."
+         term t term (msubst (bind_mvar vars p) ts)
+
 (** [matching_subs (xs,p) t] attempts to match the pattern [p] containing the
    variables [xs]) with the term [t]. If successful, it returns [Some ts]
    where [ts] is an array of terms such that substituting [xs] by the
-   corresponding elements of [ts] in [p] yields [t]. *)
+   corresponding elements of [ts] in [p] yields [t].
+
+WARNING: Some [ti] may be uninstantiated TRef's. It will happen if not all
+[vars] are in [LibTerm.free_vars p], for instance when some [vars] are type
+variables not occurring in [p], for instance when trying to apply an equation
+of the form [x = ...] with [x] of polymorphic type. This could be improved by
+generating p_terms instead of terms. Indeed, in this case, we could replace
+uninstantiated TRef's by underscores. *)
 let matching_subs : to_subst -> term -> term array option = fun (xs,p) t ->
   (* We replace [xs] by fresh [TRef]'s. *)
   let ts = Array.map (fun _ -> mk_TRef(Timed.ref None)) xs in
   let p = msubst (bind_mvar xs p) ts in
   if matches p t then Some(Array.map unfold ts) else None
+
+let matching_subs_check_TRef pos g_env ((vars,_) as xsp) t =
+  match matching_subs xsp t with
+  | Some ts ->
+      (* Check that all TRef's are instantiated. *)
+      let f i ti =
+        match unfold ti with
+        | TRef _ ->
+            fatal pos "Don't know how to instantiate the argument \"%a\" \
+                       of the equation." var vars.(i)
+        | _ -> ()
+      in
+      Array.iteri f ts;
+      ts
+  | None -> no_match pos g_env xsp t
 
 (** [find_subst (xs,p) t] tries to find the first instance of a subterm of [t]
    matching [p]. If successful, the function returns the array of terms by
@@ -254,21 +287,11 @@ let find_subst : to_subst -> term -> term array option = fun xsp t ->
     | sub -> sub
   in find t
 
-let no_match pos g_env (vars,p) t =
-  let f idmap x =
-    let name, idmap = Name.get_safe_prefix (base_name x) idmap in
-    idmap, mk_Vari (new_var name)
-  in
-  let ts = snd (Array.fold_left_map f (Env.names g_env) vars) in
-  fatal pos "No subterm of [%a] matches [%a]."
-    term t term (msubst (bind_mvar vars p) ts)
-
-let is_TRef t = match unfold t with TRef _ -> true | _ -> false
-
 let find_subst pos g_env (vars,p) t =
   match find_subst (vars,p) t with
-  | None -> no_match pos g_env (vars,p) t
+  | None -> no_match ~subterm:true pos g_env (vars,p) t
   | Some ts ->
+      (* Check that all TRef's are instantiated. *)
       let f i ti =
         match unfold ti with
         | TRef _ ->
@@ -315,7 +338,8 @@ let rec replace_wild_by_tref : term -> term = fun t ->
 
 let find_subterm_matching pos g_env p t =
   let p_refs = replace_wild_by_tref p in
-  if not (find_subterm_matching p_refs t) then no_match pos g_env ([||],p) t;
+  if not (find_subterm_matching p_refs t) then
+    no_match ~subterm:true pos g_env ([||],p) t;
   p_refs
 
 (** [bind_pattern p t] replaces in the term [t] every occurence of the pattern
@@ -415,11 +439,7 @@ let rewrite : Sig_state.t -> problem -> popt -> goal_typ -> bool ->
         (* Find a subterm [match_p] of the goal that matches [p]. *)
         let match_p = find_subterm_matching pos g_env p g_term in
         (* Build a substitution by matching [match_p] with the LHS [l]. *)
-        let sigma =
-          match matching_subs (vars,l) match_p with
-          | Some(sigma) -> sigma
-          | None -> no_match pos g_env (vars,l) match_p
-        in
+        let sigma = matching_subs_check_TRef pos g_env (vars,l) match_p in
         (* Build the data from the substitution. *)
         let (t, l, r) = msubst3 bound sigma in
         let pred_bind = bind_pattern l g_term in
@@ -467,14 +487,7 @@ let rewrite : Sig_state.t -> problem -> popt -> goal_typ -> bool ->
         let pat_l = subst pat id_val in
 
         (* This must match with the LHS of the equality proof we use. *)
-        let sigma =
-          match matching_subs (vars,l) id_val with
-          | Some(sigma) -> sigma
-          | None ->
-              fatal pos
-                "The value of [%a], [%a], in [%a] does not match [%a]."
-                var id term id_val term p term l
-        in
+        let sigma = matching_subs_check_TRef pos g_env (vars,l) id_val in
         (* Build t, l, using the substitution we found. Note that r  *)
         (* corresponds to the value we get by applying rewrite to *)
         (* id val. *)
@@ -524,13 +537,7 @@ let rewrite : Sig_state.t -> problem -> popt -> goal_typ -> bool ->
 
         (* Now we must match s, which no longer contains any TRef's
            with the LHS of the lemma. *)
-        let sigma =
-          match matching_subs (vars,l) s with
-          | Some(sigma) -> sigma
-          | None        ->
-              fatal pos "The term [%a] does not match the LHS [%a]"
-                term s term l
-        in
+        let sigma = matching_subs_check_TRef pos g_env (vars,l) s in
         let (t,l,r) = msubst3 bound sigma in
 
         (* First we work in [id_val], that is, we substitute all
@@ -577,23 +584,12 @@ let rewrite : Sig_state.t -> problem -> popt -> goal_typ -> bool ->
         (* Here we have already asserted tat an instance of p[s/id] exists
            so we know that this will match something. The step is repeated
            in order to get the value of [id]. *)
-        let sub =
-          match matching_subs ([|id|], pat_refs) p with
-          | Some(sub) -> sub
-          | None      -> assert false
-        in
+        let sub = matching_subs_check_TRef pos g_env ([|id|],pat_refs) p in
         let id_val = sub.(0) in
         (* This part of the term-building is similar to the previous
            case, as we are essentially rebuilding a term, with some
            subterms that are replaced by new ones. *)
-        let sigma =
-          match matching_subs (vars, l) id_val with
-          | Some(sigma) -> sigma
-          | None        ->
-              fatal pos
-                "The value of X, [%a], does not match the LHS, [%a]"
-                term id_val term l
-        in
+        let sigma = matching_subs_check_TRef pos g_env (vars,l) id_val in
         let (t,l,r) = msubst3 bound sigma in
 
         (* Now to do some term building. *)

--- a/src/lplib/array.ml
+++ b/src/lplib/array.ml
@@ -80,3 +80,19 @@ let unzip : ('a * 'b) array -> 'a list * 'b list = fun a ->
     returned if [n > length a]. *)
 let drop : int -> 'a array -> 'a array = fun n a ->
   let l = length a in if n >= l then [||] else A.sub a n (l - n)
+
+(** Array.fold_left_map is a combination of Array.fold_left and Array.map that
+    threads an accumulator through calls to f, since OCaml 4.13. *)
+let fold_left_map f acc input_array =
+  let len = length input_array in
+  if len = 0 then (acc, [||]) else begin
+    let acc, elt = f acc (unsafe_get input_array 0) in
+    let output_array = A.make len elt in
+    let acc = ref acc in
+    for i = 1 to len - 1 do
+      let acc', elt = f !acc (unsafe_get input_array i) in
+      acc := acc';
+      unsafe_set output_array i elt;
+    done;
+    !acc, output_array
+  end


### PR DESCRIPTION
fix problem in find_subst: some of the vars may not be instantiated by matching (e.g. type variables)

this PR fixes this problem by outputting an error message in this case
it also factorizes parts of the code

remark: it doesn't seem possible to overcome this limitation currently because the current code works on terms instead of p_terms. using p_terms would allow us to replace uninstantiated TRef's by underscores which would generate fresh metavariables when passed to refine

additional modifications: 
- libTerm: add free_vars (not used currently)
- array: add fol_left_map (since ocaml 4.13 only)
- remove check_alpha in Rewrite.matches as it seems useless