### PR TITLE
upgrade to cmdliner version 2

### DIFF
--- a/src/cli/config.ml
+++ b/src/cli/config.ml
@@ -106,7 +106,7 @@ let lib_root : string option CLT.t =
   Arg.(value & opt (some dir) None & info ["lib-root"] ~docv:"DIR" ~doc)
 
 let map_dir : (Path.t * string) list CLT.t =
-  let path : Path.t Arg.conv =
+  let mod_path : Path.t Arg.conv =
     let parse (s: string) : (Path.t, [>`Msg of string]) result =
       try Ok(Parser.path_of_string s)
       with Error.Fatal(_,s) -> Error(`Msg(s))
@@ -122,7 +122,7 @@ let map_dir : (Path.t * string) list CLT.t =
      expected folder under the library root."
   in
   let i = Arg.(info ["map-dir"] ~docv:"MOD:DIR" ~doc) in
-  Arg.(value & opt_all (pair ~sep:':' path dir) [] & i)
+  Arg.(value & opt_all (pair ~sep:':' mod_path dir) [] & i)
 
 (** Debugging and output options. *)
 


### PR DESCRIPTION
This PR brings a minor change to `config.ml` by changing the name of `path` var in `map_dir` function because the same name is used in the new API of `cmdliner`.
For now, there is no need to change any dependency since the code works the same with the old and new versions