### PR TITLE
fix matching with higher-order non-linear LHS

### DIFF
--- a/src/common/debug.ml
+++ b/src/common/debug.ml
@@ -39,11 +39,11 @@ module D = struct
 
   let array : 'a pp -> 'a array pp = fun elt ppf a ->
     let n = Array.length a in
-    if n = 0 then out ppf "[]"
+    if n = 0 then out ppf "[||]"
     else begin
-      out ppf "[%a" elt a.(0);
+      out ppf "[|%a" elt a.(0);
       for i = 1 to n-1 do out ppf "; %a" elt a.(i) done;
-      out ppf "]"
+      out ppf "|]"
     end
 
   let hashtbl : 'a pp -> 'b pp -> ('a, 'b) Hashtbl.t pp = fun key elt ->
@@ -54,7 +54,7 @@ module D = struct
     -> 'key pp -> string -> 'elt pp -> string -> 'map pp =
     fun iter key sep1 elt sep2 ppf m ->
     let f k t = out ppf "%a%s%a%s" key k sep1 elt t sep2 in
-    out ppf "["; iter f m; out ppf "]"
+    out ppf "{"; iter f m; out ppf "}"
 
   let strmap : 'a pp -> 'a StrMap.t pp = fun elt ->
     map StrMap.iter string "," elt ";"

--- a/src/common/logger.ml
+++ b/src/common/logger.ml
@@ -64,6 +64,10 @@ let make logger_key logger_name logger_desc =
 
   logger.logger_pp
 
+(** Check that [c] is a registered key. *)
+let is_registered c =
+  List.exists (fun {logger_key;_} -> logger_key = c) Stdlib.(!loggers)
+
 (** [set_debug value key] enables or disables the loggers corresponding to
    every character of [str] according to [value]. *)
 let set_debug value str =

--- a/src/common/logger.mli
+++ b/src/common/logger.mli
@@ -14,6 +14,9 @@ type logger_pp = { pp: 'a. 'a outfmt -> 'a }
 (** [make key name desc] registers a new logger and returns its pp. *)
 val make : char -> string -> string -> logger_pp
 
+(** Check that [c] is a registered key. *)
+val is_registered : char -> bool
+
 (** [set_debug value key] enables or disables the loggers corresponding to
    every character of [str] according to [value]. *)
 val set_debug : bool -> string -> unit

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -34,6 +34,10 @@ let log_snf = log_snf.pp
 let log_conv = Logger.make 'c' "conv" "conversion"
 let log_conv = log_conv.pp
 
+(** Logging function for rewriting. *)
+(*let log_rew = Logger.make 'q' "rewr" "rewriting"
+let log_rew = log_rew.pp*)
+
 (** Convert modulo eta. *)
 let eta_equality : bool Timed.ref = Console.register_flag "eta_equality" false
 
@@ -294,6 +298,9 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
      indexes defined during tree build, and [id_vars] is the inverse mapping
      of [vars_id]. *)
   let rec walk tree stk cursor vars_id id_vars =
+    if Logger.log_enabled() then
+      log_whnf "%atree_walk %a %d %a" D.depth !depth (D.list term) stk cursor
+        (D.map VarMap.iter Raw.var "," D.int ";") vars_id;
     let open Tree_type in
     match tree with
     | Fail -> None
@@ -308,8 +315,10 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
           match bound.(pos) with
           | Some(_) -> env.(slot) <- bound.(pos)
           | None    ->
-                let xs = Array.map (fun e -> IntMap.find e id_vars) xs in
-                env.(slot) <- Some(bind_mvar xs vars.(pos))
+              let f e = try IntMap.find e id_vars
+                        with Not_found -> assert false in
+              let xs = Array.map f xs in
+              env.(slot) <- Some(bind_mvar xs vars.(pos))
         in
         List.iter f rhs_subst;
         (* Complete the array with fresh meta-variables if needed. *)
@@ -320,8 +329,18 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
     | Cond({ok; cond; fail})                              ->
         let next =
           match cond with
-          | CondNL(i, j) ->
-            if eq_modulo whnf cfg vars.(i) vars.(j) then ok else fail
+          | CondNL((i,vi), (j,vj)) ->
+              if Logger.log_enabled() then
+                log_whnf "%aCondNL(%d[%a],%d[%a]) %a ≟ %a" D.depth !depth
+                  i (Array.pp D.int ",") vi j (Array.pp D.int ",") vj
+                  Raw.term vars.(i) Raw.term vars.(j);
+              let f id = try IntMap.find id id_vars
+                        with Not_found -> assert false in
+              let vj = Array.map f vj in
+              let bj = bind_mvar vj vars.(j) in
+              let vi = Array.map (fun id -> mk_Vari (f id)) vi in
+              let tj = msubst bj vi in
+              if eq_modulo whnf cfg vars.(i) tj then ok else fail
           | CondFV(i,xs) ->
               let allowed =
                 (* Variables that are allowed in the term. *)

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -315,9 +315,9 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
           match bound.(pos) with
           | Some(_) -> env.(slot) <- bound.(pos)
           | None    ->
-              let f e = try IntMap.find e id_vars
-                        with Not_found -> assert false in
-              let xs = Array.map f xs in
+              let var id = try IntMap.find id id_vars
+                           with Not_found -> assert false in
+              let xs = Array.map var xs in
               env.(slot) <- Some(bind_mvar xs vars.(pos))
         in
         List.iter f rhs_subst;
@@ -334,11 +334,11 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
                 log_rew "%aCondNL(%d[%a],%d[%a]) %a ≟ %a" D.depth !depth
                   i (Array.pp D.int ",") vi j (Array.pp D.int ",") vj
                   Raw.term vars.(i) Raw.term vars.(j);
-              let f id = try IntMap.find id id_vars
-                        with Not_found -> assert false in
-              let vj = Array.map f vj in
+              let var id = try IntMap.find id id_vars
+                           with Not_found -> assert false in
+              let vj = Array.map var vj in
               let bj = bind_mvar vj vars.(j) in
-              let vi = Array.map (fun id -> mk_Vari (f id)) vi in
+              let vi = Array.map (fun id -> mk_Vari (var id)) vi in
               let tj = msubst bj vi in
               if eq_modulo whnf cfg vars.(i) tj then ok else fail
           | CondFV(i,xs) ->

--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -35,8 +35,8 @@ let log_conv = Logger.make 'c' "conv" "conversion"
 let log_conv = log_conv.pp
 
 (** Logging function for rewriting. *)
-(*let log_rew = Logger.make 'q' "rewr" "rewriting"
-let log_rew = log_rew.pp*)
+let log_rew = Logger.make 'q' "rewr" "rewriting"
+let log_rew = log_rew.pp
 
 (** Convert modulo eta. *)
 let eta_equality : bool Timed.ref = Console.register_flag "eta_equality" false
@@ -299,7 +299,7 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
      of [vars_id]. *)
   let rec walk tree stk cursor vars_id id_vars =
     if Logger.log_enabled() then
-      log_whnf "%atree_walk %a %d %a" D.depth !depth (D.list term) stk cursor
+      log_rew "%atree_walk %a %d %a" D.depth !depth (D.list term) stk cursor
         (D.map VarMap.iter Raw.var "," D.int ";") vars_id;
     let open Tree_type in
     match tree with
@@ -331,7 +331,7 @@ and tree_walk : config -> dtree -> stack -> (term * stack) option =
           match cond with
           | CondNL((i,vi), (j,vj)) ->
               if Logger.log_enabled() then
-                log_whnf "%aCondNL(%d[%a],%d[%a]) %a ≟ %a" D.depth !depth
+                log_rew "%aCondNL(%d[%a],%d[%a]) %a ≟ %a" D.depth !depth
                   i (Array.pp D.int ",") vi j (Array.pp D.int ",") vj
                   Raw.term vars.(i) Raw.term vars.(j);
               let f id = try IntMap.find id id_vars

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -48,7 +48,7 @@ let pr_bound = D.array (fun ppf b -> if b then out ppf "*" else out ppf "_")
 type var = int * string
 
 (** [compare_vars x y] safely compares [x] and [y]. Note that it is unsafe to
-    compare variables using [Pervasive.compare]. *)
+    compare variables using [Stdlib.compare]. *)
 let compare_vars : var -> var -> int = fun (i,_) (j,_) -> Stdlib.compare i j
 
 (** [eq_vars x y] safely computes the equality of [x] and [y]. Note that it is
@@ -985,6 +985,7 @@ let new_problem : unit -> problem = fun () ->
 
 (** Printing functions for debug. *)
 module Raw = struct
+  let var = var let _ = var
   let sym = sym let _ = sym
   let term = term let _ = term
   let ctxt = ctxt let _ = ctxt

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -461,6 +461,7 @@ val rhs : sym_rule -> term
 
 (** Basic printing function (for debug). *)
 module Raw : sig
+  val var : var pp
   val sym : sym pp
   val term : term pp
   val ctxt : ctxt pp

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -97,22 +97,22 @@ module CP = struct
   let is_empty : t -> bool = fun pool ->
     PSet.is_empty pool.nl_conds && IntMap.is_empty pool.fv_conds
 
-  (** [register_nl slot i vs pool] registers the fact that the slot [slot] in
-      the [vars] array correspond to a term stored at index [i] in the
+  (** [register_nl i (slot,vs) pool] registers the fact that the slot [slot]
+      in the [vars] array correspond to a term stored at index [i] in the
       environment for the RHS. The first time that such a slot is associated
       to [i], it is registered to serve as a reference point for testing
       convertibility when (and if) another such slot is (ever)
       encountered. When that is the case, a convertibility constraint is
       registered between the term stored in the slot [slot] and the term
       stored in the reference slot. *)
-  let register_nl : int -> int -> int array -> t -> t = fun slot i vs pool ->
+  let register_nl : int -> pvar -> t -> t = fun i pv pool ->
     try
       (* We build a new condition if there is already a point of reference. *)
-      let cond = (IntMap.find i pool.variables, (slot,vs)) in
+      let cond = (IntMap.find i pool.variables, pv) in
       { pool with nl_conds = PSet.add cond pool.nl_conds }
     with Not_found ->
       (* First occurence of [i], register the slot as a point of reference. *)
-      { pool with variables = IntMap.add i (slot,vs) pool.variables }
+      { pool with variables = IntMap.add i pv pool.variables }
 
   (** [register_fv slot xs pool] registers a free variables constraint for the
       variables in [xs] on the slot [slot] of the [vars] array in [pool]. *)
@@ -136,8 +136,7 @@ module CP = struct
   (** [remove cond pool] removes condition [cond] from the pool [pool]. *)
   let remove cond pool =
     match cond with
-    | CondNL(i,j) ->
-        {pool with nl_conds = PSet.remove (i,j) pool.nl_conds}
+    | CondNL(i,j) -> {pool with nl_conds = PSet.remove (i,j) pool.nl_conds}
     | CondFV(i,xs) ->
         try
           let ys = IntMap.find i pool.fv_conds in
@@ -480,7 +479,7 @@ module CM = struct
                 log "Registering non linearity constraint on position [%a] \
                      on %d"
                   arg_path a.arg_path i;
-              CP.register_nl mem i vs cond_pool
+              CP.register_nl i (mem,vs) cond_pool
           | None    -> cond_pool
         in
         let c_subst =

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -67,15 +67,13 @@ module CP = struct
   (** Functional sets of pairs of integers. *)
   module PSet = Set.Make(
     struct
-      type t = int * int
-
-      let compare : t -> t -> int = fun (i1,i2) (j1,j2) ->
-        match i1 - j1 with 0 -> i2 - j2 | k -> k
+      type t = (int * int array) * (int * int array)
+      let compare = Stdlib.compare
     end)
 
   (** A pool of (convertibility and free variable) conditions. *)
   type t =
-    { variables : int IntMap.t
+    { variables : (int * int array) IntMap.t
     (** An association [(e, v)] maps the slot of a pattern variable (the first
         argument of a [Term.term.Patt]) to its slot in the array
         [vars] of the [Eval.tree_walk] function. It is used to remember
@@ -99,21 +97,22 @@ module CP = struct
   let is_empty : t -> bool = fun pool ->
     PSet.is_empty pool.nl_conds && IntMap.is_empty pool.fv_conds
 
-  (** [register_nl slot i pool] registers the fact that the slot [slot] in the
-      [vars] array correspond to a term stored at index [i] in the environment
-      for the RHS. The first time that such a slot is associated to [i], it is
-      registered to serve as a reference point for testing convertibility when
-      (and if) another such slot is (ever) encountered. When that is the case,
-      a convertibility constraint is registered between the term stored in the
-      slot [slot] and the term stored in the reference slot. *)
-  let register_nl : int -> int -> t -> t = fun slot i pool ->
+  (** [register_nl slot i vs pool] registers the fact that the slot [slot] in
+      the [vars] array correspond to a term stored at index [i] in the
+      environment for the RHS. The first time that such a slot is associated
+      to [i], it is registered to serve as a reference point for testing
+      convertibility when (and if) another such slot is (ever)
+      encountered. When that is the case, a convertibility constraint is
+      registered between the term stored in the slot [slot] and the term
+      stored in the reference slot. *)
+  let register_nl : int -> int -> int array -> t -> t = fun slot i vs pool ->
     try
       (* We build a new condition if there is already a point of reference. *)
-      let cond = (IntMap.find i pool.variables, slot) in
+      let cond = (IntMap.find i pool.variables, (slot,vs)) in
       { pool with nl_conds = PSet.add cond pool.nl_conds }
     with Not_found ->
       (* First occurence of [i], register the slot as a point of reference. *)
-      { pool with variables = IntMap.add i slot pool.variables }
+      { pool with variables = IntMap.add i (slot,vs) pool.variables }
 
   (** [register_fv slot xs pool] registers a free variables constraint for the
       variables in [xs] on the slot [slot] of the [vars] array in [pool]. *)
@@ -137,7 +136,8 @@ module CP = struct
   (** [remove cond pool] removes condition [cond] from the pool [pool]. *)
   let remove cond pool =
     match cond with
-    | CondNL(i,j)  -> {pool with nl_conds = PSet.remove (i,j) pool.nl_conds}
+    | CondNL(i,j) ->
+        {pool with nl_conds = PSet.remove (i,j) pool.nl_conds}
     | CondFV(i,xs) ->
         try
           let ys = IntMap.find i pool.fv_conds in
@@ -467,9 +467,10 @@ module CM = struct
     match fst (get_args r.c_lhs.(ci)) with
     | Patt(i, _, e) ->
         let (_, a, _) = List.destruct pos ci in
+        let vs = Array.map (index_var vi) e in
         let cond_pool =
-          if (Array.length e) <> a.arg_rank then
-            CP.register_fv mem (Array.map (index_var vi) e) r.cond_pool
+          if Array.length e <> a.arg_rank then
+            CP.register_fv mem vs r.cond_pool
           else r.cond_pool
         in
         let cond_pool =
@@ -479,7 +480,7 @@ module CM = struct
                 log "Registering non linearity constraint on position [%a] \
                      on %d"
                   arg_path a.arg_path i;
-              CP.register_nl mem i cond_pool
+              CP.register_nl mem i vs cond_pool
           | None    -> cond_pool
         in
         let c_subst =
@@ -496,7 +497,7 @@ module CM = struct
           let se i (_,(j,_)) = i = j in
           match i with
           | Some(i) when not (List.exists (se i) r.c_subst) ->
-              (mem, (i, Array.map (index_var vi) e)) :: r.c_subst
+              (mem, (i,vs)) :: r.c_subst
           | _ -> r.c_subst
         in
         {r with c_subst; cond_pool}
@@ -760,8 +761,7 @@ let compile : match_strat -> CM.t -> tree = fun mstrat m ->
         in
         (* Add [var] to the variables that may appear free in patterns. *)
         let vars_id = VarMap.add var v_lvl vars_id in
-        let next =
-          compile vars_id CM.{clauses; slot; positions}
+        let next = compile vars_id CM.{clauses; slot; positions}
         in
         Some(v_lvl, next)
       in

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -136,7 +136,7 @@ module CP = struct
   (** [remove cond pool] removes condition [cond] from the pool [pool]. *)
   let remove cond pool =
     match cond with
-    | CondNL(i,j) -> {pool with nl_conds = PSet.remove (i,j) pool.nl_conds}
+    | CondNL(i,j)  -> {pool with nl_conds = PSet.remove (i,j) pool.nl_conds}
     | CondFV(i,xs) ->
         try
           let ys = IntMap.find i pool.fv_conds in

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -67,13 +67,13 @@ module CP = struct
   (** Functional sets of pairs of integers. *)
   module PSet = Set.Make(
     struct
-      type t = (int * int array) * (int * int array)
+      type t = pvar * pvar
       let compare = Stdlib.compare
     end)
 
   (** A pool of (convertibility and free variable) conditions. *)
   type t =
-    { variables : (int * int array) IntMap.t
+    { variables : pvar IntMap.t
     (** An association [(e, v)] maps the slot of a pattern variable (the first
         argument of a [Term.term.Patt]) to its slot in the array
         [vars] of the [Eval.tree_walk] function. It is used to remember

--- a/src/core/tree_type.ml
+++ b/src/core/tree_type.ml
@@ -5,6 +5,8 @@ open Common
 
 (** {3 Atomic pattern constructor representation} *)
 
+type pvar = int * int array
+
 (** Representation of an atomic pattern constructor. *)
 module TC =
   struct
@@ -47,11 +49,11 @@ module TCMap = Map.Make(TC)
 
 (** Representation of a branching conditions. *)
 type tree_cond =
-  | CondNL of (int * int array) * (int * int array)
+  | CondNL of pvar * pvar
   (** Are the terms at the given indices convertible? We enforce the invariant
       that the first element is a point of reference, which appears in all the
       convertibility conditions involving a given non-linear variable. *)
-  | CondFV of int * int array
+  | CondFV of pvar
   (** Are the (indexed) bound variables (which are free at the time of the
       checking) of the term at the given index in the array? *)
 
@@ -75,7 +77,7 @@ let tree_cond : tree_cond pp = fun ppf tc ->
     substitutes variable [v] of the RHS by term [p] of array [v]. In the case
     of higher order patterns, [p] may need to be itself subsituted  with {e
     bound} variables [xs] collected when traversing binders. *)
-type rhs_substit = (int * (int * int array)) list
+type rhs_substit = (int * pvar) list
 
 (** Representation of a tree. The definition relies on parameters since module
     [Term] depends on the current module, and that would thus produce

--- a/src/core/tree_type.ml
+++ b/src/core/tree_type.ml
@@ -1,7 +1,7 @@
 (** Miscellaneous types and utilities for decision trees. *)
 
 open Lplib open Base
-open Common
+open Common open Debug
 
 (** {3 Atomic pattern constructor representation} *)
 
@@ -47,7 +47,7 @@ module TCMap = Map.Make(TC)
 
 (** Representation of a branching conditions. *)
 type tree_cond =
-  | CondNL of int * int
+  | CondNL of (int * int array) * (int * int array)
   (** Are the terms at the given indices convertible? We enforce the invariant
       that the first element is a point of reference, which appears in all the
       convertibility conditions involving a given non-linear variable. *)
@@ -63,7 +63,9 @@ type tree_cond =
 
 let tree_cond : tree_cond pp = fun ppf tc ->
   match tc with
-  | CondNL(i, j) -> out ppf "Nl(%d, %d)" i j
+  | CondNL((i,xs), (j,ys)) ->
+      out ppf "Nl(%d[%a],%d[%a])"
+        i (Array.pp D.int ",") xs j (Array.pp D.int ",") ys
   | CondFV(i, _) -> out ppf "Fv(%d)" i
 
 (** Substitution of variables in a RHS. During the filtering process, some

--- a/src/core/tree_type.ml
+++ b/src/core/tree_type.ml
@@ -1,7 +1,7 @@
 (** Miscellaneous types and utilities for decision trees. *)
 
 open Lplib open Base
-open Common open Debug
+open Common
 
 (** {3 Atomic pattern constructor representation} *)
 
@@ -65,7 +65,7 @@ let tree_cond : tree_cond pp = fun ppf tc ->
   match tc with
   | CondNL((i,xs), (j,ys)) ->
       out ppf "Nl(%d[%a],%d[%a])"
-        i (Array.pp D.int ",") xs j (Array.pp D.int ",") ys
+        i (Array.pp int ",") xs j (Array.pp int ",") ys
   | CondFV(i, _) -> out ppf "Fv(%d)" i
 
 (** Substitution of variables in a RHS. During the filtering process, some

--- a/src/export/rawdk.ml
+++ b/src/export/rawdk.ml
@@ -81,9 +81,9 @@ and param : p_term option -> string -> p_ident option pp = fun a sep ppf id ->
 and params : string -> p_params pp = fun sep ppf (ids,a,_) ->
   match ids, a with
   | None::_, None ->
-      fatal_no_pos "Cannot translate \"_\" parameters with no type."
+      fatal_no_pos "Cannot translate \"_\" binder parameters with no type."
   | Some {pos;_}::_, None ->
-      fatal pos "Cannot translate parameters with no type."
+      fatal pos "Cannot translate binder parameters with no type."
   | _ -> List.iter (out ppf "%a" (param a sep)) ids
 
 and params_list : string -> p_params list pp = fun sep ppf ->

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -84,6 +84,8 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
       let s = String.concat "" (List.map f (Logger.log_summary())) in
       return string ("debug flags:"^s)
   | P_query_debug(e,s) ->
+      String.iter (fun c -> if Logger.is_registered c then ()
+                            else fatal pos "Unknown debug flag \'%c\'" c) s;
       Logger.set_debug e s;
       Console.out 1 "debug %s%s" (if e then "+" else "-") s;
       None

--- a/src/handle/rewrite.ml
+++ b/src/handle/rewrite.ml
@@ -6,7 +6,7 @@ open Core open Term open Print
 open Goal
 
 (** Logging function for the rewrite tactic. *)
-let log = Logger.make 'r' "rewr" "rewrite tactic"
+let log = Logger.make 'r' "rtac" "rewrite tactic"
 let log = log.pp
 
 (** Equality configuration. *)

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -134,7 +134,8 @@ let fresh_patt : lhs_data -> string option -> term array -> term =
 let strint = Array.init 11 string_of_int
 
 (** [scope ~find_sym ~typ k md ss env t] turns a parser-level term [t] into an
-    actual term. *)
+    actual term. [k] is the number of space characters to print before the
+    logging data. *)
 let rec scope : ?find_sym:find_sym ->
   ?typ:bool -> int -> mode -> sig_state -> env -> p_term -> term =
   fun ?find_sym ?(typ=false) k md ss env t ->

--- a/src/tool/tree_graphviz.ml
+++ b/src/tool/tree_graphviz.ml
@@ -41,9 +41,10 @@ let tree_to_dot : Format.formatter -> _ dtree -> unit = fun ppf dtree ->
       | DotFailure           -> out ppf "✗"
     in
     let tcstr : tree_cond pp = fun ppf cstr ->
-      let ar = Array.pp int " " in
+      let ar = Array.pp int "," in
       match cstr with
-      | CondNL(i, j) -> out ppf "%d ≡ %d" i j
+      | CondNL((i,vi), (j,vj)) ->
+          out ppf "%d[%a] ≡ %d[%a]" i ar vi j ar vj
       | CondFV(i,vs) -> out ppf "%a ⊆ FV(%d)" ar vs i
     in
     let node_count = ref 0 in

--- a/tests/OK/1362.lp
+++ b/tests/OK/1362.lp
@@ -5,7 +5,7 @@ symbol f:(A → A) → (A → A) → A;
 
 //flag "print_implicits" on;
 //debug;
-//debug +dw;
+//debug +wq;
 
 rule f (λ x,$F.[x]) (λ y,$F.[y]) ↪ a;
 assert ⊢ f (λ x,x) (λ y,y) ≡ a;

--- a/tests/OK/1362.lp
+++ b/tests/OK/1362.lp
@@ -1,0 +1,23 @@
+symbol A:TYPE;
+
+symbol a:A;
+symbol f:(A → A) → (A → A) → A;
+
+//flag "print_implicits" on;
+//debug;
+//debug +dw;
+
+rule f (λ x,$F.[x]) (λ y,$F.[y]) ↪ a;
+assert ⊢ f (λ x,x) (λ y,y) ≡ a;
+
+symbol g:(A → A → A) → (A → A) → A;
+
+rule g (λ x y,$F.[x]) (λ x,$F.[x]) ↪ a;
+assert ⊢ g (λ x y,x) (λ x,x) ≡ a;
+
+symbol h:(A → A → A) → (A → A → A) → A;
+symbol i: A → A → A;
+
+rule h (λ x y,$F.[x;y]) (λ x y,$F.[y;x]) ↪ a;
+assertnot ⊢ h (λ x y,i x y) (λ x y,i x y) ≡ a;
+assert ⊢ h (λ x y,i x y) (λ x y,i y x) ≡ a;

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -68,7 +68,7 @@ do
         # abstracted variable type in rule LHS
         573-2);;
         # domain-free lambda/product
-        298_lp|262_parsing|tail|698_abst_impl|330|330b|1035|varmatch|patt|freevars-constraints|eta_equality|declared|boolean|abstractions|303|301|292|225);;
+        298_lp|262_parsing|tail|698_abst_impl|330|330b|1035|varmatch|patt|freevars-constraints|eta_equality|declared|boolean|abstractions|303|301|292|225|1362);;
         # opaque definition with no type (https://github.com/Deducteam/Dedukti/issues/319)
         547);;
         # aborted proof


### PR DESCRIPTION
LP does not correctly check non-linearities in case of higher-order pattern variables. It checks the convertibility of bodies but the bodies have been obtained with distinct variables. They need to be instantiated with the same variables before checking convertibility. This PR fixes that problem (issue #1362).

Other modifications:
- add new debug flag: q for rewriting
- query.ml/debug command: check that debug flags are valid
- Term.Raw: export var too

TODO?
- change TC.vari type from `int` to `int*int array`?
