### PR TITLE
coq export: check that identifiers are valid in rocq

### DIFF
--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -23,7 +23,7 @@ open Core
 let log = Logger.make 'x' "xprt" "export"
 let log = log.pp
 
-(** Valid Rocq identifiers. *)
+(** Valid Rocq identifiers (excluding unicode characters). *)
 
 let is_valid_first_letter =
   function 'a'..'z' | 'A'..'Z' | '_' -> true | _ -> false
@@ -81,7 +81,7 @@ let sym b = builtin.(index_of_builtin b)
 
 let rmap = ref StrMap.empty
 
-let add_renaming id1 id2 = check id2; rmap := StrMap.add id1 id2.elt !rmap
+let add_renaming id1 id2 = rmap := StrMap.add id1 id2.elt !rmap
 
 let set_renaming : string -> unit = fun f ->
   let consume = function

--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -80,8 +80,11 @@ let sym b = builtin.(index_of_builtin b)
 (** Set renaming map from file. *)
 
 let rmap = ref StrMap.empty
+let codom = ref StrSet.empty
 
-let add_renaming id1 id2 = rmap := StrMap.add id1 id2.elt !rmap
+let add_renaming id1 id2 =
+  rmap := StrMap.add id1 id2.elt !rmap;
+  codom := StrSet.add id2.elt !codom
 
 let set_renaming : string -> unit = fun f ->
   let consume = function
@@ -168,10 +171,7 @@ let list elt sep oc xs =
 
 let translate_ident : strloc -> string = fun ({elt=s;_} as id) ->
   try StrMap.find s !rmap
-  with Not_found ->
-    check id;
-    if StrMap.exists (fun _ id2 -> s = id2) !rmap then s ^ "__alt__"
-    else s
+  with Not_found -> if StrSet.mem s !codom then s^"_alt_" else (check id; s)
 
 let ident oc s = string oc (translate_ident s)
 

--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -119,8 +119,7 @@ let set_mapping : string -> unit = fun f ->
         erase := StrSet.add id !erase;
         map_erased_qid_coq :=
           QidMap.add lp_qid.elt coq_id !map_erased_qid_coq;
-        if fst lp_qid.elt = [] && id <> coq_id
-        then add_renaming pos id coq_id
+        if fst lp_qid.elt = [] then add_renaming pos id coq_id
     | {pos;_} -> fatal pos "Invalid command."
   in
   Stream.iter consume (Parser.parse_file f)

--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -31,8 +31,8 @@ let is_valid_letter =
   function 'a'..'z' | 'A'..'Z' | '_' | '0'..'9' | '\'' -> true | _ -> false
 let is_valid_rocq_id s =
   s <> "" && is_valid_first_letter s.[0] && String.for_all is_valid_letter s
-let check {elt;pos} =
-  if not (is_valid_rocq_id elt) then fatal pos "invalid Rocq identifier"
+let check pos s =
+  if not (is_valid_rocq_id s) then fatal pos "invalid Rocq identifier"
 
 (** Symbols necessary to encode STT. *)
 
@@ -173,9 +173,10 @@ let list elt sep oc xs =
 
 (** Translation of identifiers. *)
 
-let translate_ident : strloc -> string = fun ({elt=s;_} as id) ->
+let translate_ident : strloc -> string = fun {elt=s;pos} ->
   try StrMap.find s !rmap
-  with Not_found -> if StrSet.mem s !codom then s^"_alt_" else (check id; s)
+  with Not_found ->
+    if StrSet.mem s !codom then s^"__alt__" else (check pos s; s)
 
 let ident oc s = string oc (translate_ident s)
 
@@ -186,7 +187,7 @@ let param_id oc idopt =
 
 let param_ids = list param_id " "
 
-let path_elt pos oc s = check {elt=s;pos}; string oc s
+let path_elt pos oc s = check pos s; string oc s
 
 let path oc {elt;pos} = list (path_elt pos) "." oc elt
 

--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -23,6 +23,17 @@ open Core
 let log = Logger.make 'x' "xprt" "export"
 let log = log.pp
 
+(** Valid Rocq identifiers. *)
+
+let is_valid_first_letter =
+  function 'a'..'z' | 'A'..'Z' | '_' -> true | _ -> false
+let is_valid_letter =
+  function 'a'..'z' | 'A'..'Z' | '_' | '0'..'9' | '\'' -> true | _ -> false
+let is_valid_rocq_id s =
+  s <> "" && is_valid_first_letter s.[0] && String.for_all is_valid_letter s
+let check {elt;pos} =
+  if not (is_valid_rocq_id elt) then fatal pos "invalid Rocq identifier"
+
 (** Symbols necessary to encode STT. *)
 
 type builtin =
@@ -70,11 +81,13 @@ let sym b = builtin.(index_of_builtin b)
 
 let rmap = ref StrMap.empty
 
+let add_renaming id1 id2 = check id2; rmap := StrMap.add id1 id2.elt !rmap
+
 let set_renaming : string -> unit = fun f ->
   let consume = function
-    | {elt=P_builtin(coq_id,{elt=([],lp_id);_});_} ->
+    | {elt=P_builtin(coq_id,{elt=([],lp_id);_});pos} ->
         if Logger.log_enabled() then log "rename %s into %s" lp_id coq_id;
-        rmap := StrMap.add lp_id coq_id !rmap
+        add_renaming lp_id {elt=coq_id;pos}
     | {pos;_} -> fatal pos "Invalid command."
   in
   Stream.iter consume (Parser.parse_file f)
@@ -90,7 +103,7 @@ let map_erased_qid_coq = ref QidMap.empty
 
 let set_mapping : string -> unit = fun f ->
   let consume = function
-    | {elt=P_builtin(coq_id,lp_qid);_} ->
+    | {elt=P_builtin(coq_id,lp_qid);pos} ->
         if Logger.log_enabled() then
           log "rename %a into %s" Pretty.qident lp_qid coq_id;
         let id = snd lp_qid.elt in
@@ -98,8 +111,8 @@ let set_mapping : string -> unit = fun f ->
         erase := StrSet.add id !erase;
         map_erased_qid_coq :=
           QidMap.add lp_qid.elt coq_id !map_erased_qid_coq;
-        if fst lp_qid.elt = [] && id <> coq_id then
-          rmap := StrMap.add id coq_id !rmap
+        if fst lp_qid.elt = [] && id <> coq_id
+        then add_renaming id {elt=coq_id;pos};
     | {pos;_} -> fatal pos "Invalid command."
   in
   Stream.iter consume (Parser.parse_file f)
@@ -153,13 +166,14 @@ let list elt sep oc xs =
 
 (** Translation of identifiers. *)
 
-let translate_ident : string -> string = fun s ->
-  try StrMap.find s !rmap with Not_found ->
-    if StrMap.exists (fun _ id' -> s = id') !rmap then s ^ "__alt__" else s
+let translate_ident : strloc -> string = fun ({elt=s;_} as id) ->
+  try StrMap.find s !rmap
+  with Not_found ->
+    check id;
+    if StrMap.exists (fun _ id2 -> s = id2) !rmap then s ^ "__alt__"
+    else s
 
-let raw_ident oc s = string oc (translate_ident s)
-
-let ident oc {elt;_} = raw_ident oc elt
+let ident oc s = string oc (translate_ident s)
 
 let param_id oc idopt =
   match idopt with
@@ -168,14 +182,13 @@ let param_id oc idopt =
 
 let param_ids = list param_id " "
 
-let raw_path = list string "."
+let path_elt pos oc s = check {elt=s;pos}; string oc s
 
-let path oc {elt;_} = raw_path oc elt
+let path oc {elt;pos} = list (path_elt pos) "." oc elt
 
-let qident oc {elt=(mp,s);_} =
-  match mp with
-  | [] -> raw_ident oc s
-  | _::_ -> raw_path oc mp; char oc '.'; raw_ident oc s
+let qident oc {elt=(mp,s);pos} =
+  if mp <> [] then (path oc {elt=mp;pos}; char oc '.');
+  ident oc {elt=s;pos}
 
 (** Translation of terms. *)
 

--- a/src/export/coq.ml
+++ b/src/export/coq.ml
@@ -82,15 +82,20 @@ let sym b = builtin.(index_of_builtin b)
 let rmap = ref StrMap.empty
 let codom = ref StrSet.empty
 
-let add_renaming id1 id2 =
-  rmap := StrMap.add id1 id2.elt !rmap;
-  codom := StrSet.add id2.elt !codom
+let add_renaming pos s1 s2 =
+  let f = function
+    | None -> Some s2
+    | Some s2' ->
+      fatal pos "\"%s\" renamed to both \"%s\" and \"%s\"" s1 s2' s2
+  in
+  rmap := StrMap.update s1 f !rmap;
+  codom := StrSet.add s2 !codom
 
 let set_renaming : string -> unit = fun f ->
   let consume = function
     | {elt=P_builtin(coq_id,{elt=([],lp_id);_});pos} ->
         if Logger.log_enabled() then log "rename %s into %s" lp_id coq_id;
-        add_renaming lp_id {elt=coq_id;pos}
+        add_renaming pos lp_id coq_id
     | {pos;_} -> fatal pos "Invalid command."
   in
   Stream.iter consume (Parser.parse_file f)
@@ -115,7 +120,7 @@ let set_mapping : string -> unit = fun f ->
         map_erased_qid_coq :=
           QidMap.add lp_qid.elt coq_id !map_erased_qid_coq;
         if fst lp_qid.elt = [] && id <> coq_id
-        then add_renaming id {elt=coq_id;pos};
+        then add_renaming pos id coq_id
     | {pos;_} -> fatal pos "Invalid command."
   in
   Stream.iter consume (Parser.parse_file f)


### PR DESCRIPTION
This PR fixes #1391. The translation of an identifier is as follows:
- We first check whether it must be renamed using the maps given with the options --renaming and --mapping. If so, we just return the string given by the renaming maps without checking it further.
- Otherwise, we check that it is an ASCII identifier valid in Rocq. If not, we fail.

Hence, for instance, ε will fail, unless it is renamed to itself in the --renaming map (this works because we do not check the validity of strings to which identifiers are renamed).

Recognizing the unicode identifiers accepted by Rocq is non trivial (see https://github.com/rocq-prover/rocq/blob/master/clib/unicode.ml and https://github.com/rocq-prover/rocq/blob/master/parsing/cLexer.ml). As files do not usually contain so many unicode identifiers, asking users to declare them in --renaming seems like a good compromise.

Impact on performances:
- on holide library (626 Mb of dk files): the PR takes 33.3s while master takes 32.3s (+3%)

Other changes:
- We check that identifiers declared with the options --renaming and --mapping are not renamed twice.

TODO:
- [x] measure impact of identifier validity checking on performances
- [ ] add option to deactivate validity checking ?
- [ ] port these changes to lean export (#1197)