### PR TITLE
fix(lsp): go-to-definition, hover, and stale session state

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ Active Contributors (in alphabetical order)
 - Abdelghani Alidra (2024-)
 - Bruno Barras (2025-)
 - Jean-Paul Bodeveix (2026-)
+- Ciarán Dunne (2026-)
 
 Past Contributors (in alphabetical order)
 =========================================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Selection of the library mapping with the longest matching prefix in
   `path_of_file`: with nested mappings, the computed module path could get a
   duplicated directory component.
+- LSP server: go-to-definition and hover on qualified identifiers, and session
+  state leaking between open documents.
 
 ## 3.0.0 (2025-07-16)
 

--- a/src/common/pos.ml
+++ b/src/common/pos.ml
@@ -36,6 +36,13 @@ let cat : pos -> pos -> pos = fun p1 p2 ->
   ; end_col = p2.end_col
   ; end_offset = p2.end_offset }
 
+(** [file_start fname] is a zero-length position at the start of file [fname],
+    used as a fallback for error reporting when no finer position is known. *)
+let file_start : string -> pos = fun fname ->
+  { fname = Some fname
+  ; start_line = 1; start_col = 0; start_offset = 0
+  ; end_line = 1; end_col = 0; end_offset = 0 }
+
 (** [locate ?fname (p1,p2)] converts the pair of Lexing positions [p1,p2] and
     filename [fname] into a {!type:pos}. *)
 let locate : ?fname:string -> Lexing.position * Lexing.position -> pos =

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -148,17 +148,7 @@ let new_doc ~uri ~version ~text =
       let path = String.sub uri 7 (String.length uri - 7) in
       Some(Pure.initial_state path), []
     with Error.Fatal(_pos, msg, err_desc) ->
-      let loc : Pos.pos =
-        {
-          fname = Some(uri);
-          start_line = 0;
-          start_col  = 0;
-          start_offset  = 0;
-          end_line = 0;
-          end_col = 0;
-          end_offset  = 0
-        } in
-      (None, [(1, msg ^ "\n" ^ err_desc), Some(loc)])
+      (None, [(1, msg ^ "\n" ^ err_desc), Some (Pos.file_start uri)])
   in
   { uri;
     text;

--- a/src/lsp/lp_lsp.ml
+++ b/src/lsp/lp_lsp.ml
@@ -10,7 +10,7 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Lplib open Extra
+open Lplib
 open Common
 open Core
 
@@ -59,17 +59,8 @@ let do_check_text ofmt ~doc =
     try
       Lp_doc.check_text ~doc
     with Common.Error.Fatal(_pos, msg, err_desc) ->
-      let loc : Pos.pos =
-        {
-          fname = Some(doc.uri);
-          start_line = 0;
-          start_col  = 0;
-          start_offset  = 0;
-          end_line = 0;
-          end_col = 0;
-          end_offset  = 0;
-        } in
-      (doc, Lp_doc.mk_error ~doc loc (msg ^ "\n" ^ err_desc))
+      (doc, Lp_doc.mk_error ~doc (Pos.file_start doc.uri)
+              (msg ^ "\n" ^ err_desc))
   in
   Hashtbl.replace doc_table doc.uri doc;
   Hashtbl.replace completed_table doc.uri doc;
@@ -131,9 +122,11 @@ let mk_syminfo file (name, _path, kind, pos) : J.t =
                   ]
   ]
 
+(* [file] is a plain filesystem path (as produced by
+   [Library.file_of_path]), never a URI. *)
 let mk_definfo file pos =
   `Assoc [
-      "uri", `String file
+      "uri", `String ("file://" ^ file)
     ; "range", LSP.mk_range pos
         ]
 
@@ -157,6 +150,7 @@ let do_symbols ofmt ~id params =
     let msg = LSP.mk_reply ~id ~result:`Null in
     LIO.send_json ofmt msg
   | Some ss ->
+    Pure.restore_time ss;
     let sym = Pure.get_symbols ss in
     let sym =
       Extra.StrMap.fold
@@ -230,11 +224,7 @@ let get_node_at_pos doc line pos =
   let open Lp_doc in
   List.find_opt (fun { ast; _ } ->
       let loc = Pure.Command.get_pos ast in
-      let res = in_range ?loc (line,pos) in
-      let ls = Format.asprintf "%B l:%d p:%d / %a"
-                 res line pos Pos.pp loc in
-      LIO.log_error "get_node_at_pos" ("call: "^ls);
-      res
+      in_range ?loc (line,pos)
     ) doc.Lp_doc.nodes
 
 (** [get_first_error doc] returns the first error inferred from doc.logs *)
@@ -272,24 +262,6 @@ let rec get_goals ~doc ~line ~pos =
     | Some (v,_) -> Some v
 
 let get_logs ~doc ~line ~pos : string =
-  (* DEBUG LOG START *)
-  LIO.log_error "get_logs"
-    (Printf.sprintf "%s:%d,%d" doc.Lp_doc.uri line pos);
-  let log_to_str ((sev, log), posopt) =
-    let pos_str =
-      match posopt with
-      | None -> "None"
-      | Some Pos.{start_line; start_col; _} ->
-          Printf.sprintf "(%d, %d)" start_line start_col
-    in
-    let log_str =
-      let len = String.length log in
-      Printf.sprintf "length: %d | %s" len (String.sub log 0 (min 30 len))in
-    Format.asprintf "element(severity:%d): %s -> %s\n " sev pos_str log_str
-  in
-  Lsp_io.log_error "get_logs"
-    (List.fold_left (^) "\n" (List.map log_to_str doc.Lp_doc.logs));
-  (* DEBUG LOG END *)
   let line = line+1 in
   let end_limit =
     match get_first_error doc with
@@ -318,20 +290,15 @@ let do_goals ofmt ~id params =
   let msg = LSP.mk_reply ~id ~result in
   LIO.send_json ofmt msg
 
-let msg_fail hdr msg =
-  LIO.log_error hdr msg;
-  failwith msg
 
-let get_symbol : Range.point ->
-('a * 'b) RangeMap.t -> ('b * Range.t) option
+let get_symbol : Range.point -> 'a RangeMap.t -> ('a * Range.t) option
 = fun pos doc ->
 
   let open RangeMap in
 
   match (find pos doc) with
   | None -> None
-  | Some(interval, (_, token)) -> Some (token, interval)
-
+  | Some(interval, value) -> Some (value, interval)
 
 let do_definition ofmt ~id params =
 
@@ -341,122 +308,63 @@ let do_definition ofmt ~id params =
     let msg = LSP.mk_reply ~id ~result:`Null in
     LIO.send_json ofmt msg
   | Some ss ->
+    Pure.restore_time ss;
     let ln, pos = get_textPosition params in
 
-    (* Lines send by the client start at 0 *)
+    (* Lines sent by the client start at 0 *)
     let pt = Range.make_point (ln + 1) pos in
-    let sym_target =
-      match get_symbol pt doc.map with
-      | None -> "No symbol found"
-      | Some(token, _) -> token
-    in
-
-    (*Some printing in the log*)
-    LIO.log_error "token map" (RangeMap.to_string snd doc.map);
-    LIO.log_error "do_definition" sym_target;
-
-    let sym = Pure.get_symbols ss in
-    let map_pp : string =
-      Extra.StrMap.bindings sym
-      |> List.map (fun (key, sym) ->
-          Format.asprintf "{%s} / %s: @[%a@]"
-            key sym.Term.sym_name Pos.pp sym.sym_pos)
-      |> String.concat "\n"
-    in
-    LIO.log_error "symbol map" map_pp;
-
     let sym_info =
-      match StrMap.find_opt sym_target sym with
-      | None -> `Null
-      | Some s ->
-        match s.sym_pos with
+      match get_symbol pt doc.map with
+      | None ->
+        LIO.log_error "do_definition" "no symbol at point"; `Null
+      | Some (qid, _) ->
+        LIO.log_error "do_definition" (snd qid);
+        match Pure.find_sym ss qid with
         | None -> `Null
-        | Some pos ->
-        (* A JSON with the path towards the definition of the term
-          and its position is returned
-          /!\ : extension is fixed, only works for .lp files *)
-          mk_definfo
-            Library.(file_of_path s.Term.sym_path ^ lp_src_extension) pos
+        (* Ghost symbols (internal symbols used e.g. for unification
+           rules and string literals) have no user-facing definition
+           site one could jump to. *)
+        | Some s when s.Term.sym_path = Sign.Ghost.path -> `Null
+        | Some s ->
+          let file =
+            Library.(file_of_path s.Term.sym_path ^ lp_src_extension) in
+          let pos = Option.get (Pos.file_start file) s.sym_pos in
+          mk_definfo file pos
     in
     let msg = LSP.mk_reply ~id ~result:sym_info in
     LIO.send_json ofmt msg
 
 let hover_symInfo ofmt ~id params =
-
   let _, _, doc = grab_doc params in
   let ln, pos = get_textPosition params in
-
-  (* Positions sent by the client are one line late *)
   let pt = Range.make_point (ln + 1) pos in
-  LIO.log_error "searched point" (Range.point_to_string pt);
+  LIO.log_error "hover_symInfo" (Range.point_to_string pt);
 
-  (* The hovered token and its start/finish positions are stored *)
-  let sym_target, interval  =
-  match get_symbol pt doc.map with
-    | None ->
-      "No symbol found", (Range.make_interval pt pt)
-    (* VSCode highlights the token properly if the interval is extended to the
-       character next to it. This might be handled differently in other
-       editors in the future, but it is the most practical solution for
-       now. *)
-    | Some(token, range) ->
-      token, (Range.translate range 0 1)
+  let send_null () =
+    LIO.send_json ofmt (LSP.mk_reply ~id ~result:`Null)
   in
 
-  (* Some printing in the log *)
-  (* LIO.log_error "token map" (RangeMap.to_string snd doc.map);
-
-  LIO.log_error "hoverSymInfo" sym_target;
-  LIO.log_error "hoverSymInfo" (Range.interval_to_string interval); *)
-
   try
-    (* The information about the tokens is stored *)
-    let sym =
-      match doc.final with
-      | Some ss -> Pure.get_symbols ss
-      | None    -> raise (Error.fatal_no_pos("Root state is missing
-      probably because new_doc has raised exception")) in
+    let ss = match doc.final with
+      | Some ss -> ss
+      | None ->
+        raise (Error.fatal_no_pos "Final state is missing: the document \
+                                   was never successfully loaded") in
+    Pure.restore_time ss;
 
-    (* The start/finish positions are used to hover the full qualified term,
-      not just the token *)
-    let start = Range.interval_start interval
-    and finish = Range.interval_end interval in
-
-    (* FIXME: types and typed conversion should take care of this *)
-    let sl, sc, fl, fc =
-      (Range.line start - 1),
-      (Range.column start - 1),
-      (Range.line finish - 1),
-      (Range.column finish - 1)
-    in
-
-    let s = `Assoc["line", `Int sl; "character", `Int sc] in
-    let f = `Assoc["line", `Int fl; "character", `Int fc] in
-    let range = `Assoc["start", s; "end", f] in
-
-    let map_pp : string =
-      Extra.StrMap.bindings sym
-      |> List.map (fun (key, sym) ->
-          Format.asprintf "{%s} / %s: @[%a@]"
-            key sym.Term.sym_name Pos.pp sym.sym_pos)
-      |> String.concat "\n"
-    in
-    LIO.log_error "symbol map" map_pp;
-
-    let sym_found =
-      match StrMap.find_opt sym_target sym with
-      | None -> msg_fail "hover_SymInfo" "Sym not found"
-      | Some sym -> sym
-    in
-    let sym_type = Format.asprintf "%a" Core.Print.sym_type sym_found in
-    let result : J.t =
-      `Assoc [ "contents", `String sym_type; "range", range ] in
-    let msg = LSP.mk_reply ~id ~result in
-    LIO.send_json ofmt msg
-
-  with _ ->
-    let msg = LSP.mk_reply ~id ~result:`Null in
-    LIO.send_json ofmt msg
+    match get_symbol pt doc.map with
+    | None -> send_null ()
+    | Some (qid, range) ->
+      match Pure.find_sym ss qid with
+      | None -> send_null ()
+      | Some sym_found ->
+        let sym_type = Format.asprintf "%a" Core.Print.sym_type sym_found in
+        let result = `Assoc [ "contents", `String sym_type
+                            ; "range", LSP.mk_range_of_interval range ] in
+        LIO.send_json ofmt (LSP.mk_reply ~id ~result)
+  with e ->
+    LIO.log_error "hover_symInfo" (Printexc.to_string e);
+    send_null ()
 
 let protect_dispatch p f x =
   try f x
@@ -488,10 +396,12 @@ let dispatch_message ofmt dict =
       (do_symbols ofmt ~id) params
 
   | "textDocument/hover" ->
-    hover_symInfo ofmt ~id params
+    (try hover_symInfo ofmt ~id params
+     with _ -> LIO.send_json ofmt (LSP.mk_reply ~id ~result:`Null))
 
   | "textDocument/definition" ->
-    do_definition ofmt ~id params
+    (try do_definition ofmt ~id params
+     with _ -> LIO.send_json ofmt (LSP.mk_reply ~id ~result:`Null))
 
   | "proof/goals" ->
     do_goals ofmt ~id params
@@ -528,13 +438,12 @@ let process_input ofmt (com : J.t) =
     let bt = Printexc.get_backtrace () in
     LIO.log_error "[BT]" bt;
     LIO.log_error "process_input" (Printexc.to_string exn);
-    (*Send an "empty" answer with Null goals when exception occurs*)
-    let id     = oint_field "id" (U.to_assoc com) in
-    let goals = None in
-    let logs = "" in
-    let result = LSP.json_of_goals goals ~logs in
-    let msg = LSP.mk_reply ~id ~result in
-    LIO.send_json ofmt msg
+    (* Send a null reply so the client doesn't hang *)
+    let id = oint_field "id" (U.to_assoc com) in
+    if id <> 0 then begin
+      let msg = LSP.mk_reply ~id ~result:`Null in
+      LIO.send_json ofmt msg
+    end
 
 let main std log_file =
 

--- a/src/lsp/lp_lsp.mli
+++ b/src/lsp/lp_lsp.mli
@@ -13,3 +13,4 @@
 val default_log_file : string
 
 val main : bool -> string -> unit
+(** [main standard_lsp log_file] starts the LSP server. *)

--- a/src/lsp/lsp_base.ml
+++ b/src/lsp/lsp_base.ml
@@ -10,6 +10,7 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Lplib
 open Common
 open Handle
 
@@ -31,13 +32,26 @@ let mk_reply ~id ~result =
 let mk_event m p   =
   `Assoc [ "jsonrpc", `String "2.0"; "method", `String m; "params", `Assoc p ]
 
+(* LSP positions are 0-based, non-negative, and require start <= end.
+   Lambdapi lines are 1-based, and generated symbols carry virtual
+   positions violating the other two constraints (see the NOTE on
+   generated symbols in [Core.Term]): hence shift lines, floor at 0,
+   and collapse inverted ranges to their start. *)
+let json_of_range l1 c1 l2 c2 : J.t =
+  let max0 n = if n < 0 then 0 else n in
+  let l1 = max0 (l1 - 1) and c1 = max0 c1 in
+  let l2 = max0 (l2 - 1) and c2 = max0 c2 in
+  let l2, c2 = if (l2, c2) < (l1, c1) then l1, c1 else l2, c2 in
+  `Assoc ["start", `Assoc ["line", `Int l1; "character", `Int c1];
+          "end",   `Assoc ["line", `Int l2; "character", `Int c2]]
+
 let mk_range (p : Pos.pos) : J.t =
-  let open Pos in
-  let {start_line=line1; start_col=col1; end_line=line2; end_col=col2; _} =
-    p
-  in
-  `Assoc ["start", `Assoc ["line", `Int (line1 - 1); "character", `Int col1];
-          "end",   `Assoc ["line", `Int (line2 - 1); "character", `Int col2]]
+  Pos.(json_of_range p.start_line p.start_col p.end_line p.end_col)
+
+let mk_range_of_interval (r : Range.t) : J.t =
+  let s = Range.interval_start r and e = Range.interval_end r in
+  json_of_range (Range.line s) (Range.column s)
+    (Range.line e) (Range.column e)
 
 let json_of_goal (hyps, concl) =
   let json_of_hyp (s,t) = `Assoc ["hname", `String s; "htype", `String t] in

--- a/src/lsp/lsp_base.mli
+++ b/src/lsp/lsp_base.mli
@@ -10,6 +10,7 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Lplib
 open Common
 open Handle
 
@@ -18,6 +19,8 @@ module J = Yojson.Basic
 val std_protocol : bool ref
 
 val mk_range : Pos.pos -> J.t
+
+val mk_range_of_interval : Range.t -> J.t
 
 val mk_reply : id:int -> result:J.t -> J.t
 

--- a/src/pure/pure.ml
+++ b/src/pure/pure.ml
@@ -182,6 +182,18 @@ let end_proof : proof_state -> command_result =
 let get_symbols : state -> Term.sym Extra.StrMap.t =
   fun (_, ss) -> ss.in_scope
 
+let find_sym : state -> Term.qident -> Term.sym option =
+  fun (_, ss) qid ->
+  try Some (Sig_state.find_sym ~prt:true ~prv:true ss (Pos.none qid))
+  with Fatal _ -> None
+
+(* [restore_time st] activates the timed state (loaded signatures, library
+   mappings, ...) captured when [st] was computed. LSP requests must call
+   this before touching timed globals like [Library.lib_mappings], otherwise
+   they would observe whichever document was opened most recently. *)
+let restore_time : state -> unit =
+  fun (t, _) -> Time.restore t
+
 (* Equality tests, important for the incremental engine *)
 
 (* There are two kind of tests for equality:

--- a/src/pure/pure.mli
+++ b/src/pure/pure.mli
@@ -86,6 +86,17 @@ val end_proof : proof_state -> command_result
     [st]. This can be used for displaying the type of symbols. *)
 val get_symbols : state -> Term.sym Extra.StrMap.t
 
+(** [find_sym st qid] returns the symbol denoted by [qid] in state [st].
+    Handles short names in scope, aliased module paths, and fully-qualified
+    identifiers. Returns [None] if no such symbol is accessible. *)
+val find_sym : state -> Term.qident -> Term.sym option
+
+(** [restore_time st] activates the timed state (loaded signatures, library
+    mappings, ...) captured when [st] was computed. LSP handlers must call
+    this before touching timed globals, otherwise they see whichever
+    document was opened most recently. *)
+val restore_time : state -> unit
+
 (** [set_initial_time ()] records the current imperative state as the rollback
     "time" for the [initial_state] function. This is only useful to initialise
     or reinitialise the pure interface. *)


### PR DESCRIPTION
## 1. Fix go-to-definition and hover

Four bugs in `do_definition`/`hover_symInfo`. Three share a root cause: the handlers carried hand-rolled conversions (URI vs path, short-name vs qualified lookup, 1-based vs 0-based columns) instead of reusing the helpers the rest of the codebase uses.

### 1a. Go-to-definition on an external symbol lands at line 1 of the target file

- **Issue:** Go-to-definition on any symbol defined in another module always points to line 1 of the file.
- **Cause:** `do_definition` compared the symbol's `sym_pos.fname` (a raw filesystem path) against `doc.uri` (a `file://` URI). The comparison never succeeds for external symbols, so the code fell back to a synthesized line-1 position.
- **Fix:** use `sym_pos` directly when present; `mk_definfo` takes the filesystem path (the only thing its caller ever passes) and builds the URI from it.

### 1b. Qualified identifiers resolve to the wrong symbol; aliases don't resolve at all

- **Issue:** 
(i). go-to-definition/hover on `M.foo` while a local symbol is also named `foo` targets the local `foo`. 
(ii). go-to-definition/hover on a qualified symbol (i.e.,  `A.foo` given `require M as A;`) gives no result.
- **Cause:** the handlers looked the name up in the flat in-scope short-name map, trying the unqualified name first, with no knowledge of module aliases.
- **Fix:** new `Pure.find_sym` wrapping `Sig_state.find_sym` as used by scoper, with correct shadowing precedence and alias support. Both handlers now pass the full qualified identifier through it.

### 1c. Hover highlights a range shifted one column to the left

- **Cause:** `hover_symInfo` was the only handler still assembling its range JSON by hand, and its column arithmetic had drifted: a stale `column - 1` from when columns were 1-based.
- **Fix:** new helper `LSP.mk_range_of_interval`; hover now uses the same `Range.t` → JSON conversion that diagnostics and go-to-definition go through.

### 1d. Illegal positions reach the client

- **Issue:**  LSP positions must be `uinteger` with `start <= end`.
- **Fix:** `json_of_range` sanitizes every outgoing range: coordinates floored at 0, inverted ranges collapsed to a caret at their start.

## 2. Requests on one document run against another document's state

- **Issue:** open document A, then open document B from a different package; any go-to-definition / hover / documentSymbol request on A afterwards resolves paths against B's configuration. 
e.g., with `Foo.lp` open, opening `Nat.lp` from Stdlib made subsequent queries in `Foo.lp` produce URIs relative to `<lib_root>/Stdlib/...` rather than that of the package. 
- **Cause:** `Pure.initial_state` does `Time.restore t0` and re-applies the opened file's package config, which installs that file's library mappings and *wipes the mappings of every other open document* (they live in timed state).
- **Fix:** expose `Pure.restore_time` and call it at the start of `do_definition`, `hover_symInfo` and `do_symbols`, so each request restores the timed state saved with its own document before touching timed globals like `Library.lib_mappings`.
