### PR TITLE
improve rewrite tactic applicability

### DIFF
--- a/src/handle/rewrite.ml
+++ b/src/handle/rewrite.ml
@@ -178,7 +178,8 @@ let matches : term -> term -> bool =
         if Logger.log_enabled() then log (Color.red "<TRef> ≔ %a") term u;
         Timed.(r := Some u);
         eq (add_eqs l ps ts2)
-      | Meta _
+      | Meta _ -> eq l (* In case of a meta, we assume that it can be
+                          instantiated. This may later fail in refine. *)
       | Prod _
       | Abst _
       | LLet _

--- a/src/handle/rewrite.ml
+++ b/src/handle/rewrite.ml
@@ -178,8 +178,10 @@ let matches : term -> term -> bool =
         if Logger.log_enabled() then log (Color.red "<TRef> ≔ %a") term u;
         Timed.(r := Some u);
         eq (add_eqs l ps ts2)
-      | Meta _ -> eq l (* In case of a meta, we assume that it can be
-                          instantiated. This may later fail in refine. *)
+      | Meta _ -> eq l (* We assume that metas can always be instantiated by
+                          the corresponding RHS although this might not be the
+                          case, in which case tac_refine or solve will later
+                          fail. This way, we may chose the wrong subterm. *)
       | Prod _
       | Abst _
       | LLet _

--- a/tests/OK/1151.lp
+++ b/tests/OK/1151.lp
@@ -1,0 +1,6 @@
+require open tests.OK.List tests.OK.Prop tests.OK.Eq tests.OK.Set;
+
+opaque symbol rot_size [a] (l:𝕃 a) : π (rot (size l) l = l) ≔
+begin
+  assume a l; simplify; rewrite take_size; rewrite drop_size; reflexivity
+end;

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -60,7 +60,7 @@ do
         # proofs
         why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit);;
         # "open"
-        triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|Option|String|HOL|Impred|PropExt|Classic|1217);;
+        triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|Option|String|HOL|Impred|PropExt|Classic|1217|1151);;
         # "inductive"
         strictly_positive_*|inductive|989|904|830|341);;
         # underscore in query


### PR DESCRIPTION
by assuming that metavariables occurring in a pattern (equation LHS or rewrite tactic pattern), introduced for implicit arguments, always match (this may later fail within refine though)