### PR TITLE
have Sig_state.dummy open Ghost.sign

### DIFF
--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -217,7 +217,7 @@ let decision_tree_cmd : Config.t -> qident -> bool -> unit =
       let ss = Sig_state.of_sign sign in
       if ghost then
         (* Search through ghost symbols. *)
-        try Sign.Ghost.find sym
+        try Sign.find Sign.Ghost.sign sym
         with Not_found -> fatal_no_pos "Unknown ghost symbol %s." sym
       else
         try Sig_state.find_sym ~prt:true ~prv:true ss (Pos.none (mp, sym))

--- a/src/core/sig_state.ml
+++ b/src/core/sig_state.ml
@@ -84,7 +84,8 @@ let open_sign : sig_state -> Sign.t -> sig_state = fun ss sign ->
   {ss with in_scope; open_paths}
 
 (** [of_sign sign] creates a new sig_state with signature [sign] and open it
-    and the ghost signature as well. *)
+    and the ghost signature as well, assuming that [sign] has been created
+    using [Sign.create]. *)
 let of_sign : Sign.t -> sig_state = fun signature ->
   let ss =
     { signature

--- a/src/core/sig_state.ml
+++ b/src/core/sig_state.ml
@@ -15,14 +15,6 @@ open Timed
 open Term
 open Sign
 
-(** [create_sign path] creates a signature with path [path] and the ghost
-    module as dependency. *)
-let create_sign : Path.t -> Sign.t = fun sign_path ->
-  let sign = Sign.dummy() in
-  let dep = {dep_symbols = StrMap.empty; dep_open=true} in
-  let deps = Path.Map.singleton Sign.Ghost.path dep in
-  {sign with sign_path; sign_deps = ref deps}
-
 (** State of the signature, including aliasing and accessible symbols. *)
 type sig_state =
   { signature : Sign.t                    (** Current signature. *)
@@ -33,12 +25,6 @@ type sig_state =
   ; open_paths : Path.Set.t               (** Open modules. *) }
 
 type t = sig_state
-
-(** Dummy [sig_state]. *)
-let dummy : sig_state =
-  { signature = Sign.dummy (); in_scope = StrMap.empty;
-    alias_path = StrMap.empty; path_alias = Path.Map.empty;
-    builtins = StrMap.empty; open_paths = Path.Set.empty }
 
 (** [add_symbol ss expo prop mstrat opaq id pos typ impl def] generates a new
     signature state from [ss] by creating a new symbol with expo [e], property
@@ -97,10 +83,21 @@ let open_sign : sig_state -> Sign.t -> sig_state = fun ss sign ->
   let open_paths = Path.Set.add sign.sign_path ss.open_paths in
   {ss with in_scope; open_paths}
 
-(** [of_sign sign] creates a state from the signature [sign] and open it as
-   well as the ghost signature. *)
+(** [of_sign sign] creates a new sig_state with signature [sign] and open it
+    and the ghost signature as well. *)
 let of_sign : Sign.t -> sig_state = fun signature ->
-  open_sign (open_sign {dummy with signature} Ghost.sign) signature
+  let ss =
+    { signature
+    ; in_scope = StrMap.empty
+    ; alias_path = StrMap.empty
+    ; path_alias = Path.Map.empty
+    ; builtins = StrMap.empty
+    ; open_paths = Path.Set.empty }
+  in
+  open_sign (open_sign ss Ghost.sign) signature
+
+(** Dummy [sig_state]. *)
+let dummy : sig_state = of_sign (Sign.create [])
 
 (** [find_sym] is the type of functions used to return the symbol
     corresponding to a qualified / non qualified name *)

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -24,7 +24,8 @@ type dep_data =
   ; dep_open : bool }
 
 (** Representation of a signature, that is, what is introduced by a
-    module/file. *)
+    module/file. Signatures must be created with the functions [create] or
+    [read] below only.*)
 type t =
   { sign_symbols  : sym StrMap.t ref
   ; sign_path     : Path.t

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -50,7 +50,7 @@ let rec compile_with :
       let forced = if force then " (forced)" else "" in
       Console.out 1 (Color.blu "Start checking \"%s\"%s") src forced;
       loading := mp :: !loading;
-      let sign = Sig_state.create_sign mp in
+      let sign = Sign.create mp in
       let ss = Stdlib.ref (Sig_state.of_sign sign) in
       (* [sign] is added to [loaded] before processing the commands so that it
          is possible to qualify the symbols of the current modules. *)

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -283,7 +283,7 @@ and scope_head : ?find_sym:find_sym ->
       begin
         let s = "\""^s^"\"" in
         let sym =
-          try Sign.Ghost.find s
+          try Sign.find Sign.Ghost.sign s
           with Not_found ->
             let s_typ = mk_Symb (Builtin.get ss pos "String") in
             Sign.add_symbol Sign.Ghost.sign Public Const Eager true

--- a/src/pure/pure.ml
+++ b/src/pure/pure.ml
@@ -150,7 +150,7 @@ let initial_state : string -> state = fun fname ->
   Package.apply_config fname;
   let mp = Library.path_of_file LpLexer.escape fname in
   Sign.loading := [mp];
-  let sign = Sig_state.create_sign mp in
+  let sign = Sign.create mp in
   Sign.loaded  := Path.Map.add mp sign !Sign.loaded;
   (Time.save (), Sig_state.of_sign sign)
 

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -564,7 +564,7 @@ let index_sign sign =
   (fun path d ->
     Lplib.Extra.StrMap.iter
      (fun name sd ->
-       let sym = Core.Sign.find_sym path name in
+       let sym = Core.Sign.find_qualified path name in
        List.iter (index_rule sym) sd.Sign.rules)
      d.Sign.dep_symbols)
   deps

--- a/tests/kernel.ml
+++ b/tests/kernel.ml
@@ -8,7 +8,7 @@ let () =
 
 let open_sign_default () =
   (* Check that by default, [Sig_state.of_sign s] opens [s] *)
-  let sign = Sig_state.create_sign [ "dummy" ] in
+  let sign = Sign.create [ "dummy" ] in
   let _ =
     Sign.add_symbol sign Term.Public Term.Defin Term.Eager false
       (Pos.none "foo") None Term.mk_Type []

--- a/tests/rewriting.ml
+++ b/tests/rewriting.ml
@@ -20,8 +20,7 @@ let add_sym ss id =
 (* Define a signature state and some symbols. *)
 
 let sig_state : Sig_state.t =
-  let sign = Sig_state.create_sign (Path.ghost "rewriting_tests") in
-  Sig_state.of_sign sign
+  Sig_state.of_sign (Sign.create (Path.ghost "rewriting_tests"))
 
 let sig_state, c = add_sym sig_state "C"
 let sig_state, ok = add_sym sig_state "Ok"


### PR DESCRIPTION
- define Sig_state.dummy so that it is valid, that is, it requires and opens Ghost.sign
- replace Sign.Ghost.find sym by Sign.find Sign.Ghost.sign
- move and rename Sig_state.create_sign into Sign.create
- remove Sign.dummy: signatures must be created with Sign.create or Sign.read only
- rename Sign.find_sym into Sign.find_qualified