### PR TITLE
Eval tactic: weak head normalize argument step by step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `simplify` now fails if the goal cannot be simplified.
 - Position of the error is removed from diagnostics when the error occurs in the file currently open in the editor.
-- Change lp parser based on menhir by one written by hand to provide more helpful error messages while being equally efficient.
+- Change lp parser based on Menhir by one written by hand to provide more helpful error messages while being equally efficient.
+- Replace full SNF reduction of tactic terms by a more incremental reduction strategy using WHNF and recursively reducing only subterms that are tactic terms.
+- Infer the type and solve unification constraints of tactic terms before reduction and interpretation as tactics.
 
 ### Fixed
 

--- a/doc/tacticals.rst
+++ b/doc/tacticals.rst
@@ -64,14 +64,14 @@ An example of use is given in `Tactic.lp <https://github.com/Deducteam/lambdapi/
 ``orelse``
 ----------
 
-``orelse T1 T2`` applies ``T1``. If ``T1`` succeeds, then ``orelse T1 T2`` stops. Otherwise, ``orelse T1 T2`` applied ``T2``.
+``orelse T1 T2`` applies ``T1``. If ``T1`` succeeds, then ``orelse T1 T2`` stops. Otherwise, ``orelse T1 T2`` applies ``T2``.
 
 .. _repeat:
 
 ``repeat``
 ----------
 
-``repeat T`` applies ``T`` on the first goals as long as possible, unless the number of goals decreases, in which case the tactic stops.
+``repeat T`` applies ``T`` on the first goal until the number of goals decreases.
 
 .. _try:
 

--- a/doc/tacticals.rst
+++ b/doc/tacticals.rst
@@ -35,7 +35,7 @@ The BNF grammar of tactics is in `lambdapi.bnf <https://raw.githubusercontent.co
    builtin "try" ≔ …; // : T → T
    builtin "why3" ≔ …; // : T
 
-The tactics taking a string as argument need the ``"String"`` :ref:`builtin` to be set. The string argument of ``refine`` is parsed as a term, and thus can contain underscores.
+The tactics taking a string as argument need the ``"String"`` :ref:`builtin` to be set. The string argument of ``refine`` is parsed as a term, and thus can contain underscores. If the builtin ``and`` is mapped to some symbol, say ``&``, then ``t & u`` is interpreted as follows: the tactic ``t`` is applied and, in case of success, the tactic ``u`` is applied. All other symbols are interpreted by the corresponding tactics.
 
 An example of use is given in `Tactic.lp <https://github.com/Deducteam/lambdapi/blob/master/tests/OK/Tactic.lp>`__:
 

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -27,7 +27,8 @@ let sig_state_of_require =
     (* Search for a package from the current working directory. *)
     Package.apply_config (Filename.concat (Sys.getcwd()) ".") ;
     Core.Sig_state.of_sign
-     (Compile.compile (Parsing.Parser.path_of_string req))
+      (Compile.compile Core.Sig_state.dummy
+         (Parsing.Parser.path_of_string req))
 
 let search_cmd cfg rules require s dbpath_opt =
  Config.init cfg;
@@ -213,7 +214,7 @@ let decision_tree_cmd : Config.t -> qident -> bool -> unit =
     Package.apply_config (Filename.concat (Sys.getcwd()) ".");
     let sym =
       Timed.(Console.verbose := 0); (* To avoid printing "Checked ..." *)
-      let sign = Compile.compile mp in
+      let sign = Compile.compile Sig_state.dummy mp in
       let ss = Sig_state.of_sign sign in
       if ghost then
         (* Search through ghost symbols. *)

--- a/src/common/library.ml
+++ b/src/common/library.ml
@@ -242,3 +242,14 @@ let install_path : string -> string = fun fname ->
   match Stdlib.(!lib_root) with
   | None -> assert false
   | Some(p) -> List.fold_left Filename.concat p mp ^ ext
+
+(** Restore library mappings and console state after running [f x]. *)
+let restore_after f x =
+  let lm = Stdlib.ref !lib_mappings in
+  Console.State.push();
+  let restore() =
+    lib_mappings := Stdlib.(!lm);
+    Console.State.pop()
+  in
+  try let res = f x in restore(); res
+  with e -> restore(); raise e

--- a/src/core/builtin.ml
+++ b/src/core/builtin.ml
@@ -15,7 +15,7 @@ let get : sig_state -> popt -> Path.t -> string -> sym =
   | [] -> (* Symbol in scope. *)
       begin
         try StrMap.find s ss.builtins
-        with Not_found -> fatal pos "Unknown builtin %s." s
+        with Not_found -> fatal pos "Unknown builtin \"%s\"." s
       end
   | [m] when StrMap.mem m ss.alias_path -> (* Aliased module path. *)
       begin
@@ -26,7 +26,7 @@ let get : sig_state -> popt -> Path.t -> string -> sym =
         in
         (* Look for the symbol. *)
         try StrMap.find s !(sign.sign_builtins) with Not_found ->
-          fatal pos "Unknown builtin %a.%s." Path.pp p s
+          fatal pos "Unknown builtin \"%a.%s\"." Path.pp p s
       end
   | _  -> (* Fully-qualified symbol. *)
       begin
@@ -41,7 +41,7 @@ let get : sig_state -> popt -> Path.t -> string -> sym =
         in
         (* Look for the symbol. *)
         try StrMap.find s !(sign.sign_builtins) with Not_found ->
-          fatal pos "Unknown builtin %a.%s." Path.pp p s
+          fatal pos "Unknown builtin \"%a.%s\"." Path.pp p s
       end
 
 (** [get_opt ss name] returns [Some s] where [s] is the symbol mapped to

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -346,8 +346,7 @@ and atom idmap ppf t = pp `Atom idmap ppf t
 and appl idmap ppf t = pp `Appl idmap ppf t
 and func idmap ppf t = pp `Func idmap ppf t
 
-(* we cleanup terms to print non-dependent products are arrow types *)
-let term_in idmap ppf t = func idmap ppf (cleanup t)
+let term_in = func
 
 let term = term_in StrMap.empty
 

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -625,16 +625,16 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
   | e                           ->
       fatal pos "Uncaught exception: %s." (Printexc.to_string e)
 
-(** [handle compile_mod ss cmd] retrieves proof data from [cmd] (with
+(** [handle compile ss cmd] retrieves proof data from [cmd] (with
     {!val:get_proof_data}) and handles proofs using functions from
-    {!module:Tactic} The function [compile_mod] is used to compile required
+    {!module:Tactic} The function [compile] is used to compile required
     modules recursively. *)
 let handle : compiler -> Sig_state.t -> Syntax.p_command -> Sig_state.t =
-  fun compile_mod ss cmd ->
+  fun compile ss cmd ->
   LibMeta.reset_meta_counter ();
-  (* We provide the compilation function to the handle commands, so that
+  (* We provide the compilation function to the handle command, so that
      "require" is able to compile files. *)
-  let (ss, p, _) = get_proof_data compile_mod ss cmd in
+  let (ss, p, _) = get_proof_data compile ss cmd in
   match p with
   | None -> ss
   | Some d ->

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -9,7 +9,7 @@ open Proof
 open Goal
 
 (** Type alias for a function that compiles a Lambdapi module. *)
-type compiler = Path.t -> Sign.t
+type compiler = sig_state -> Path.t -> Sign.t
 
 (** Register a check for the type of the builtin symbols "nat_zero" and
     "nat_succ". *)
@@ -94,7 +94,7 @@ let rec rec_require : compiler -> sig_state -> Path.t -> sig_state =
     else
       begin
         (* Compile [p] (this adds it to [Sign.loaded]). *)
-        let sign = compile p in
+        let sign = compile ss p in
         (* Recurse on the dependencies of [p]. *)
         let f p _ ss = rec_require compile ss p in
         let ss = Path.Map.fold f !(sign.sign_deps) ss in

--- a/src/handle/command.mli
+++ b/src/handle/command.mli
@@ -13,7 +13,7 @@ val too_long : float Stdlib.ref
 val sr_check : bool Stdlib.ref
 
 (** Type alias for a function that compiles a Lambdapi module. *)
-type compiler = Common.Path.t -> Sign.t
+type compiler = sig_state -> Path.t -> Sign.t
 
 (** Representation of a yet unchecked proof. The structure is initialized when
     the proof mode is entered, and its finalizer is called when the proof mode

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -23,12 +23,13 @@ let source base =
   | true , false -> lp_src
   | false, true -> dk_src
 
-(** [compile] returns a compiler, i.e. a function of type [Path.t ->
-    Sign.t]. [compile mp] returns the signature associated to the module path
-    [mp]. The corresponding file is processed only when the corresponding
+(** [compile] returns a compiler, i.e. a function of type [sig_state -> Path.t
+    -> Sign.t]. [compile ss mp] returns the signature associated to the module
+    path [mp]. The corresponding file is processed only when the corresponding
     object file does not exist or must be updated. In that case, the signature
-    is stored in the corresponding object file if [!gen_obj] is [true]. *)
-let rec compile : Command.compiler = fun mp ->
+    is stored in the corresponding object file if [!gen_obj] is [true]. The
+    sig_state [ss] is only used to get the "String" builtin. *)
+let rec compile : Command.compiler = fun ss mp ->
   if List.mem mp !loading then
     begin
       let base = file_of_path mp in
@@ -49,7 +50,6 @@ let rec compile : Command.compiler = fun mp ->
       Console.out 1 (Color.blu "Start checking \"%s\"") src;
       loading := mp :: !loading;
       let sign = Sign.create mp in
-      let ss = Stdlib.ref (Sig_state.of_sign sign) in
       (* [sign] is added to [loaded] before processing the commands so that it
          is possible to qualify the symbols of the current modules. *)
       loaded := Path.Map.add mp sign !loaded;
@@ -57,6 +57,7 @@ let rec compile : Command.compiler = fun mp ->
         Path.Map.iter (fun p _ -> sout " %a" Path.pp p) !loaded;
         sout "\n%!";*)
       Tactic.reset_admitted();
+      let ss = Stdlib.ref (Sig_state.of_sign sign) in
       let consume cmd = Stdlib.(ss := Command.handle compile !ss cmd) in
       Debug.stream_iter consume (Parser.parse_file src);
       Console.out 1 (Color.blu "End checking \"%s\"") src;
@@ -73,46 +74,21 @@ let rec compile : Command.compiler = fun mp ->
       Console.out 2 (Color.blu "Load \"%s\"") obj;
       let sign = Sign.read obj in
       (* We recursively load every module [mp'] on which [mp] depends. *)
-      Path.Map.iter (fun mp' _ -> ignore (compile mp')) !(sign.sign_deps);
+      Path.Map.iter (fun mp' _ -> ignore (compile ss mp')) !(sign.sign_deps);
       loaded := Path.Map.add mp sign !loaded;
       Sign.link sign;
       (* Since the ghost signature is implicitly loaded but not linked, we
          need to explicitly update the decision tree of ghost symbols and the
          type of string literals with the String builtin. *)
-      (* [find_opt name sign] tries to find the builtin [name] in [sign] or in
-         its open dependencies. *)
-      let find_opt name =
-        let exception Found of Term.sym in
-        let rec find sign =
-          match Extra.StrMap.find_opt name !(sign.sign_builtins) with
-          | Some sym -> raise (Found sym)
-          | None ->
-              let f mp d =
-                if d.dep_open then
-                  match Path.Map.find_opt mp !loaded with
-                  | Some sign -> find sign
-                  | None -> assert false
-              in
-              Path.Map.iter f !(sign.sign_deps)
-        in
-        try find sign; None with Found sym -> Some sym
-      in
-      (* [get_sym_String()] searches for the "String" builtin once and record
-         it to return it right away if asked again. *)
-      let get_sym_String =
-        let open Stdlib in
-        let searched = ref false and sym = ref None in
-        fun () ->
-        if !searched then !sym
-        else let s = find_opt "String" in (sym := s; searched := true; s)
-      in
-      (* update the type and decision trees of ghost symbols *)
       let update s =
-        Tree.update_dtree s [];
-        if String.is_string_literal s.sym_name then
-          match get_sym_String() with
+        if String.is_string_literal s.Term.sym_name then
+          match Extra.StrMap.find_opt "String" !(sign.sign_builtins) with
+          | Some sym_String -> s.sym_type := Term.mk_Symb sym_String
+          | None ->
+          match Builtin.get_opt ss "String" with
           | Some sym_String -> s.sym_type := Term.mk_Symb sym_String
           | None -> assert false
+        else Tree.update_dtree s []
       in
       Ghost.iter update;
       sign
@@ -122,4 +98,4 @@ let rec compile : Command.compiler = fun mp ->
     and compiles [fname]. *)
 let compile_file (fname:string): Sign.t =
   Package.apply_config fname;
-  compile (path_of_file LpLexer.escape fname)
+  compile Sig_state.dummy (path_of_file LpLexer.escape fname)

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -14,8 +14,8 @@ let gen_obj = Stdlib.ref false
     Sign.t]. [compile force mp] returns the signature associated to the module
     path [mp]. The corresponding file is processed only when the corresponding
     object file does not exist or must be updated, or when [force] is
-    [true]. In that case, the produced signature is stored in the
-    corresponding object file if the option [--gen_obj] or [-c] is set. *)
+    [true]. In that case, the signature is stored in the corresponding object
+    file if the option [!gen_obj] is [true]. *)
 let rec compile : bool -> Command.compiler = fun force mp ->
   if mp = Ghost.path then Ghost.sign else
   let base = file_of_path mp in

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -13,7 +13,7 @@ let gen_obj = Stdlib.ref false
 (** [compile force] returns a compiler, i.e. a function of type [Path.t ->
     Sign.t]. [compile force mp] returns the signature associated to the module
     path [mp]. The corresponding file is processed only when the corresponding
-    object file does not exist or must be updated, or when [~force] is
+    object file does not exist or must be updated, or when [force] is
     [true]. In that case, the produced signature is stored in the
     corresponding object file if the option [--gen_obj] or [-c] is set. *)
 let rec compile : bool -> Command.compiler = fun force mp ->

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -10,42 +10,43 @@ open Core open Sign
     source files. The default behaviour is not te generate them. *)
 let gen_obj = Stdlib.ref false
 
-(** [compile force] returns a compiler, i.e. a function of type [Path.t ->
-    Sign.t]. [compile force mp] returns the signature associated to the module
-    path [mp]. The corresponding file is processed only when the corresponding
-    object file does not exist or must be updated, or when [force] is
-    [true]. In that case, the signature is stored in the corresponding object
-    file if the option [!gen_obj] is [true]. *)
-let rec compile : bool -> Command.compiler = fun force mp ->
-  if mp = Ghost.path then Ghost.sign else
-  let base = file_of_path mp in
-  let src =
-    let lp_src = base ^ lp_src_extension in
-    let dk_src = base ^ dk_src_extension in
-    match (Sys.file_exists lp_src, Sys.file_exists dk_src) with
-    | (false, false) ->
-        fatal_no_pos "File \"%s.lp\" (or .dk) not found." base
-    | (true , true ) ->
-        wrn None "Both \"%s\" and \"%s\" exist. We take \"%s\"."
-          lp_src dk_src lp_src; lp_src
-    | (true , false) -> lp_src
-    | (false, true ) -> dk_src
-  in
-  let obj = base ^ obj_extension in
+(** [source base] returns which file among [base.dk] and [base.lp] to use. *)
+let source base =
+  let lp_src = base ^ lp_src_extension
+  and dk_src = base ^ dk_src_extension in
+  match Sys.file_exists lp_src, Sys.file_exists dk_src with
+  | false, false ->
+      fatal_no_pos "File \"%s.lp\" (or .dk) not found." base
+  | true , true ->
+      wrn None "Both \"%s\" and \"%s\" exist. We take \"%s\"."
+        lp_src dk_src lp_src; lp_src
+  | true , false -> lp_src
+  | false, true -> dk_src
+
+(** [compile] returns a compiler, i.e. a function of type [Path.t ->
+    Sign.t]. [compile mp] returns the signature associated to the module path
+    [mp]. The corresponding file is processed only when the corresponding
+    object file does not exist or must be updated. In that case, the signature
+    is stored in the corresponding object file if [!gen_obj] is [true]. *)
+let rec compile : Command.compiler = fun mp ->
   if List.mem mp !loading then
     begin
-      fatal_msg "Circular dependencies detected in \"%s\".@." src;
-      fatal_msg "Dependency stack for module %a:@." Path.pp mp;
+      let base = file_of_path mp in
+      fatal_msg "Circular dependency detected in \"%s\".@." (source base);
+      fatal_msg "Dependency stack for module:@.";
       List.iter (fatal_msg "- %a@." Path.pp) !loading;
       fatal_no_pos "Build aborted."
     end;
+  if mp = Ghost.path then Ghost.sign else
   match Path.Map.find_opt mp !loaded with
   | Some sign -> sign
   | None ->
-    if force || Extra.more_recent src obj then
+    let base = file_of_path mp in
+    let obj = base ^ obj_extension in
+    let src = source base in
+    if Extra.more_recent src obj then
     begin
-      let forced = if force then " (forced)" else "" in
-      Console.out 1 (Color.blu "Start checking \"%s\"%s") src forced;
+      Console.out 1 (Color.blu "Start checking \"%s\"") src;
       loading := mp :: !loading;
       let sign = Sign.create mp in
       let ss = Stdlib.ref (Sig_state.of_sign sign) in
@@ -56,34 +57,39 @@ let rec compile : bool -> Command.compiler = fun force mp ->
         Path.Map.iter (fun p _ -> sout " %a" Path.pp p) !loaded;
         sout "\n%!";*)
       Tactic.reset_admitted();
-      let consume cmd =
-        Stdlib.(ss := Command.handle (compile force) !ss cmd) in
+      let consume cmd = Stdlib.(ss := Command.handle compile !ss cmd) in
       Debug.stream_iter consume (Parser.parse_file src);
-      Console.out 1 (Color.blu "End checking \"%s\"%s") src forced;
+      Console.out 1 (Color.blu "End checking \"%s\"") src;
       Sign.strip_private sign;
       if Stdlib.(!gen_obj) then begin
-        Console.out 2 (Color.blu "Writing \"%s\" ...")obj; Sign.write sign obj
+        Console.out 2 (Color.blu "Write \"%s\"") obj;
+        Sign.write sign obj
       end;
       loading := List.tl !loading;
       sign
     end
     else
     begin
-      Console.out 2 (Color.blu "Loading \"%s\" ...") obj;
+      Console.out 2 (Color.blu "Load \"%s\"") obj;
       let sign = Sign.read obj in
       (* We recursively load every module [mp'] on which [mp] depends. *)
-      let compile mp _ = ignore (compile false mp) in
-      Path.Map.iter compile !(sign.sign_deps);
+      Path.Map.iter (fun mp' _ -> ignore (compile mp')) !(sign.sign_deps);
       loaded := Path.Map.add mp sign !loaded;
       Sign.link sign;
-      (* Since ghost signatures are always assumed to be already loaded,
-         we need to explicitly update the decision tree of their symbols
-         because it is not done in linking which normally follows loading. *)
-      Ghost.iter (fun s -> Tree.update_dtree s []);
+      (* Since ghost signatures are always assumed to be already loaded, we
+         need to explicitly update the decision tree of their symbols because
+         it is not done in linking which normally follows loading. We also
+         need to set the type of string symbols to the String builtin. *)
+      let update s =
+        Tree.update_dtree s [];
+        if String.is_string_literal s.sym_name then
+          let ss = Sig_state.of_sign sign in
+          let string_sym = Builtin.get ss s.sym_pos mp "String" in
+          s.sym_type := Term.mk_Symb string_sym
+      in
+      Ghost.iter update;
       sign
     end
-
-let compile = compile false
 
 (** [compile_file fname] looks for a package configuration file for [fname]
     and compiles [fname]. *)

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -76,16 +76,43 @@ let rec compile : Command.compiler = fun mp ->
       Path.Map.iter (fun mp' _ -> ignore (compile mp')) !(sign.sign_deps);
       loaded := Path.Map.add mp sign !loaded;
       Sign.link sign;
-      (* Since ghost signatures are always assumed to be already loaded, we
-         need to explicitly update the decision tree of their symbols because
-         it is not done in linking which normally follows loading. We also
-         need to set the type of string symbols to the String builtin. *)
+      (* Since the ghost signature is implicitly loaded but not linked, we
+         need to explicitly update the decision tree of ghost symbols and the
+         type of string literals with the String builtin. *)
+      (* [find_opt name sign] tries to find the builtin [name] in [sign] or in
+         its open dependencies. *)
+      let find_opt name =
+        let exception Found of Term.sym in
+        let rec find sign =
+          match Extra.StrMap.find_opt name !(sign.sign_builtins) with
+          | Some sym -> raise (Found sym)
+          | None ->
+              let f mp d =
+                if d.dep_open then
+                  match Path.Map.find_opt mp !loaded with
+                  | Some sign -> find sign
+                  | None -> assert false
+              in
+              Path.Map.iter f !(sign.sign_deps)
+        in
+        try find sign; None with Found sym -> Some sym
+      in
+      (* [get_sym_String()] searches for the "String" builtin once and record
+         it to return it right away if asked again. *)
+      let get_sym_String =
+        let open Stdlib in
+        let searched = ref false and sym = ref None in
+        fun () ->
+        if !searched then !sym
+        else let s = find_opt "String" in (sym := s; searched := true; s)
+      in
+      (* update the type and decision trees of ghost symbols *)
       let update s =
         Tree.update_dtree s [];
         if String.is_string_literal s.sym_name then
-          let ss = Sig_state.of_sign sign in
-          let string_sym = Builtin.get ss s.sym_pos mp "String" in
-          s.sym_type := Term.mk_Symb string_sym
+          match get_sym_String() with
+          | Some sym_String -> s.sym_type := Term.mk_Symb sym_String
+          | None -> assert false
       in
       Ghost.iter update;
       sign

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -10,16 +10,13 @@ open Core open Sign
     source files. The default behaviour is not te generate them. *)
 let gen_obj = Stdlib.ref false
 
-(** [compile_with ~handle ~force mp] compiles the file corresponding to module
-   path [mp] using function [~handle] to process commands. Module [mp] is
-   processed when it is necessary, i.e. the corresponding object file does not
-   exist, or it must be updated, or [~force] is [true]. In that case, the
-   produced signature is stored in the corresponding object file if the option
-   [--gen_obj] or [-c] is set. *)
-let rec compile_with :
-  handle:(Command.compiler -> Sig_state.t -> Syntax.p_command -> Sig_state.t)
-  -> force:bool -> Command.compiler =
-  fun ~handle ~force mp ->
+(** [compile force] returns a compiler, i.e. a function of type [Path.t ->
+    Sign.t]. [compile force mp] returns the signature associated to the module
+    path [mp]. The corresponding file is processed only when the corresponding
+    object file does not exist or must be updated, or when [~force] is
+    [true]. In that case, the produced signature is stored in the
+    corresponding object file if the option [--gen_obj] or [-c] is set. *)
+let rec compile : bool -> Command.compiler = fun force mp ->
   if mp = Ghost.path then Ghost.sign else
   let base = file_of_path mp in
   let src =
@@ -59,8 +56,8 @@ let rec compile_with :
         Path.Map.iter (fun p _ -> sout " %a" Path.pp p) !loaded;
         sout "\n%!";*)
       Tactic.reset_admitted();
-      let compile = compile_with ~handle ~force in
-      let consume cmd = Stdlib.(ss := handle compile !ss cmd) in
+      let consume cmd =
+        Stdlib.(ss := Command.handle (compile force) !ss cmd) in
       Debug.stream_iter consume (Parser.parse_file src);
       Console.out 1 (Color.blu "End checking \"%s\"%s") src forced;
       Sign.strip_private sign;
@@ -75,7 +72,7 @@ let rec compile_with :
       Console.out 2 (Color.blu "Loading \"%s\" ...") obj;
       let sign = Sign.read obj in
       (* We recursively load every module [mp'] on which [mp] depends. *)
-      let compile mp' _ = ignore (compile_with ~handle ~force:false mp') in
+      let compile mp _ = ignore (compile false mp) in
       Path.Map.iter compile !(sign.sign_deps);
       loaded := Path.Map.add mp sign !loaded;
       Sign.link sign;
@@ -86,49 +83,10 @@ let rec compile_with :
       sign
     end
 
-(** [compile force mp] compiles module path [mp], forcing
-    compilation of up-to-date files if [force] is true. *)
-let compile : ?force:bool -> Path.t -> Sign.t = fun ?(force=false) ->
-  compile_with ~handle:Command.handle ~force
+let compile = compile false
 
-(** [compile_file fname] looks for a package configuration file for
-    [fname] and compiles [fname]. It is the main compiling function. It
-    is called from the main program exclusively. *)
-let compile_file : ?force:bool -> string -> Sign.t =
-  fun ?(force=false) fname ->
+(** [compile_file fname] looks for a package configuration file for [fname]
+    and compiles [fname]. *)
+let compile_file (fname:string): Sign.t =
   Package.apply_config fname;
-  compile ~force (path_of_file LpLexer.escape fname)
-
-(** The functions provided in this module perform the same computations as the
-   ones defined earlier, but restore the console state and the library
-   mappings when they have finished. An optional library mapping or console
-   state can be passed as argument to change the settings. *)
-module PureUpToSign = struct
-
-  (** [apply_cfg ?lm ?st f x] is the same as [f x] except that the console
-     state and {!val:Library.lib_mappings} are restored after the evaluation
-     of [f x]. [?lm] allows to set the library mappings and [?st] to set the
-     console state. *)
-  let apply_cfg :
-    ?lm:Path.t*string -> ?st:Console.State.t -> ('a -> 'b) -> 'a -> 'b =
-    fun ?lm ?st f x ->
-      let lib_mappings = !Library.lib_mappings in
-      Console.State.push ();
-      Option.iter Library.add_mapping lm;
-      Option.iter Console.State.apply st;
-      let restore () =
-        Library.lib_mappings := lib_mappings;
-        Console.State.pop ()
-      in
-      try let res = f x in restore (); res
-      with e -> restore (); raise e
-
-  let compile :
-  ?lm:Path.t*string -> ?st:Console.State.t -> ?force:bool -> Path.t -> Sign.t
-    = fun ?lm ?st ?(force=false) -> apply_cfg ?lm ?st (compile ~force)
-
-  let compile_file :
-  ?lm:Path.t*string -> ?st:Console.State.t -> ?force:bool -> string -> Sign.t
-    = fun ?lm ?st ?(force=false) -> apply_cfg ?lm ?st (compile_file ~force)
-
-end
+  compile (path_of_file LpLexer.escape fname)

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -23,9 +23,8 @@ let source base =
   | true , false -> lp_src
   | false, true -> dk_src
 
-(** [compile] returns a compiler, i.e. a function of type [sig_state -> Path.t
-    -> Sign.t]. [compile ss mp] returns the signature associated to the module
-    path [mp]. The corresponding file is processed only when the corresponding
+(** [compile ss mp] returns the signature associated to the module path
+    [mp]. The corresponding file is processed only when the corresponding
     object file does not exist or must be updated. In that case, the signature
     is stored in the corresponding object file if [!gen_obj] is [true]. The
     sig_state [ss] is only used to get the "String" builtin. *)

--- a/src/handle/compile.mli
+++ b/src/handle/compile.mli
@@ -7,23 +7,9 @@ val gen_obj : bool Stdlib.ref
 (** [gen_obj] indicates whether we should generate object files when compiling
     source files. The default behaviour is not to generate them. *)
 
-val compile : ?force:bool -> Path.t -> Sign.t
-(** [compile force mp] compiles module path [mp], forcing
-    recompilation of up-to-date files if [force] is true. *)
+val compile : Path.t -> Sign.t
+(** [compile mp] returns the signature associated to [mp]. *)
 
-val compile_file : ?force:bool -> string -> Sign.t
-(** [compile_file force fname] looks for a package configuration file for
-   [fname] and compiles [fname], forcing recompilation of up-to-date files if
-   [force] is true. It is the main compiling function. It is called from the
-   main program exclusively. *)
-
-(** The functions provided in this module perform the same computations as the
-   ones defined earlier, but restore the console state and the library
-   mappings when they have finished. An optional library mapping or console
-   state can be passed as argument to change the settings. *)
-module PureUpToSign : sig
-  val compile :
-  ?lm:Path.t*string -> ?st:Console.State.t -> ?force:bool -> Path.t -> Sign.t
-  val compile_file :
-  ?lm:Path.t*string -> ?st:Console.State.t -> ?force:bool -> string -> Sign.t
-end
+val compile_file : string -> Sign.t
+(** [compile_file fname] looks for a package configuration file for
+   [fname] and returns the signature associated to it [fname]. *)

--- a/src/handle/compile.mli
+++ b/src/handle/compile.mli
@@ -1,15 +1,12 @@
 (** High-level compilation functions. *)
 
-open Common
-open Core
-
 val gen_obj : bool Stdlib.ref
 (** [gen_obj] indicates whether we should generate object files when compiling
     source files. The default behaviour is not to generate them. *)
 
-val compile : Path.t -> Sign.t
+val compile : Command.compiler
 (** [compile mp] returns the signature associated to [mp]. *)
 
-val compile_file : string -> Sign.t
+val compile_file : string -> Core.Sign.t
 (** [compile_file fname] looks for a package configuration file for
    [fname] and returns the signature associated to it [fname]. *)

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -349,44 +349,52 @@ let is_right (pos:popt) (t:term): bool =
       end
   | _ -> fatal pos "rewrite tactic not applied to a side string literal"
 
-(** [p_tactic ss pos idmap t] interprets as a tactic the term [t] obtained by
-    scoping and normalization of a p_term at position [pos]. *)
-let p_tactic (ss:Sig_state.t) (pos:popt): int StrMap.t -> term -> p_tactic =
-  let c = get_config ss pos in
-  let rec tac idmap t = Pos.make pos (tac_aux idmap t)
-  and tac_aux idmap t =
+(** [p_tactic ss pt] translates the p_term [pt] into a p_tactic. *)
+let p_tactic (ss:Sig_state.t) (prv:bool) (ps:proof_state) (pt:p_term)
+      (g:goal) (env:Env.t) : p_tactic =
+  let pos = pt.pos
+  and idmap = get_names g
+  and ctx = Env.to_ctxt env in
+  let c = get_config ss pos
+  and scope = Scope.scope_term ~mok:(Proof.meta_of_key ps) prv ss env in
+  let tac pt = Pos.make pos (P_tac_eval pt) in
+  let tac_aux pt =
+    let t = scope pt in
+    let t = Eval.whnf ctx t in
     match get_args t with
     | Symb s, ts ->
         begin
           try
             match Hashtbl.find c s.sym_name, ts with
             | T_admit, _ -> P_tac_admit
-            | T_and, [t1;t2] -> P_tac_and(tac idmap t1, tac idmap t2)
+            | T_and, [t1;t2] -> P_tac_and(tac t1, tac t2)
             | T_and, _ -> assert false
-            | T_apply, [_;t] -> P_tac_apply(p_term pos idmap t)
+            | T_apply, [_;t] -> P_tac_apply t
             | T_apply, _ -> assert false
             | T_assume, [t] -> P_tac_assume [Some(p_ident_of_sym pos t)]
             | T_assume, _ -> assert false
-            | T_change, [_;t] -> P_tac_apply(p_term pos idmap t)
+            | T_change, [_;t] -> P_tac_apply t
             | T_change, _ -> assert false
             | T_fail, _ -> P_tac_fail
             | T_generalize, [_;t] -> P_tac_generalize(p_ident_of_var pos t)
             | T_generalize, _ -> assert false
             | T_have, [t1;t2] ->
-                let prf_sym = Builtin.get ss pos [] "P" in
-                let prf = p_term pos idmap (mk_Symb prf_sym) in
-                let t2 = Pos.make pos (P_Appl(prf, p_term pos idmap t2)) in
-                P_tac_have(p_ident_of_sym pos t1, t2)
+                let s = Builtin.get ss t2.pos [] "P" in
+                let p = P_Iden(mk(s.sym_path,s.sym_name),true) in
+                let p = if !(s.sym_nota) = NoNotation then p
+                        else P_Wrap (Pos.make t2.pos p)
+                let t2 = Pos.make t2.pos (P_Appl(p,t2)) in
+                P_tac_have(t1,t2)
             | T_have, _ -> assert false
             | T_induction, _ -> P_tac_induction
-            | T_orelse, [t1;t2] -> P_tac_orelse(tac idmap t1, tac idmap t2)
+            | T_orelse, [t1;t2] -> P_tac_orelse(tac t1, tac t2)
             | T_orelse, _ -> assert false
             | T_refine, [t] -> P_tac_refine(p_term_of_string pos t)
             | T_refine, _ -> assert false
             | T_reflexivity, _ -> P_tac_refl
             | T_remove, [_;t] -> P_tac_remove [p_ident_of_var pos t]
             | T_remove, _ -> assert false
-            | T_repeat, [t] -> P_tac_repeat(tac idmap t)
+            | T_repeat, [t] -> P_tac_repeat(tac t)
             | T_repeat, _ -> assert false
             | T_rewrite, [side;pat;_;t] ->
                 P_tac_rewrite(is_right pos side,
@@ -399,7 +407,7 @@ let p_tactic (ss:Sig_state.t) (pos:popt): int StrMap.t -> term -> p_tactic =
             | T_simplify_beta, _ -> P_tac_simpl SimpBetaOnly
             | T_solve, _ -> P_tac_solve
             | T_symmetry, _ -> P_tac_sym
-            | T_try, [t] -> P_tac_try(tac idmap t)
+            | T_try, [t] -> P_tac_try(tac t)
             | T_try, _ -> assert false
             | T_why3, _ -> P_tac_why3 None
           with Not_found ->
@@ -688,9 +696,7 @@ let rec handle :
       let ps = handle ss sym_pos prv ps t1 in
       handle ss sym_pos prv ps t2
   | P_tac_eval pt ->
-      let t = Eval.snf (Env.to_ctxt env) (scope pt) in
-      let idmap = get_names g in
-      handle ss sym_pos prv ps (p_tactic ss pt.pos idmap t)
+      handle ss sym_pos prv ps (p_tactic ss pt)
 
 (** Representation of a tactic output. *)
 type tac_output = proof_state * Query.result

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -416,11 +416,11 @@ let p_tactic (ss:Sig_state.t) (g:goal) (env:Env.t) (pos:Pos.popt) (t:term)
   in
   Pos.make pos (tac t)
 
-(** [handle ss sym_pos prv ps tac] applies tactic [tac] in the proof state
+(** [handle ss sym_pos priv ps tac] applies tactic [tac] in the proof state
    [ps] and returns the new proof state. *)
-let rec handle :
-  Sig_state.t -> popt -> bool -> proof_state -> p_tactic -> proof_state =
-  fun ss sym_pos prv ps ({elt;pos} as tac) ->
+let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
+    :proof_state -> p_tactic -> proof_state =
+  let rec handle ps ({elt;pos} as tac) =
   if Logger.log_enabled () then log "%a" Pretty.tactic tac;
   match ps.proof_goals with
   | [] -> assert false (* done before *)
@@ -454,7 +454,11 @@ let rec handle :
   match g with
   | Unif _ -> fatal pos "Not a typing goal."
   | Typ ({goal_hyps=env;_} as gt) ->
-  let scope t = Scope.scope_term ~mok:(Proof.meta_of_key ps) prv ss env t in
+  let scope ?(prot=false) =
+    let find_sym: Sig_state.find_sym =
+      fun ~prt:_ ~prv:_ -> Sig_state.find_sym ~prt:prot ~prv:priv in
+    Scope.scope_term ~find_sym ~mok:(Proof.meta_of_key ps) priv ss env
+  in
   (* Function to apply the assume tactic several times without checking the
      validity of identifiers. *)
   let assume idopts =
@@ -502,8 +506,8 @@ let rec handle :
       let vparam = [[Some vabs],Some pa,false] in
       let idbody = Pos.make pos (P_Iden(varg,false)) in
       let id =  Pos.make pos (P_Abst(vparam,idbody)) in
-      let t = Pos.make pos (P_Appl(id,Pos.make pos P_Wild)) in
-      tac_refine pos ps gt gs (new_problem()) (scope t)
+      let pt = Pos.make pos (P_Appl(id,Pos.make pos P_Wild)) in
+      tac_refine pos ps gt gs (new_problem()) (scope pt)
   | P_tac_generalize {elt=id; pos=idpos} ->
       (* From a goal [e1,id:a,e2 ⊢ ?[e1,id,e2] : u], generate a new goal [e1 ⊢
          ?m[e1] : Π id:a, Π e2, u], and refine [?[e]] with [?m[e1] id e2]. *)
@@ -522,12 +526,12 @@ let rec handle :
           tac_refine pos ps gt gs p t
         with Not_found -> fatal idpos "Unknown hypothesis %a" uid id;
       end
-  | P_tac_have(id, t) ->
+  | P_tac_have(id, pt) ->
       (* From a goal [e ⊢ ?[e] : u], generate two new goals [e ⊢ ?1[e] : t]
          and [e,x:t ⊢ ?2[e,x] : u], and refine [?[e]] with [?2[e,?1[e]]. *)
       check id;
       let p = new_problem() in
-      let t = scope t in
+      let t = scope pt in
       (* Generate the constraints for [t] to be of type [Type]. *)
       let c = Env.to_ctxt env in
       begin
@@ -547,12 +551,12 @@ let rec handle :
         let u = mk_Meta (m2, Array.append ts [|mk_Meta (m1, ts)|]) in
         tac_refine pos ps gt gs p u
       end
-  | P_tac_set(id,t) ->
+  | P_tac_set(id,pt) ->
       (* From a goal [e ⊢ ?[e]:a], generate a new goal [e,x:b≔t ⊢ ?1[e,x]:a],
          where [b] is the type of [t], and refine [?[e]] with [?1[e,t]]. *)
       check id;
       let p = new_problem() in
-      let t = scope t in
+      let t = scope pt in
       let c = Env.to_ctxt env in
       begin
         match Infer.infer_noexn p c t with
@@ -577,7 +581,7 @@ let rec handle :
                             to be typable are not satisfiable." term t
       end
   | P_tac_induction -> tac_induction pos ps gt gs
-  | P_tac_refine t -> tac_refine pos ps gt gs (new_problem()) (scope t)
+  | P_tac_refine pt -> tac_refine pos ps gt gs (new_problem()) (scope pt)
   | P_tac_refl ->
       begin
         let cfg = Rewrite.get_eq_config ss pos in
@@ -672,47 +676,42 @@ let rec handle :
             Why3_tactic.handle ss pos cfg gt; tac_admit ss sym_pos ps gt
         | _ -> assert false
       end
-  | P_tac_try tactic ->
-      begin
-        try handle ss sym_pos prv ps tactic
-        with Fatal(_, _s) -> ps
-      end
+  | P_tac_try t ->
+      begin try handle ps t with Fatal(_, _s) -> ps end
   | P_tac_orelse(t1,t2) ->
-      begin
-        try handle ss sym_pos prv ps t1
-        with Fatal(_, _s) -> handle ss sym_pos prv ps t2
-      end
+      begin try handle ps t1 with Fatal(_, _s) -> handle ps t2 end
   | P_tac_repeat t ->
       begin
         try
           let nb_goals = List.length ps.proof_goals in
-          let ps = handle ss sym_pos prv ps t in
+          let ps = handle ps t in
           if List.length ps.proof_goals < nb_goals then ps
-          else handle ss sym_pos prv ps tac
+          else handle ps tac
         with Fatal(_, _s) -> ps
       end
-  | P_tac_and(t1,t2) ->
-      let ps = handle ss sym_pos prv ps t1 in
-      handle ss sym_pos prv ps t2
+  | P_tac_and(t1,t2) -> handle (handle ps t1) t2
   | P_tac_eval pt ->
-      let t = scope pt and p = new_problem() and c = Env.to_ctxt env in
+      let t = scope pt
+      and p = new_problem()
+      and c = Env.to_ctxt env in
       match Infer.infer_noexn p c t with
       | None ->
           let term = term_in (Ctxt.names c) in
           fatal pt.pos "Cannot infer the type of [%a]" term t
       | Some(t,_) ->
           if Unif.solve_noexn p then
-            handle ss sym_pos prv ps (p_tactic ss g env pos t)
+            handle ps (p_tactic ss g env pos t)
           else fatal pos "Cannot solve typing constraints for [%a]" term t
+  in handle
 
 (** Representation of a tactic output. *)
 type tac_output = proof_state * Query.result
 
-(** [handle ss sym_pos prv ps tac] applies tactic [tac] in the proof state
+(** [handle ss sym_pos priv ps tac] applies tactic [tac] in the proof state
    [ps] and returns the new proof state. *)
 let handle :
   Sig_state.t -> popt -> bool -> proof_state -> p_tactic -> tac_output =
-  fun ss sym_pos prv ps ({elt;pos} as tac) ->
+  fun ss sym_pos priv ps ({elt;pos} as tac) ->
   match elt with
   | P_tac_fail -> fatal pos "Call to tactic \"fail\"."
   | P_tac_query(q) ->
@@ -723,15 +722,15 @@ let handle :
   | [] -> fatal pos "No remaining goal."
   | g::_ ->
     if Logger.log_enabled() then log ("goal %a") Goal.pp_no_hyp g;
-    handle ss sym_pos prv ps tac, None
+    handle ss sym_pos priv ps tac, None
 
-(** [handle sym_pos prv r tac n] applies the tactic [tac] from the previous
+(** [handle sym_pos priv r tac n] applies the tactic [tac] from the previous
    tactic output [r] and checks that the number of goals of the new proof
    state is compatible with the number [n] of subproofs. *)
 let handle :
   Sig_state.t -> popt -> bool -> tac_output -> p_tactic -> int -> tac_output =
-  fun ss sym_pos prv (ps, _) t nb_subproofs ->
-  let (ps', _) as a = handle ss sym_pos prv ps t in
+  fun ss sym_pos priv (ps, _) t nb_subproofs ->
+  let (ps', _) as a = handle ss sym_pos priv ps t in
   let nb_goals_before = List.length ps.proof_goals in
   let nb_goals_after = List.length ps'.proof_goals in
   let nb_newgoals = nb_goals_after - nb_goals_before in

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -254,17 +254,18 @@ let get_config (ss:Sig_state.t) (pos:Pos.popt) : config =
 
 (** [p_term pos t] converts the term [t] into a p_term at position [pos]. *)
 let p_term (pos:popt): int StrMap.t -> term -> p_term =
-  let mk = Pos.make pos in
-  let rec term idmap t = Pos.make pos (term_aux idmap t)
+  let rec term idmap (t:term) :p_term =
+    if Logger.log_enabled() then log "p_term %a" Print.term t;
+    Pos.make pos (term_aux idmap t)
   and params idmap x a =
     [Some(Pos.make pos (base_name x))],Some(term idmap a),false
   and term_aux idmap t :p_term_aux =
     match unfold t with
     | Type -> P_Type
     | Symb s ->
-        let t = P_Iden(mk(s.sym_path,s.sym_name),true) in
+        let t = P_Iden(Pos.make pos (s.sym_path,s.sym_name),true) in
         if !(s.sym_nota) = NoNotation then t else P_Wrap (Pos.make pos t)
-    | Vari v -> P_Iden(mk([],base_name v),false)
+    | Vari v -> P_Iden(Pos.make pos ([],base_name v),false)
     | Appl(u,v) -> P_Appl(term idmap u, term idmap v)
     | Prod(a,b) ->
         let (x,b),idmap' = Print.safe_unbind idmap b in
@@ -359,7 +360,9 @@ let p_tactic (ss:Sig_state.t) (g:goal) (env:Env.t) (pos:Pos.popt) (t:term)
   let p_term = p_term pos idmap in
   let tac_eval t = Pos.make pos (P_tac_eval (p_term t)) in
   let tac t =
+    if Logger.log_enabled() then log "p_tactic %a" term t;
     let t = Eval.whnf ctx t in
+    if Logger.log_enabled() then log "whnf %a" term t;
     match get_args t with
     | Symb s, ts ->
         begin
@@ -498,10 +501,9 @@ let rec handle :
       let vabs = Pos.make pos vname in
       let varg = Pos.make pos ([],vname) in
       let vparam = [[Some vabs],Some pa,false] in
-      let mk = Pos.make pos in
-      let idbody = mk(P_Iden(varg,false)) in
-      let id = mk(P_Abst(vparam,idbody)) in
-      let t = mk(P_Appl(id,mk P_Wild)) in
+      let idbody = Pos.make pos (P_Iden(varg,false)) in
+      let id =  Pos.make pos (P_Abst(vparam,idbody)) in
+      let t = Pos.make pos (P_Appl(id,Pos.make pos P_Wild)) in
       tac_refine pos ps gt gs (new_problem()) (scope t)
   | P_tac_generalize {elt=id; pos=idpos} ->
       (* From a goal [e1,id:a,e2 ⊢ ?[e1,id,e2] : u], generate a new goal [e1 ⊢
@@ -694,8 +696,15 @@ let rec handle :
       let ps = handle ss sym_pos prv ps t1 in
       handle ss sym_pos prv ps t2
   | P_tac_eval pt ->
-      let t = scope pt in
-      handle ss sym_pos prv ps (p_tactic ss g env pos t)
+      let t = scope pt and p = new_problem() and c = Env.to_ctxt env in
+      match Infer.infer_noexn p c t with
+      | None ->
+          let term = term_in (Ctxt.names c) in
+          fatal pt.pos "Cannot infer the type of [%a]" term t
+      | Some(t,_) ->
+          if Unif.solve_noexn p then
+            handle ss sym_pos prv ps (p_tactic ss g env pos t)
+          else fatal pos "Cannot solve typing constraints for [%a]" term t
 
 (** Representation of a tactic output. *)
 type tac_output = proof_state * Query.result

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -350,16 +350,14 @@ let is_right (pos:popt) (t:term): bool =
   | _ -> fatal pos "rewrite tactic not applied to a side string literal"
 
 (** [p_tactic ss pt] translates the p_term [pt] into a p_tactic. *)
-let p_tactic (ss:Sig_state.t) (prv:bool) (ps:proof_state) (pt:p_term)
-      (g:goal) (env:Env.t) : p_tactic =
-  let pos = pt.pos
-  and idmap = get_names g
+let p_tactic (ss:Sig_state.t) (g:goal) (env:Env.t) (pos:Pos.popt) (t:term)
+    : p_tactic =
+  let idmap = get_names g
   and ctx = Env.to_ctxt env in
-  let c = get_config ss pos
-  and scope = Scope.scope_term ~mok:(Proof.meta_of_key ps) prv ss env in
-  let tac pt = Pos.make pos (P_tac_eval pt) in
-  let tac_aux pt =
-    let t = scope pt in
+  let c = get_config ss pos in
+  let p_term = p_term pos idmap in
+  let tac_eval t = Pos.make pos (P_tac_eval (p_term t)) in
+  let tac t =
     let t = Eval.whnf ctx t in
     match get_args t with
     | Symb s, ts ->
@@ -367,54 +365,53 @@ let p_tactic (ss:Sig_state.t) (prv:bool) (ps:proof_state) (pt:p_term)
           try
             match Hashtbl.find c s.sym_name, ts with
             | T_admit, _ -> P_tac_admit
-            | T_and, [t1;t2] -> P_tac_and(tac t1, tac t2)
+            | T_and, [t1;t2] -> P_tac_and(tac_eval t1, tac_eval t2)
             | T_and, _ -> assert false
-            | T_apply, [_;t] -> P_tac_apply t
+            | T_apply, [_;t] -> P_tac_apply (p_term t)
             | T_apply, _ -> assert false
             | T_assume, [t] -> P_tac_assume [Some(p_ident_of_sym pos t)]
             | T_assume, _ -> assert false
-            | T_change, [_;t] -> P_tac_apply t
+            | T_change, [_;t] -> P_tac_apply (p_term t)
             | T_change, _ -> assert false
             | T_fail, _ -> P_tac_fail
             | T_generalize, [_;t] -> P_tac_generalize(p_ident_of_var pos t)
             | T_generalize, _ -> assert false
             | T_have, [t1;t2] ->
-                let s = Builtin.get ss t2.pos [] "P" in
-                let p = P_Iden(mk(s.sym_path,s.sym_name),true) in
-                let p = if !(s.sym_nota) = NoNotation then p
-                        else P_Wrap (Pos.make t2.pos p)
-                let t2 = Pos.make t2.pos (P_Appl(p,t2)) in
-                P_tac_have(t1,t2)
+                let prf_sym = Builtin.get ss pos [] "P" in
+                let prf = p_term (mk_Symb prf_sym) in
+                let t2 = Pos.make pos (P_Appl(prf, p_term t2)) in
+                P_tac_have(p_ident_of_sym pos t1, t2)
             | T_have, _ -> assert false
             | T_induction, _ -> P_tac_induction
-            | T_orelse, [t1;t2] -> P_tac_orelse(tac t1, tac t2)
+            | T_orelse, [t1;t2] -> P_tac_orelse(tac_eval t1, tac_eval t2)
             | T_orelse, _ -> assert false
             | T_refine, [t] -> P_tac_refine(p_term_of_string pos t)
             | T_refine, _ -> assert false
             | T_reflexivity, _ -> P_tac_refl
             | T_remove, [_;t] -> P_tac_remove [p_ident_of_var pos t]
             | T_remove, _ -> assert false
-            | T_repeat, [t] -> P_tac_repeat(tac t)
+            | T_repeat, [t] -> P_tac_repeat(tac_eval t)
             | T_repeat, _ -> assert false
             | T_rewrite, [side;pat;_;t] ->
                 P_tac_rewrite(is_right pos side,
-                              p_rwpatt_of_string pos pat, p_term pos idmap t)
+                              p_rwpatt_of_string pos pat, p_term t)
             | T_rewrite, _ -> assert false
             | T_set, [t1;_;t2] ->
-                P_tac_set(p_ident_of_sym pos t1, p_term pos idmap t2)
+                P_tac_set(p_ident_of_sym pos t1, p_term t2)
             | T_set, _ -> assert false
             | T_simplify, _ -> P_tac_simpl SimpAll
             | T_simplify_beta, _ -> P_tac_simpl SimpBetaOnly
             | T_solve, _ -> P_tac_solve
             | T_symmetry, _ -> P_tac_sym
-            | T_try, [t] -> P_tac_try(tac t)
+            | T_try, [t] -> P_tac_try(tac_eval t)
             | T_try, _ -> assert false
             | T_why3, _ -> P_tac_why3 None
           with Not_found ->
             fatal pos "Unhandled tactic expression: %a." term t
         end
     | _ -> fatal pos "Unhandled tactic expression: %a." term t
-  in tac
+  in
+  Pos.make pos (tac t)
 
 (** [handle ss sym_pos prv ps tac] applies tactic [tac] in the proof state
    [ps] and returns the new proof state. *)
@@ -696,7 +693,8 @@ let rec handle :
       let ps = handle ss sym_pos prv ps t1 in
       handle ss sym_pos prv ps t2
   | P_tac_eval pt ->
-      handle ss sym_pos prv ps (p_tactic ss pt)
+      let t = scope pt in
+      handle ss sym_pos prv ps (p_tactic ss g env pos t)
 
 (** Representation of a tactic output. *)
 type tac_output = proof_state * Query.result

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -349,7 +349,8 @@ let is_right (pos:popt) (t:term): bool =
       end
   | _ -> fatal pos "rewrite tactic not applied to a side string literal"
 
-(** [p_tactic ss pt] translates the p_term [pt] into a p_tactic. *)
+(** [p_tactic ss g env pos t] weak head normalizes [t] and convert the result
+    into a p_tactic. *)
 let p_tactic (ss:Sig_state.t) (g:goal) (env:Env.t) (pos:Pos.popt) (t:term)
     : p_tactic =
   let idmap = get_names g

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -255,7 +255,7 @@ let get_config (ss:Sig_state.t) (pos:Pos.popt) : config =
 (** [p_term pos t] converts the term [t] into a p_term at position [pos]. *)
 let p_term (pos:popt): int StrMap.t -> term -> p_term =
   let rec term idmap (t:term) :p_term =
-    if Logger.log_enabled() then log "p_term %a" Print.term t;
+    (*if Logger.log_enabled() then log "p_term %a" Print.term t;*)
     Pos.make pos (term_aux idmap t)
   and params idmap x a =
     [Some(Pos.make pos (base_name x))],Some(term idmap a),false
@@ -328,8 +328,8 @@ let p_term_of_string (pos:popt) (t:term): p_term =
     term [t] that is part of a bigger term obtained by scoping and normalizing
     of a p_term at position [pos]. *)
 let p_rwpatt_of_string (pos:popt) (t:term): p_rwpatt option =
-  if Logger.log_enabled() then
-    log "p_rwpatt_of_string %a %a" Pos.short pos term t;
+  (*if Logger.log_enabled() then
+    log "p_rwpatt_of_string %a %a" Pos.short pos term t;*)
   match t with
   | Symb s when String.is_string_literal s.sym_name ->
       let string = remove_quotes s.sym_name in
@@ -360,9 +360,8 @@ let p_tactic (ss:Sig_state.t) (g:goal) (env:Env.t) (pos:Pos.popt) (t:term)
   let p_term = p_term pos idmap in
   let tac_eval t = Pos.make pos (P_tac_eval (p_term t)) in
   let tac t =
-    if Logger.log_enabled() then log "p_tactic %a" term t;
     let t = Eval.whnf ctx t in
-    if Logger.log_enabled() then log "whnf %a" term t;
+    if Logger.log_enabled() then log "%a" term t;
     match get_args t with
     | Symb s, ts ->
         begin

--- a/src/parsing/scope.mli
+++ b/src/parsing/scope.mli
@@ -11,7 +11,7 @@ open Syntax
     contain any private subterms. If [~typ] is [true], then [t] must be
     a type (defaults to [false]). No {b new} metavariables may appear in
     [t], but metavariables in the image of [mok] may be used. The function
-    [mok] defaults to the function constant to [None]. The function
+    [mok] defaults to the constant function equal to [None]. The function
     [~find_sym] is used to scope symbol identifiers. *)
 val scope_term :
   ?find_sym:find_sym -> ?typ:bool (* default: false *) ->

--- a/tests/OK/1374.lp
+++ b/tests/OK/1374.lp
@@ -1,0 +1,57 @@
+
+require open tests.OK.HOL tests.OK.Tactic tests.OK.PropExt;
+
+symbol #and ≔ (&);
+
+// We can combine equality theorems from PropExt.lp to define tactics:
+
+symbol rem¬⊤ ≔ #and (#rewrite "" "" ¬⊤) (#rewrite "" "" ⊥∨);
+
+// We can use these as expected in proofs:
+
+symbol example x : π ((¬ ⊤ ∨ x) = x)≔
+begin
+    assume x;
+    eval rem¬⊤;
+    reflexivity
+end;
+
+// However, if we state the same theories without the "opaque" modifier, like this:
+
+symbol ¬⊤_noOp : π (¬ ⊤ = ⊥) ≔
+begin
+  refine propExt (¬ ⊤) ⊥ _ _
+    {assume h1; refine h1 ⊤ᵢ}
+    {assume h1; refine ⊥ₑ h1}
+end;
+
+symbol ⊥∨_noOp x : π ((⊥ ∨ x) = x) ≔
+begin
+  assume x; rewrite ∨_com; refine ∨⊥ x
+end;
+
+// we can successfully use them manually to write a proof:
+
+symbol example_noO_manual x : π ((¬ ⊤ ∨ x) = x)≔
+begin
+    assume x;
+    rewrite ¬⊤_noOp;
+    rewrite ⊥∨_noOp;
+    reflexivity
+end;
+
+// But if we define an equivalent tactic using these theorems:
+
+symbol rem¬⊤_noOP ≔ #and (#rewrite "" "" ¬⊤_noOp) (#rewrite "" "" ⊥∨_noOp);
+
+
+// pattern matching fails:
+
+symbol example_noOp x : π ((¬ ⊤ ∨ x) = x)≔
+begin
+    assume x;
+    eval rem¬⊤_noOP;
+    reflexivity
+end;
+
+

--- a/tests/OK/1374.lp
+++ b/tests/OK/1374.lp
@@ -1,13 +1,8 @@
-
 require open tests.OK.HOL tests.OK.Tactic tests.OK.PropExt;
 
 symbol #and ≔ (&);
 
-// We can combine equality theorems from PropExt.lp to define tactics:
-
 symbol rem¬⊤ ≔ #and (#rewrite "" "" ¬⊤) (#rewrite "" "" ⊥∨);
-
-// We can use these as expected in proofs:
 
 symbol example x : π ((¬ ⊤ ∨ x) = x)≔
 begin
@@ -15,8 +10,6 @@ begin
     eval rem¬⊤;
     reflexivity
 end;
-
-// However, if we state the same theories without the "opaque" modifier, like this:
 
 symbol ¬⊤_noOp : π (¬ ⊤ = ⊥) ≔
 begin
@@ -30,8 +23,6 @@ begin
   assume x; rewrite ∨_com; refine ∨⊥ x
 end;
 
-// we can successfully use them manually to write a proof:
-
 symbol example_noO_manual x : π ((¬ ⊤ ∨ x) = x)≔
 begin
     assume x;
@@ -40,12 +31,7 @@ begin
     reflexivity
 end;
 
-// But if we define an equivalent tactic using these theorems:
-
 symbol rem¬⊤_noOP ≔ #and (#rewrite "" "" ¬⊤_noOp) (#rewrite "" "" ⊥∨_noOp);
-
-
-// pattern matching fails:
 
 symbol example_noOp x : π ((¬ ⊤ ∨ x) = x)≔
 begin
@@ -54,4 +40,24 @@ begin
     reflexivity
 end;
 
+symbol a: Prop;
 
+symbol repeat_rewrite_defined ≔ #repeat (#rewrite "" "" =⊤);
+
+symbol example1 : π ((a = ⊤) = a) ≔
+begin
+  eval repeat_rewrite_defined;
+  reflexivity
+end;
+
+symbol example2 : π ((a = ⊤) = a) ≔
+begin
+  eval (#rewrite "" "" =⊤);
+  reflexivity
+end;
+
+symbol example3 : π ((a = ⊤) = a) ≔
+begin
+  eval (#repeat (#rewrite "" "" =⊤));
+  reflexivity
+end;

--- a/tests/OK/Tactic.lp
+++ b/tests/OK/Tactic.lp
@@ -46,7 +46,7 @@ builtin "remove" ≔ #remove;
 constant symbol #repeat : Tactic → Tactic;
 builtin "repeat" ≔ #repeat;
 
-constant symbol #rewrite [p] : π p → Tactic;
+ symbol #rewrite : String → String → Π [a], π a → Tactic;
 builtin "rewrite" ≔ #rewrite;
 
 constant symbol #set : String → Π [a], τ a → Tactic;
@@ -69,6 +69,9 @@ builtin "try" ≔ #try;
 
 constant symbol #why3 : Tactic;
 builtin "why3" ≔ #why3;
+
+constant symbol #change : Tactic;
+builtin "change" ≔ #change;
 
 // defined tactics
 

--- a/tests/export_dk.sh
+++ b/tests/export_dk.sh
@@ -47,7 +47,7 @@ do
         # require escaped module name
         π/utf_path|escape_path|'a b/escape file'|require_nondkmident);;
         # use builtin strings
-        Tactic);;
+        Tactic|1374);;
         # default case
         *) translate $f.lp;;
     esac

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -60,7 +60,7 @@ do
         # proofs
         why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit|change);;
         # "open"
-        triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod);;
+        triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|1374|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod);;
         # "inductive"
         strictly_positive_*|inductive|989|904|830|341);;
         # underscore in query

--- a/tests/purity.ml
+++ b/tests/purity.ml
@@ -9,9 +9,9 @@ let () =
 (** Sanity check for pure compilation: same file may be compiled twice. *)
 let test_compile_twice () =
   let nat_lp = "OK/natural.lp" in
-  ignore @@ Compile.PureUpToSign.compile_file nat_lp;
+  ignore @@ Library.restore_after Compile.compile_file nat_lp;
   Alcotest.(check unit) "Compile twice same file in same runtime"
-   (ignore @@ Compile.PureUpToSign.compile_file nat_lp) ()
+   (ignore @@ Library.restore_after Compile.compile_file nat_lp) ()
 
 (** Check that pure compilation is indeed pure. *)
 let purity_check () =
@@ -21,7 +21,7 @@ let purity_check () =
   let verbose = !Console.verbose in
   let loggers = Logger.get_activated_loggers () in
   let flags = Stdlib.(!Console.boolean_flags) in
-  ignore @@ Compile.PureUpToSign.compile_file "OK/natural.lp";
+  ignore @@ Library.restore_after Compile.compile_file "OK/natural.lp";
   Alcotest.(check int) "verbosity" verbose !Console.verbose;
   Alcotest.(check string) "loggers" loggers (Logger.get_activated_loggers ());
   (* The pretty printer is used to check equality *)

--- a/tests/regressions/dtrees.ml
+++ b/tests/regressions/dtrees.ml
@@ -7,7 +7,7 @@ open Core
 let () =
   Library.set_lib_root (Some "/tmp");
   Timed.(Console.verbose := 0);
-  let sign = Compile.PureUpToSign.compile_file "../OK/boolean.lp" in
+  let sign = Library.restore_after Compile.compile_file "../OK/boolean.lp" in
   let ss = Sig_state.of_sign sign in
   (* Regular symbol *)
   let sym =

--- a/tests/regressions/hrs.ml
+++ b/tests/regressions/hrs.ml
@@ -6,5 +6,5 @@ open Handle
 let () =
   Library.set_lib_root (Some "/tmp");
   Timed.(Console.verbose := 0);
-  let sign = Compile.PureUpToSign.compile_file "../OK/group.lp" in
+  let sign = Library.restore_after Compile.compile_file "../OK/group.lp" in
   Export.Hrs.sign Format.std_formatter sign

--- a/tests/regressions/xtc.ml
+++ b/tests/regressions/xtc.ml
@@ -4,5 +4,5 @@ open Handle
 let () =
   Library.set_lib_root (Some "/tmp");
   Timed.(Console.verbose := 0);
-  let sign = Compile.PureUpToSign.compile_file "../OK/group.lp" in
+  let sign = Library.restore_after Compile.compile_file "../OK/group.lp" in
   Export.Xtc.sign Format.std_formatter sign


### PR DESCRIPTION
- fix #1374 
- replace full snf reduction of tactic terms by a more incremental reduction strategy using whnf and reducing only subterms that are tactic terms
- infer the type and solve unification constraints of tactic terms before reduction and interpretation as tactics
- simplify the interface of compilation functions
- fix loading of (ghost) string symbols (their type was not set to the String builtin)