### PR TITLE
grammar change: use commas in environments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `simplify` now fails if the goal cannot be simplified.
 - Position of the error is removed from diagnostics when the error occurs in the file currently open in the editor.
 - Change lp parser based on menhir by one written by hand to provide more helpful error messages while being equally efficient.
-- Syntax: use a comma instead of a semicolon as element separator in environments of pattern or meta variables.
+- Syntax: use a comma instead of a semicolon as element separator in environments of pattern or meta variables, and unification rule right hand-sides.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Change lp parser based on menhir by one written by hand to provide more helpful error messages while being equally efficient.
 - Syntax: use a comma instead of a semicolon as element separator in environments of pattern or meta variables.
 
+### Fixed
+
+- Convertibility test of non-linear higher-order pattern variables in rule LHS.
+
 ## 3.0.0 (2025-07-16)
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `simplify` now fails if the goal cannot be simplified.
 - Position of the error is removed from diagnostics when the error occurs in the file currently open in the editor.
 - Change lp parser based on menhir by one written by hand to provide more helpful error messages while being equally efficient.
+- Syntax: use a comma instead of a semicolon as element separator in environments of pattern or meta variables.
 
 ## 3.0.0 (2025-07-16)
 

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -559,8 +559,8 @@ Examples:
 ::
 
    unif_rule Bool ≡ T $t ↪ [ $t ≡ bool ];
-   unif_rule $x + $y ≡ 0 ↪ [ $x ≡ 0; $y ≡ 0 ];
-   unif_rule $a → $b ≡ T $c ↪ [ $a ≡ T $a'; $b ≡ T $b'; $c ≡ arrow $a' $b' ];
+   unif_rule $x + $y ≡ 0 ↪ [ $x ≡ 0, $y ≡ 0 ];
+   unif_rule $a → $b ≡ T $c ↪ [ $a ≡ T $a', $b ≡ T $b', $c ≡ arrow $a' $b' ];
 
 Thanks to the first unification rule, a problem ``T ?x ≡ Bool`` is
 transformed into ``?x ≡ bool``.

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -368,11 +368,11 @@ ambiguity, i.e. when the variable is not under a binder (unlike in the
 rule η above).
 
 It is possible to define an unnamed pattern variable with the syntax
-``$_.[x;y]``.
+``$_.[x,y]``.
 
 The unnamed pattern variable ``_`` is always the most general: if ``x``
 and ``y`` are the only variables in scope, then ``_`` is equivalent to
-``$_.[x;y]``.
+``$_.[x,y]``.
 
 In rule left-hand sides, λ-expressions cannot have type annotations.
 

--- a/editors/emacs/lambdapi-smie.el
+++ b/editors/emacs/lambdapi-smie.el
@@ -75,7 +75,7 @@ Indent by `lambdapi-indent-basic' in proofs, and 0 otherwise."
 (defconst lambdapi-smie-bnf
   '((ident)
       (env (ident)
-           (ident ";"))
+           (ident ","))
       (rw-patt)
       (args (ident)
             ("{" ident ":" sterm "}")

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -353,7 +353,7 @@ let term_in idmap ppf t = func idmap ppf (cleanup t)
 let term = term_in StrMap.empty
 
 let env ppf ts =
-  if Array.length ts > 0 then out ppf ".[%a]" (Array.pp term ";") ts
+  if Array.length ts > 0 then out ppf ".[%a]" (Array.pp term ",") ts
 
 let rec prod_in : int StrMap.t -> (term * bool list) pp =
   let decl idmap ppf (x,t) = out ppf "%a : %a" var x (func idmap) t in

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -166,6 +166,9 @@ let are_quant_args : term list -> bool = fun args ->
   | [b] -> is_abst b
   | _ -> false
 
+let env term ppf ts =
+  if Array.length ts > 0 then out ppf ".[%a]" (Array.pp term ",") ts
+
 (** The possible priority levels are [`Func] (top level, including abstraction
    and product), [`Appl] (application) and [`Atom] (smallest priority). *)
 type priority = [`Func | `Appl | `Atom]
@@ -260,10 +263,6 @@ and quantifier idmap ppf s args =
 and meta ppf m = out ppf "?%d" m.meta_key
 
 and head idmap wrap ppf t =
-  let env ppf ts =
-    if Array.length ts > 0 then
-      out ppf ".[%a]" (Array.pp (func idmap) ";") ts
-  in
   match unfold t with
   | Appl(_,_)   -> assert false
   (* Application is handled separately, unreachable. *)
@@ -277,9 +276,9 @@ and head idmap wrap ppf t =
   | Type        -> out ppf "TYPE"
   | Kind        -> out ppf "KIND"
   | Symb(s)     -> sym ppf s
-  | Meta(m,e)   -> meta ppf m; if !print_meta_args then env ppf e
+  | Meta(m,e)   -> meta ppf m; if !print_meta_args then env (func idmap) ppf e
   | Plac(_)     -> out ppf "_"
-  | Patt(_,n,e) -> out ppf "$%a%a" uid n env e
+  | Patt(_,n,e) -> out ppf "$%a%a" uid n (env (func idmap)) e
   | Bvar _      -> assert false
   (* Product and abstraction (only them can be wrapped). *)
   | Abst(a,b)   ->
@@ -352,8 +351,7 @@ let term_in idmap ppf t = func idmap ppf (cleanup t)
 
 let term = term_in StrMap.empty
 
-let env ppf ts =
-  if Array.length ts > 0 then out ppf ".[%a]" (Array.pp term ",") ts
+let env = env term
 
 let rec prod_in : int StrMap.t -> (term * bool list) pp =
   let decl idmap ppf (x,t) = out ppf "%a : %a" var x (func idmap) t in

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -358,23 +358,21 @@ let rec term : term pp = fun ppf t ->
   | Kind -> out ppf "KIND"
   | Symb s -> sym ppf s
   | Prod(a,(n,b,e)) ->
-      out ppf "(Π %s:%a, %a#(%a))" n.binder_name term a clos_env e term b
+      out ppf "(Π %s:%a, %a#(%a))" n.binder_name term a terms e term b
   | Abst(a,(n,b,e)) ->
-      out ppf "(λ %s:%a, %a#(%a))" n.binder_name term a clos_env e term b
+      out ppf "(λ %s:%a, %a#(%a))" n.binder_name term a terms e term b
   | Appl(a,b) -> out ppf "(%a %a)" term a term b
   | Meta(m,ts) -> out ppf "?%d%a" m.meta_key terms ts
-  | Patt(i,s,ts) -> out ppf "$%a_%s%a" (D.option D.int) i s terms ts
+  | Patt(i,s,ts) -> out ppf "$%a_%s%a" (D.option int) i s terms ts
   | Plac(_) -> out ppf "_"
   | Wild -> out ppf "_"
   | TRef r -> out ppf "&%a" (Option.pp term) Timed.(!r)
   | LLet(a,t,(n,b,e)) ->
       out ppf "let %s:%a ≔ %a in %a#(%a)"
-        n.binder_name term a term t clos_env e term b
+        n.binder_name term a term t terms e term b
 and var : var pp = fun ppf (i,n) -> out ppf "%s%d" n i
 and sym : sym pp = fun ppf s -> string ppf s.sym_name
-and terms : term array pp = fun ppf ts ->
-  if Array.length ts > 0 then D.array term ppf ts
-and clos_env : term array pp =  fun ppf env -> D.array term ppf env
+and terms : term array pp = fun ppf -> out ppf "[%a]" (Array.pp term ",")
 
 (** [unfold t] repeatedly unfolds the definition of the surface constructor
    of [t], until a significant {!type:term} constructor is found.  The term
@@ -428,7 +426,7 @@ and msubst : mbinder -> term array -> term = fun (bi,tm,env) vs ->
     then tm
     else msubst tm in
   if Logger.log_enabled() then
-    log "msubst %a#%a %a = %a" clos_env env term tm (D.array term) vs term r;
+    log "msubst %a#%a %a = %a" terms env term tm terms vs term r;
   r
 
 (** Total order on terms. *)
@@ -683,7 +681,7 @@ let subst : binder -> term -> term = fun (bi,tm,env) v ->
     if bi.binder_bound = false &&  Array.length env = 0 then tm
     else subst tm in
   if Logger.log_enabled() then
-    log "subst %a#%a [%a] = %a" clos_env env term tm term v term r;
+    log "subst %a#%a [%a] = %a" terms env term tm term v term r;
   r
 
 (** [unbind b] substitutes the binder [b] by a fresh variable of name [name]

--- a/src/export/dk.ml
+++ b/src/export/dk.ml
@@ -147,30 +147,6 @@ let rec term : bool -> term pp = fun b ppf t ->
 
 (** Translation of declarations. *)
 
-let modifiers : sym -> string = fun s ->
-  match s.sym_expo with
-  | Public ->
-      begin
-        match s.sym_prop with
-        | Const -> ""
-        | Defin -> "def "
-        | Injec -> "injective "
-        | AC _ -> "defac "
-        | Commu -> assert false
-        | Assoc _ -> assert false
-      end
-  | Protec ->
-      begin
-        match s.sym_prop with
-        | Const -> ""
-        | Defin -> "private "
-        | Injec -> "private injective "
-        | AC _ -> "private defac "
-        | Commu -> assert false
-        | Assoc _ -> assert false
-      end
-  | Privat -> assert false
-
 (* Dedukti only accepts the following declarations:
 def s : A := t
 thm s : A := t

--- a/src/export/dk.ml
+++ b/src/export/dk.ml
@@ -147,47 +147,67 @@ let rec term : bool -> term pp = fun b ppf t ->
 
 (** Translation of declarations. *)
 
-let modifiers : sym -> string list = fun s ->
-  let open Stdlib in
-  let r = ref [] in
-  let add m = r := m::!r in
-  begin
-    match s.sym_prop with
-    | Const -> ()
-    | Injec -> add "injective"
-    | AC _ -> add "defac"
-    | Defin -> add "def"
-    | Assoc _ -> assert false
-    | Commu -> assert false
-  end;
-  if s.sym_expo = Protec then add "private";
-  !r
+let modifiers : sym -> string = fun s ->
+  match s.sym_expo with
+  | Public ->
+      begin
+        match s.sym_prop with
+        | Const -> ""
+        | Defin -> "def "
+        | Injec -> "injective "
+        | AC _ -> "defac "
+        | Commu -> assert false
+        | Assoc _ -> assert false
+      end
+  | Protec ->
+      begin
+        match s.sym_prop with
+        | Const -> ""
+        | Defin -> "private "
+        | Injec -> "private injective "
+        | AC _ -> "private defac "
+        | Commu -> assert false
+        | Assoc _ -> assert false
+      end
+  | Privat -> assert false
+
+(* Dedukti only accepts the following declarations:
+def s : A := t
+thm s : A := t
+
+injective s : A
+private s : A
+private injective s : A
+def s : A
+defac s [A]
+private defac [A]
+*)
+let sym_type : sym pp = fun ppf s ->
+  match s.sym_prop with
+  | AC _ ->
+      out ppf "[%a]" (term true)
+        (match unfold !(s.sym_type) with Prod(t,_) -> t | _ -> assert false)
+  | _ -> out ppf ": %a" (term true) !(s.sym_type)
+
+let sym_decl_only : sym pp = fun ppf s ->
+  out ppf "%s%s%a %a.@."
+    (if s.sym_expo = Protec then "private " else "")
+    (match s.sym_prop with
+     | AC _ -> "defac " | Injec -> "injective" | _ -> "")
+    ident s.sym_name sym_type s
 
 let sym_decl : sym pp = fun ppf s ->
   match !(s.sym_def) with
-  | None ->
-    begin match s.sym_prop with
-      | AC _ ->
-        begin match unfold !(s.sym_type) with
-          | Prod(t,_) ->
-            out ppf "%a%a [%a].@."
-              (List.pp (suffix string " ") "") (modifiers s)
-              ident s.sym_name (term true) t
-          | _ -> assert false
-        end
-      | _ ->
-        out ppf "%a%a : %a.@."
-          (List.pp (suffix string " ") "") (modifiers s)
-          ident s.sym_name (term true) !(s.sym_type)
-    end
+  | None -> sym_decl_only ppf s
   | Some d ->
-    if !(s.sym_opaq) then
-      out ppf "thm %a : %a := %a.@."
-        ident s.sym_name (term true) !(s.sym_type) (term true) d
-    else
-      out ppf "%a%a : %a := %a.@."
-        (List.pp (suffix string " ") "") (modifiers s)
-        ident s.sym_name (term true) !(s.sym_type) (term true) d
+      (* in case of an AC, injective or protected symbol, we need to give the
+         definition in a rule after the declaration *)
+      if is_modulo s || s.sym_prop = Injec || s.sym_expo = Protec then
+        out ppf "%a[]%s --> %a.@." sym_decl_only s s.sym_name (term true) d
+      else
+        out ppf "%s%a : %a := %a.@."
+          (if !(s.sym_opaq) then "thm " else "def ")
+          ident s.sym_name (term true) !(s.sym_type) (term true) d
 
 let rule_decl : (Path.t * string * rule) pp = fun ppf (p, n, r) ->
   let rec var ppf i =

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -513,7 +513,7 @@ let rec command pos1 (p_sym_mod:p_modifier list) (lb:lexbuf): p_command =
       consume HOOK_ARROW lb;
       consume L_SQ_BRACKET lb;
       let eq1 = equation lb in
-      let eqs = list (prefix SEMICOLON equation) lb in
+      let eqs = list (prefix COMMA equation) lb in
       let es = eq1::eqs in
       consume R_SQ_BRACKET lb;
       (* FIXME: give sensible positions instead of Pos.none and P.appl. *)

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -1448,7 +1448,7 @@ and env (lb:lexbuf): p_term list =
             []
         | _ ->
             let t = term lb in
-            let ts = list (prefix SEMICOLON term) lb in
+            let ts = list (prefix COMMA term) lb in
             consume R_SQ_BRACKET lb;
             t::ts
       end

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -125,7 +125,7 @@ let rec term : p_term pp = fun ppf t ->
       match ts with
       | None -> ()
       | Some [||] when !empty_context -> ()
-      | Some ts -> out ppf ".[%a]" (Array.pp func "; ") ts
+      | Some ts -> out ppf ".[%a]" (Array.pp func ",") ts
     in
     match (t.elt, priority) with
     | (P_Type              , _    ) -> out ppf "TYPE"
@@ -219,7 +219,7 @@ let unif_rule : p_rule pp = fun ppf {elt=(l,r);_} ->
     | (_, [t; u]) -> (t, u)
     | _           -> assert false
   in
-  out ppf "%a ↪ [%a]" equiv lhs (List.pp equiv "; ") (unpack r)
+  out ppf "%a ↪ [%a]" equiv lhs (List.pp equiv ", ") (unpack r)
 
 let proof_end : p_proof_end pp = fun ppf pe ->
   out ppf (match pe.elt with

--- a/tests/OK/1362.lp
+++ b/tests/OK/1362.lp
@@ -3,10 +3,6 @@ symbol A:TYPE;
 symbol a:A;
 symbol f:(A → A) → (A → A) → A;
 
-//flag "print_implicits" on;
-//debug;
-//debug +wq;
-
 rule f (λ x,$F.[x]) (λ y,$F.[y]) ↪ a;
 assert ⊢ f (λ x,x) (λ y,y) ≡ a;
 

--- a/tests/OK/1362.lp
+++ b/tests/OK/1362.lp
@@ -18,6 +18,6 @@ assert ⊢ g (λ x y,x) (λ x,x) ≡ a;
 symbol h:(A → A → A) → (A → A → A) → A;
 symbol i: A → A → A;
 
-rule h (λ x y,$F.[x;y]) (λ x y,$F.[y;x]) ↪ a;
+rule h (λ x y,$F.[x,y]) (λ x y,$F.[y,x]) ↪ a;
 assertnot ⊢ h (λ x y,i x y) (λ x y,i x y) ≡ a;
 assert ⊢ h (λ x y,i x y) (λ x y,i y x) ≡ a;

--- a/tests/OK/abstractions.lp
+++ b/tests/OK/abstractions.lp
@@ -2,7 +2,7 @@
 symbol R : TYPE;
 
 symbol flip : (R → R → R) → (R → R → R);
-rule flip (λ x, λ y, $f.[x; y]) ↪ λ (x:R), λ (y:R), $f.[y; x];
+rule flip (λ x, λ y, $f.[x,y]) ↪ λ (x:R), λ (y:R), $f.[y,x];
 
 symbol f : R → R → R;
 symbol x : R;

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -24,7 +24,7 @@ symbol iz: I z;
 //    &x ≡ z   &y ≡ z
 // -------------------
 //    + &x &y ≡ z
-unif_rule (+ $x $y) ≡ z ↪ [ $x ≡ z; $y ≡ z ];
+unif_rule (+ $x $y) ≡ z ↪ [ $x ≡ z, $y ≡ z ];
 // Trigger the unification problem + ?1 ?2 ≡ z
 type H (+ _ _) iz;
 
@@ -42,7 +42,7 @@ compute J (pair _ z) kz;
 // The arrow problem
 constant symbol arrow : Set → Set → Set;
 rule El (arrow $t $u) ↪ El $t → El $u;
-unif_rule $a → $b ≡ El $c ↪ [ $a ≡ El $ea; $b ≡ El $eb; $c ≡ arrow $ea $eb ];
+unif_rule $a → $b ≡ El $c ↪ [ $a ≡ El $ea, $b ≡ El $eb, $c ≡ arrow $ea $eb ];
 symbol eq (t: Set): El t → El t → Bool;
 type eq _ (λ _, z) (λ _, z);
 


### PR DESCRIPTION
This PR proposes the following small grammar change:
- in rule LHS write `$M.[x,y]` instead of `$M.[x;y]`
- in unification rule RHS, write `[a,b]` instead of `[a;b]`