### PR TITLE
fix(lsp): comply with LSP spec for positions and go-to-definition

### DIFF
--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -151,10 +151,10 @@ let new_doc ~uri ~version ~text =
       let loc : Pos.pos =
         {
           fname = Some(uri);
-          start_line = 0;
+          start_line = 1;
           start_col  = 0;
           start_offset  = 0;
-          end_line = 0;
+          end_line = 1;
           end_col = 0;
           end_offset  = 0
         } in

--- a/src/lsp/lp_lsp.ml
+++ b/src/lsp/lp_lsp.ml
@@ -62,10 +62,10 @@ let do_check_text ofmt ~doc =
       let loc : Pos.pos =
         {
           fname = Some(doc.uri);
-          start_line = 0;
+          start_line = 1;
           start_col  = 0;
           start_offset  = 0;
-          end_line = 0;
+          end_line = 1;
           end_col = 0;
           end_offset  = 0;
         } in
@@ -133,7 +133,7 @@ let mk_syminfo file (name, _path, kind, pos) : J.t =
 
 let mk_definfo file pos =
   `Assoc [
-      "uri", `String file
+      "uri", `String ("file://" ^ file)
     ; "range", LSP.mk_range pos
         ]
 

--- a/src/lsp/lsp_base.ml
+++ b/src/lsp/lsp_base.ml
@@ -36,8 +36,10 @@ let mk_range (p : Pos.pos) : J.t =
   let {start_line=line1; start_col=col1; end_line=line2; end_col=col2; _} =
     p
   in
-  `Assoc ["start", `Assoc ["line", `Int (line1 - 1); "character", `Int col1];
-          "end",   `Assoc ["line", `Int (line2 - 1); "character", `Int col2]]
+  `Assoc ["start", `Assoc ["line", `Int (max 0 (line1 - 1));
+                            "character", `Int (max 0 col1)];
+          "end",   `Assoc ["line", `Int (max 0 (line2 - 1));
+                            "character", `Int (max 0 col2)]]
 
 let json_of_goal (hyps, concl) =
   let json_of_hyp (s,t) = `Assoc ["hname", `String s; "htype", `String t] in


### PR DESCRIPTION
## Summary

- **mk_range**: clamp line/character to `max 0` so negative values are never sent. LSP spec requires `uinteger` for positions, but error fallback positions with `start_line=0` would produce `line=-1` after the 1-based to 0-based conversion.
- **Error fallback positions**: use `start_line=1`/`end_line=1` instead of `0` in `new_doc` and `do_check_text` error handlers, so `mk_range` produces valid `line=0` (beginning of file).
- **Go-to-definition**: prefix URI with `file://` in `mk_definfo`. The LSP spec requires `DocumentUri` ([RFC 3986](https://www.rfc-editor.org/rfc/rfc3986)), but bare file paths were being sent, causing editors to fail to parse the `GotoDefinitionResponse`.

These issues were discovered while developing the [Zed editor extension for Lambdapi](https://github.com/ciaran-matthew-dunne/zed-lambdapi). Zed's strict LSP deserialization surfaced all three problems:
- `Error("invalid value: integer -1, expected u32")` from the position issue
- `data did not match any variant of untagged enum GotoDefinitionResponse` from the missing `file://` prefix

## Test plan

- [x] Verified go-to-definition works in Zed after the `file://` fix
- [x] Verified no more `-1` position errors in Zed logs
- [x] `dune build` passes
- [ ] Existing test suite (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)