### PR TITLE
Update search query syntax documentation and rebuild Sphinx

### DIFF
--- a/doc/lambdapi.bnf
+++ b/doc/lambdapi.bnf
@@ -153,8 +153,8 @@
          | <where> <relation> ["generalize"] <term>
          | "(" <search_query> ")"
 
-<conjunction> ::= <base> ("," <base>)*
+<conjunction> ::= <base> ("with" <base>)*
 
-<disjunction> ::= <conjunction> (";" <conjunction>)*
+<disjunction> ::= <conjunction> ("|" <conjunction>)*
 
-<search> ::= <disjunction> | <search> "|" <id>
+<search> ::= <disjunction> | <search> "in" <id>

--- a/doc/queries.rst
+++ b/doc/queries.rst
@@ -115,7 +115,7 @@ specification.
 
 ::
 
-  search "spine >= (nat → nat) with hyp >= bool";
+  search spine >= (nat → nat) with hyp >= bool;
 
 .. _type:
 

--- a/doc/queries.rst
+++ b/doc/queries.rst
@@ -115,7 +115,7 @@ specification.
 
 ::
 
-  search "spine >= (nat → nat) , hyp >= bool";
+  search "spine >= (nat → nat) with hyp >= bool";
 
 .. _type:
 

--- a/doc/query_language.rst
+++ b/doc/query_language.rst
@@ -5,24 +5,24 @@ Queries can be expressed according to the following syntax:
 
 ::
 
-   Q ::= B | Q,Q | Q;Q | Q|PATH
+   Q ::= B | Q with Q | Q|Q | Q in PATH
    B ::= WHERE HOW GENERALIZE? PATTERN
    PATH ::= << string >>
    WHERE ::= name | anywhere | rule | lhs | rhs | type | concl | hyp | spine
    HOW ::= > | = | >= | ≥
    GENERALIZE ::= generalize
-   PATTERN ::= << term possibly containing placeholders _ (for terms) and V# (for variable occurrences >>
+   PATTERN ::= << term possibly containing placeholders _ (for terms) and V# (for variable occurrences) >>
 
 where
 
-* the precedence order is ``,`` > ``;`` > ``|``
+* the precedence order is ``with`` > ``|`` > ``in``
 * parentheses can be used as usual to force a different precedence order
 * ``anywhere`` can be paired only with ``>=`` and ``name`` can be paired only with ``>=`` and no ``generalize``
 * a pattern should be wrapped in parentheses, unless it is atomic (e.g. an identifier or a placeholder)
 
 The semantics of the query language is the following:
 
-* a query ``Q`` is either a base query ``B``, the conjunction ``Q1,Q2`` of two queries ``Q1`` and ``Q2``, their disjunction ``Q1;Q2`` or the query ``Q|PATH`` that behaves as ``Q``, but only keeps the results whose path is a suffix of ``PATH`` (that must be a valid path prefix)
+* a query ``Q`` is either a base query ``B``, the conjunction ``Q1 with Q2`` of two queries ``Q1`` and ``Q2``, their disjunction ``Q1 | Q2`` or the query ``Q in PATH`` that behaves as ``Q``, but only keeps the results whose path is a suffix of ``PATH`` (that must be a valid path prefix)
 * a base query ``name = ID`` looks for symbols with name ``ID`` in the library.
   The identifier ``ID`` must not be qualified.
 * a base query ``WHERE HOW GENERALIZE? PATTERN`` looks in the library for occurrences of the pattern ``PATTERN`` **up to normalization rules** and, if ``generalize`` is specified, also **up to generalization** of the pattern. The normalization rules are library specific and are employed during indexing. They can be used, for example, to remove the clutter associated to encodings, to align concepts by mapping symbols to cross-library standard ones, or to standardize the shape of statements to improve recall (e.g. replacing occurrence of ``x > y`` with ``y < x``).
@@ -46,12 +46,12 @@ Note that for commodity, ``forall`` and ``->`` can be used inside the query inst
 
 Examples:
 
-  *  ``hyp = (nat → bool) , hyp >= (list nat)``
+  *  ``hyp = (nat → bool) with hyp >= (list nat)``
      searches for theorem that have an hypothesis ``nat → bool`` and such that ``list nat`` occurs in some (other) hypothesis. The query can return ``filter_nat_list: list nat → (nat → bool) → list nat``
-  *  ``concl > plus | math.arithmetics``
+  *  ``concl > plus in math.arithmetics``
      searches for theorems having an hypothesis containing ``plus`` and located
      in a module whose path is a suffix of ``math.arithmetics``. The query
      can return ``plus_O : ∀x: nat. plus x O = x`` where ``plus_O`` has
      fully qualified name ``math.arithmetics.addition.plus``
-  *  ``name = nat ; name = NAT``
+  *  ``name = nat | name = NAT``
      searches for symbols named either ``nat`` or ``NAT``

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -270,6 +270,7 @@ let rec token lb =
   | "verbose" -> VERBOSE
   | "why3" -> WHY3
   | "with" -> WITH
+  | "ANND" -> DISJUNCTION
 
   (* other tokens *)
   | '+', Plus lowercase -> DEBUG_FLAGS(true, remove_first lb)
@@ -284,7 +285,6 @@ let rec token lb =
   | '`' -> BACKQUOTE
   | ',' -> COMMA
   | ':' -> COLON
-  | '&' -> DISJUNCTION
   | '.' -> DOT
   | 0x2261 (* ≡ *) -> EQUIV
   | 0x21aa (* ↪ *) -> HOOK_ARROW

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -109,6 +109,7 @@ type token =
   | BACKQUOTE
   | COMMA
   | COLON
+  | DISJUNCTION
   | DOT
   | EQUIV
   | HOOK_ARROW
@@ -283,6 +284,7 @@ let rec token lb =
   | '`' -> BACKQUOTE
   | ',' -> COMMA
   | ':' -> COLON
+  | '&' -> DISJUNCTION
   | '.' -> DOT
   | 0x2261 (* ≡ *) -> EQUIV
   | 0x21aa (* ↪ *) -> HOOK_ARROW

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -109,7 +109,6 @@ type token =
   | BACKQUOTE
   | COMMA
   | COLON
-  | DISJUNCTION
   | DOT
   | EQUIV
   | HOOK_ARROW
@@ -270,7 +269,6 @@ let rec token lb =
   | "verbose" -> VERBOSE
   | "why3" -> WHY3
   | "with" -> WITH
-  | "ANND" -> DISJUNCTION
 
   (* other tokens *)
   | '+', Plus lowercase -> DEBUG_FLAGS(true, remove_first lb)

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -35,6 +35,7 @@ let string_of_token = function
   | CONSTANT -> "constant"
   | DEBUG -> "debug"
   | DEBUG_FLAGS _ -> "debug flags"
+  | DISJUNCTION -> "&"
   | DOT -> "."
   | END -> "end"
   | EQUIV -> "≡"
@@ -1571,26 +1572,31 @@ and asearch (lb:lexbuf): search =
       let t = term lb in
       QBase(QSearch(t,g,Some(QXhs(r,None))))
   | UID "spine" ->
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QType(Some(Spine r)))))
   | UID "concl" ->
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QType(Some(Conclusion r)))))
   | UID "hyp" ->
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QType(Some(Hypothesis r)))))
   | UID "lhs" ->
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QXhs(r,Some Lhs))))
   | UID "rhs" ->
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
@@ -1617,8 +1623,8 @@ and ssearch (lb:lexbuf): search =
   if log_enabled() then log "%s" __FUNCTION__;
   let cq = csearch lb in
   match current_token() with
-  | SEMICOLON ->
-      let cqs = list (prefix SEMICOLON csearch) lb in
+  | DISJUNCTION ->
+      let cqs = list (prefix DISJUNCTION csearch) lb in
       List.fold_left (fun x cq -> QOp(x,Union,cq)) cq cqs
   | _ ->
       cq

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -35,7 +35,7 @@ let string_of_token = function
   | CONSTANT -> "constant"
   | DEBUG -> "debug"
   | DEBUG_FLAGS _ -> "debug flags"
-  | DISJUNCTION -> "&"
+  | DISJUNCTION -> "ANND"
   | DOT -> "."
   | END -> "end"
   | EQUIV -> "≡"

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -35,7 +35,6 @@ let string_of_token = function
   | CONSTANT -> "constant"
   | DEBUG -> "debug"
   | DEBUG_FLAGS _ -> "debug flags"
-  | DISJUNCTION -> "ANND"
   | DOT -> "."
   | END -> "end"
   | EQUIV -> "≡"
@@ -1613,8 +1612,8 @@ and csearch (lb:lexbuf): search =
   if log_enabled() then log "%s" __FUNCTION__;
   let aq = asearch lb in
   match current_token() with
-  | COMMA ->
-      let aqs = list (prefix COMMA asearch) lb in
+  | WITH ->
+      let aqs = list (prefix WITH asearch) lb in
       List.fold_left (fun x aq -> QOp(x,Intersect,aq)) aq aqs
   | _ ->
       aq
@@ -1623,8 +1622,8 @@ and ssearch (lb:lexbuf): search =
   if log_enabled() then log "%s" __FUNCTION__;
   let cq = csearch lb in
   match current_token() with
-  | DISJUNCTION ->
-      let cqs = list (prefix DISJUNCTION csearch) lb in
+  | VBAR ->
+      let cqs = list (prefix VBAR csearch) lb in
       List.fold_left (fun x cq -> QOp(x,Union,cq)) cq cqs
   | _ ->
       cq
@@ -1632,7 +1631,7 @@ and ssearch (lb:lexbuf): search =
 and search (lb:lexbuf): search =
   if log_enabled() then log "%s" __FUNCTION__;
   let q = ssearch lb in
-  let qids = list (prefix VBAR qid) lb in
+  let qids = list (prefix IN qid) lb in
   let path_of_qid qid =
     let p,n = qid.elt in
     if p = [] then n

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -273,7 +273,7 @@ let filter ppf (Path s) = out ppf " | %s" s
 let rec search ppf = function
   | QBase b -> search_base ppf b
   | QOp(q1,o,q2) -> out ppf "%a%a%a" search q1 op o search q2
-  | QFilter(q,f) -> out ppf "%a%a;" search q filter f
+  | QFilter(q,f) -> out ppf "%a%a" search q filter f
 
 let query : p_query pp = fun ppf { elt; _ } ->
   match elt with

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -264,14 +264,16 @@ let search_base ppf = function
   | QSearch(t,g,Some c) ->
       out ppf "%a%a%a" search_constr c generalize g term t
 
-let op ppf o = string ppf (match o with Union -> "; " | Intersect -> ", ")
+let op ppf o = string ppf (match o with
+    Union -> " " ^ LpParser.string_of_token DISJUNCTION ^ " "
+  | Intersect -> LpParser.string_of_token COMMA ^ " ")
 
 let filter ppf (Path s) = out ppf " | %s" s
 
 let rec search ppf = function
   | QBase b -> search_base ppf b
   | QOp(q1,o,q2) -> out ppf "%a%a%a" search q1 op o search q2
-  | QFilter(q,f) -> out ppf "%a%a" search q filter f
+  | QFilter(q,f) -> out ppf "%a%a;" search q filter f
 
 let query : p_query pp = fun ppf { elt; _ } ->
   match elt with

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -259,7 +259,7 @@ let search_constr ppf = function
 let generalize ppf b = if b then string ppf " generalize"
 
 let search_base ppf = function
-  | QName s -> out ppf "name %s" s
+  | QName s -> out ppf "name = %s" s
   | QSearch(t,g,None) -> out ppf "anywhere%a%a" generalize g term t
   | QSearch(t,g,Some c) ->
       out ppf "%a%a%a" search_constr c generalize g term t

--- a/src/parsing/pretty.ml
+++ b/src/parsing/pretty.ml
@@ -265,10 +265,10 @@ let search_base ppf = function
       out ppf "%a%a%a" search_constr c generalize g term t
 
 let op ppf o = string ppf (match o with
-    Union -> " " ^ LpParser.string_of_token DISJUNCTION ^ " "
-  | Intersect -> LpParser.string_of_token COMMA ^ " ")
+    Union -> " | "
+  | Intersect -> " with ")
 
-let filter ppf (Path s) = out ppf " | %s" s
+let filter ppf (Path s) = out ppf " in %s" s
 
 let rec search ppf = function
   | QBase b -> search_base ppf b

--- a/tests/OK/search.lp
+++ b/tests/OK/search.lp
@@ -1,6 +1,6 @@
 
 //verbose 3;
 symbol C : TYPE;
-search name = C , name = C | tests.OK ;
-search name = C ANND name = QQ;
-search name = C | tests.OK;
+search name = C with name = C in tests.OK ;
+search name = C | name = QQ;
+search name = C in tests.OK;

--- a/tests/OK/search.lp
+++ b/tests/OK/search.lp
@@ -1,4 +1,6 @@
 
 //verbose 3;
 symbol C : TYPE;
-search name = C;
+search name = C , name = QQ;
+search name = C ANND name = QQ;
+search name = C ;

--- a/tests/OK/search.lp
+++ b/tests/OK/search.lp
@@ -1,6 +1,6 @@
 
 //verbose 3;
 symbol C : TYPE;
-search name = C , name = QQ;
+search name = C , name = C | tests.OK ;
 search name = C ANND name = QQ;
-search name = C ;
+search name = C | tests.OK;

--- a/tests/OK/search.lp
+++ b/tests/OK/search.lp
@@ -1,0 +1,4 @@
+
+//verbose 3;
+symbol C : TYPE;
+search name = C;


### PR DESCRIPTION
This PR updates the search query syntax documentation to reflect the current parser implementation and fixes the inconsistency reported in #1373.

### Syntax Changes

The search query command now uses the following operators:
- **`with`** (instead of `,`): conjunction
- **`|`**  (instead of `;`): disjunction  
- **`in`**  (instead of `|`): filtering

### Checklist from CONTRIBUTING for syntax changes:
- [x] doc/lambdapi.bnf
- [x] src/core/lpLexer.ml (no changes needed)
- [x] src/core/lpParser.ml 
- [x] src/core/pretty.ml
- [x] src/core/print.ml (no changes needed)
- [x] editors/vim/syntax/lambdapi.vim (no changes needed)
- [x] editors/emacs/lambdapi-vars.el (no changes needed)
- [x] editors/emacs/lambdapi-smie.el (no changes needed)
- [x] editors/vscode/lp.configuration.json (no changes needed)
- [x] editors/vscode/syntaxes/lp.tmLanguage.json (no changes needed)
- [x] misc/lambdapi.tex (no changes needed)
- [x] User Manual files in doc/ repository (Sphinx build verified)

### Verification

- Sphinx build succeeded with `python3 -m sphinx -b html . _build/html`
- HTML documentation generated in doc/_build/html
- Test suite passes with updated search query syntax

Closes #1373"