### PR TITLE
Rocq export: rename identifiers that are in the codomain of the renaming map

### DIFF
--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -154,7 +154,8 @@ let list elt sep oc xs =
 (** Translation of identifiers. *)
 
 let translate_ident : string -> string = fun s ->
-  try StrMap.find s !rmap with Not_found -> s
+  try StrMap.find s !rmap with Not_found ->
+    if StrMap.exists (fun _ id' -> s = id') !rmap then s ^ "__alt__" else s
 
 let raw_ident oc s = string oc (translate_ident s)
 


### PR DESCRIPTION
- Check if an identifier (in particular, a variable name) is one of the mapped Rocq identifiers.
- If so, add the "\_\_alt__" suffix to disambiguate them