### PR TITLE
lexer: fail when escaping a regular id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Change lp parser based on Menhir by one written by hand to provide more helpful error messages while being equally efficient.
 - Replace full SNF reduction of tactic terms by a more incremental reduction strategy using WHNF and recursively reducing only subterms that are tactic terms.
 - Infer the type and solve unification constraints of tactic terms before reduction and interpretation as tactics.
+- Syntax: forbid escaping regular identifiers that are not keywords.
 
 ### Fixed
 

--- a/doc/terms.rst
+++ b/doc/terms.rst
@@ -9,13 +9,10 @@ An identifier can be:
 
 * a *regular* identifier: ``/`` or an arbitrary non-empty sequence of
   UTF-8 codepoints not among ``\t\r\n :,;`(){}[]".@$|?/`` that is not
-  an integer number
+  a space, a tabulation, a newline, an integer or a keyword
 
-* an *escaped* identifier: an arbitrary sequence of characters
-  enclosed between ``{|`` and ``|}``
-
-**Remark:** for any regular identifier ``i``, ``{|i|}`` and ``i`` are
-identified.
+* an *escaped* identifier: an arbitrary sequence of characters that is
+  not a regular identifier enclosed between ``{|`` and ``|}``
 
 **Convention:** identifiers starting with an uppercase letter denote
 types (e.g.  ``Nat``, ``List``), and identifiers starting with a

--- a/src/export/dk.ml
+++ b/src/export/dk.ml
@@ -2,7 +2,7 @@
 
 open Lplib open Base open Extra
 open Timed
-open Common
+open Common open Escape open Error
 open Core open Term
 
 (** Translation of identifiers. Lambdapi identifiers that are Dedukti keywords
@@ -64,20 +64,34 @@ let is_mident : string -> bool = fun s ->
   done;
   to_string b*)
 
+(* convert a Lambdapi id into a Dedukti id *)
 let ident : string pp = fun ppf s ->
   string ppf
-    (if s = "" then Escape.escape s
-     else if s.[0] = '{' then s
-     else if is_keyword s then Escape.escape s
+    (if s = "" then escape s
+     else if s.[0] = '{' then
+       begin
+         let s' = unescape s in
+         if Parsing.LpLexer.is_keyword s' then
+           if is_keyword s' then s else s'
+         else s
+       end
+     else if is_keyword s then escape s
      else if is_ident s then s
-     else Escape.escape s)
+     else escape s)
 
-(** Translation of paths. Paths equal to the [!current_path] are not
-   printed. Non-empty paths end with a dot. We assume that the module p1.p2.p3
-   is in the file p1_p2_p3.dk. *)
-
-let path_elt : string pp = fun ppf s ->
-  string ppf (if Escape.is_escaped s then Escape.unescape s else s)
+let mident: string pp = fun ppf s ->
+  let exception Invalid in
+  try
+    string ppf
+      (if s = "" then raise Invalid
+       else if s.[0] = '{' then
+         begin
+           let s' = unescape s in
+           if Parsing.LpLexer.is_keyword s' then s' else raise Invalid
+         end
+       else if is_mident s then s
+       else raise Invalid)
+  with Invalid -> fatal_no_pos "invalid Dedukti module name \"%s\"" s
 
 let current_path = Stdlib.ref []
 
@@ -85,7 +99,7 @@ let path : Path.t pp = fun ppf p ->
   if p <> Stdlib.(!current_path) then
   match p with
   | [] -> ()
-  | p -> out ppf "%s." (List.last p)
+  | p -> out ppf "%a." mident (List.last p)
 
 let qid : (Path.t * string) pp = fun ppf (p, i) ->
   out ppf "%a%a" path p ident i

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -24,6 +24,74 @@ let fail : lexbuf -> string -> 'a = fun lb msg ->
 let invalid_character : lexbuf -> 'a = fun lb ->
   fail lb "Invalid character"
 
+let keywords = Extra.StrSet.of_list [
+    "abort";
+    "admit";
+    "admitted";
+    "apply";
+    "as";
+    "assert";
+    "assertnot";
+    "associative";
+    "assume";
+    "begin";
+    "builtin";
+    "change";
+    "coerce_rule";
+    "commutative";
+    "compute";
+    "constant";
+    "debug";
+    "end";
+    "eval";
+    "fail";
+    "flag";
+    "generalize";
+    "have";
+    "in";
+    "induction";
+    "inductive";
+    "infix";
+    "injective";
+    "left";
+    "let";
+    "notation";
+    "off";
+    "on";
+    "opaque";
+    "open";
+    "postfix";
+    "prefix";
+    "print";
+    "private";
+    "proofterm";
+    "protected";
+    "prover";
+    "prover_timeout";
+    "quantifier";
+    "refine";
+    "reflexivity";
+    "remove";
+    "repeat";
+    "require";
+    "rewrite";
+    "right";
+    "rule";
+    "search";
+    "sequential";
+    "set";
+    "simplify";
+    "solve";
+    "symbol";
+    "symmetry";
+    "try";
+    "type";
+    "Type";
+    "unif_rule";
+    "verbose";
+    "why3";
+    "with"]
+
 (** Tokens. *)
 type token =
   (* end of file *)
@@ -145,18 +213,13 @@ let string = [%sedlex.regexp? '"', Star (Compl '"'), '"']
 (** Identifiers.
 
    There are two kinds of identifiers: regular identifiers and escaped
-   identifiers of the form ["{|...|}"].
+   identifiers of the form [{|...|}].
 
    Modulo those surrounding brackets, escaped identifiers allow to use as
    identifiers keywords or filenames that are not regular identifiers.
 
    An escaped identifier denoting a filename or directory is unescaped before
-   accessing to it. Hence, the module ["{|a b|}"] refers to the file ["a b"].
-
-   Identifiers need to be normalized so that an escaped identifier, once
-   unescaped, is not regular. To this end, every identifier of the form
-   ["{|s|}"] with s regular, is understood as ["s"] (function
-   [remove_useless_escape] below).
+   accessing to it. Hence, the module [{|a b|}] refers to the file [a b].
 
    Finally, identifiers must not be empty, so that we can use the empty string
    for the path of ghost signatures. *)
@@ -182,10 +245,13 @@ let escid = [%sedlex.regexp?
    regular. We do not check whether [s] contains ["|}"]. FIXME? *)
 let escape s = if is_regid s then s else Escape.escape s
 
-(** [remove_useless_escape s] replaces escaped regular identifiers by their
+(** [check_escape s] replaces escaped regular identifiers by their
    unescape form. *)
-let remove_useless_escape : string -> string = fun s ->
-  let s' = Escape.unescape s in if is_regid s' then s' else s
+let check_escape : lexbuf -> string -> string = fun lb s ->
+  let s' = Escape.unescape s in
+  if is_regid s' && not (Extra.StrSet.mem s' keywords)
+  then fail lb "Escaped regular identifier"
+  else s
 
 (** Lexer. *)
 let rec token lb =
@@ -301,18 +367,18 @@ let rec token lb =
 
   (* identifiers *)
   | regid -> UID(Utf8.lexeme lb)
-  | escid -> UID(remove_useless_escape(Utf8.lexeme lb))
+  | escid -> UID(check_escape lb (Utf8.lexeme lb))
   | '@', regid -> UID_EXPL(remove_first lb)
-  | '@', escid -> UID_EXPL(remove_useless_escape(remove_first lb))
+  | '@', escid -> UID_EXPL(check_escape lb (remove_first lb))
   | '?', nat -> UID_META(int_of_string(remove_first lb))
   | '$', regid -> UID_PATT(remove_first lb)
-  | '$', escid -> UID_PATT(remove_useless_escape(remove_first lb))
+  | '$', escid -> UID_PATT(check_escape lb (remove_first lb))
   | '$', nat -> UID_PATT(remove_first lb)
 
   | regid, '.' -> qid false [remove_last lb] lb
-  | escid, '.' -> qid false [remove_useless_escape(remove_last lb)] lb
+  | escid, '.' -> qid false [check_escape lb (remove_last lb)] lb
   | '@', regid, '.' -> qid true [remove_ends lb] lb
-  | '@', escid, '.' -> qid true [remove_useless_escape(remove_ends lb)] lb
+  | '@', escid, '.' -> qid true [check_escape lb (remove_ends lb)] lb
 
   (* invalid character *)
   | _ -> invalid_character lb
@@ -323,13 +389,13 @@ and qid expl ids lb =
   | "/*" -> comment (qid expl ids) 0 lb
   | int -> QINT(List.rev ids, Utf8.lexeme lb)
   | regid, '.' -> qid expl (remove_last lb :: ids) lb
-  | escid, '.' -> qid expl (remove_useless_escape(remove_last lb) :: ids) lb
+  | escid, '.' -> qid expl (check_escape lb (remove_last lb) :: ids) lb
   | regid ->
     if expl then QID_EXPL(Utf8.lexeme lb :: ids)
     else QID(Utf8.lexeme lb :: ids)
   | escid ->
-    if expl then QID_EXPL(remove_useless_escape (Utf8.lexeme lb) :: ids)
-    else QID(remove_useless_escape (Utf8.lexeme lb) :: ids)
+    if expl then QID_EXPL(check_escape lb (Utf8.lexeme lb) :: ids)
+    else QID(check_escape lb (Utf8.lexeme lb) :: ids)
   | _ -> fail lb ("Invalid identifier: \"" ^ Utf8.lexeme lb ^ "\".")
 
 and comment next i lb =

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -92,6 +92,8 @@ let keywords = Extra.StrSet.of_list [
     "why3";
     "with"]
 
+let is_keyword s = Extra.StrSet.mem s keywords
+
 (** Tokens. *)
 type token =
   (* end of file *)
@@ -249,7 +251,7 @@ let escape s = if is_regid s then s else Escape.escape s
    unescape form. *)
 let check_escape : lexbuf -> string -> string = fun lb s ->
   let s' = Escape.unescape s in
-  if is_regid s' && not (Extra.StrSet.mem s' keywords)
+  if is_regid s' && not (is_keyword s')
   then fail lb "Escaped regular identifier"
   else s
 

--- a/tests/KO/escape.lp
+++ b/tests/KO/escape.lp
@@ -1,0 +1,1 @@
+symbol {|B|}:TYPE;

--- a/tests/KO/escape2.lp
+++ b/tests/KO/escape2.lp
@@ -1,0 +1,2 @@
+symbol A:TYPE;
+assert ⊢ A ≡ {|A|};

--- a/tests/OK/262_pair_ex_2.lp
+++ b/tests/OK/262_pair_ex_2.lp
@@ -1,4 +1,4 @@
-require open tests.OK.{|262_pair_ex_1|};
+require open tests.OK.262_pair_ex_1;
 
 symbol a : A;
 symbol b : A;

--- a/tests/OK/262_private_in_lhs.lp
+++ b/tests/OK/262_private_in_lhs.lp
@@ -1,5 +1,5 @@
 // Using private symbols in LHSs
-require tests.OK.{|262_parsing|} as D;
+require tests.OK.262_parsing as D;
 
 symbol f : D.A → D.A;
 

--- a/tests/OK/621c.lp
+++ b/tests/OK/621c.lp
@@ -1,4 +1,0 @@
-// test that an escaped regular identifier is equal to its unescaped form
-
-symbol A:TYPE;
-symbol f (v0:A) ≔ {|v0|};

--- a/tests/OK/Escaped.lp
+++ b/tests/OK/Escaped.lp
@@ -1,12 +1,11 @@
-// The following is forbidden as [KIND] is reserved.
-//symbol KIND : TYPE;
+// used in tests/dtrees.sh
 
 // The following is accepted.
-symbol {|KIND|} : TYPE;
+symbol {|symbol|} : TYPE;
 
 // Escaped with dots (used to test module resolution)
 symbol {|KIND.OF.BLUE|}: TYPE;
 
 // Escaped with some rules
-symbol {|_set|} : TYPE;
-rule {|_set|} ↪ {|KIND|};
+symbol {|let|} : TYPE;
+rule {|let|} ↪ {|symbol|};

--- a/tests/OK/a b/escape file.lp
+++ b/tests/OK/a b/escape file.lp
@@ -4,4 +4,3 @@ symbol {|}|}:TYPE;
 symbol {|||}:TYPE;
 symbol {|a.}|_|_}}|||}:TYPE;
 symbol A:TYPE;
-assert ⊢ A ≡ {|A|};

--- a/tests/OK/escape_path.lp
+++ b/tests/OK/escape_path.lp
@@ -1,4 +1,4 @@
 // test escaped identifiers in paths
-require open {|tests|}.OK.{|a b|}.{|escape file|};
-assert ⊢ {|tests|}.OK.{|a b|}.{|escape file|}.A
+require open tests.OK.{|a b|}.{|escape file|};
+assert ⊢ tests.OK.{|a b|}.{|escape file|}.A
            ≡ tests.OK.{|a b|}.{|escape file|}.A;

--- a/tests/OK/inductive.lp
+++ b/tests/OK/inductive.lp
@@ -480,23 +480,23 @@ assert a p q pnode pnil pcons t l ⊢
 
 ////////////////// Type sum - test names between {|...|} too
 
-inductive {|sum|} : Set → Set → TYPE ≔
- | {|inl_sum|} : Π a b, τ a → {|sum|} a b
- | inr : Π a b, τ b → {|sum|} a b;
+inductive sum : Set → Set → TYPE ≔
+ | inl_sum : Π a b, τ a → sum a b
+ | inr : Π a b, τ b → sum a b;
 
-assert ⊢ {|sum|} : Set → Set → TYPE;
-assert ⊢ {|inl_sum|} : Π a b, τ a → {|sum|} a b;
-assert ⊢ inr : Π a b, τ b → {|sum|} a b;
+assert ⊢ sum : Set → Set → TYPE;
+assert ⊢ inl_sum : Π a b, τ a → sum a b;
+assert ⊢ inr : Π a b, τ b → sum a b;
 
-assert ⊢ {|ind_sum|} : Π p,
-(Π a b xa, π(p a b ({|inl_sum|} a b xa))) →
+assert ⊢ ind_sum : Π p,
+(Π a b xa, π(p a b (inl_sum a b xa))) →
 (Π a b xb, π(p a b (inr a b xb))) →
 Π a b s, π(p a b s);
 
 assert pS pinl pinr g d xg
-⊢ {|ind_sum|} pS pinl pinr g d ({|inl_sum|} g d xg) ≡ pinl g d xg;
+⊢ ind_sum pS pinl pinr g d (inl_sum g d xg) ≡ pinl g d xg;
 assert pS pinl pinr g d xd
-⊢ {|ind_sum|} pS pinl pinr g d (inr g d xd) ≡ pinr g d xd;
+⊢ ind_sum pS pinl pinr g d (inr g d xd) ≡ pinr g d xd;
 
 //////////////////// Vectors of natural numbers
 

--- a/tests/OK/logic.lp
+++ b/tests/OK/logic.lp
@@ -57,7 +57,7 @@ constant symbol eqind : Π a x y, P (x = y) → Π p:T a → Prop, P (p y) → P
 constant symbol bot        : Prop;
 constant symbol top        : Prop;
 constant symbol imp        : Prop → Prop → Prop;
-constant symbol {|and|}    : Prop → Prop → Prop;
+constant symbol and    : Prop → Prop → Prop;
 constant symbol or         : Prop → Prop → Prop;
 constant symbol not        : Prop → Prop;
 
@@ -74,9 +74,9 @@ symbol bot_elim         : Π (p : Prop), P bot → P p;
 symbol excl_mid         : Π (p : Prop), P (or p (not p));
 
 // Intro and Elimination of and
-symbol and_intro        : Π (p : Prop) (q : Prop), P p → P q → P ({|and|} p q);
-symbol and_elim1        : Π (p : Prop) (q : Prop), P ({|and|} p q) → P p;
-symbol and_elim2        : Π (p : Prop) (q : Prop), P ({|and|} p q) → P q;
+symbol and_intro        : Π (p : Prop) (q : Prop), P p → P q → P (and p q);
+symbol and_elim1        : Π (p : Prop) (q : Prop), P (and p q) → P p;
+symbol and_elim2        : Π (p : Prop) (q : Prop), P (and p q) → P q;
 
 // Intro and Elimination of or
 symbol or_intro1        : Π (p : Prop) (q : Prop), P p → P (or p q);
@@ -110,7 +110,7 @@ builtin "refl"  ≔ refl;
 builtin "bot"   ≔ bot;
 builtin "top"   ≔ top;
 builtin "imp"   ≔ imp;
-builtin "and"   ≔ {|and|};
+builtin "and"   ≔ and;
 builtin "or"    ≔ or;
 builtin "not"   ≔ not;
 
@@ -118,5 +118,5 @@ constant symbol ex: Π (a : U), (T a → Prop) → Prop;
 builtin "ex" ≔ ex; 
 builtin "all" ≔ all;
 
-symbol eqv p q ≔ {|and|} (imp p q) (imp q p);
+symbol eqv p q ≔ and (imp p q) (imp q p);
 builtin "eqv" ≔ eqv;

--- a/tests/dtrees.sh
+++ b/tests/dtrees.sh
@@ -23,12 +23,12 @@ else
 fi
 
 # Escaped identifier with no rule
-out="$(${LAMBDAPI} 'tests.OK.Escaped.{|KIND|}' 2>/dev/null)"
+out="$(${LAMBDAPI} 'tests.OK.Escaped.{|symbol|}' 2>/dev/null)"
 if [ "$?" = 1 ]; then
-    ko 'tests.OK.Escaped.{|KIND|}'
+    ko 'tests.OK.Escaped.{|symbol|}'
 fi
 if [ -z "$out" ]; then
-    ok 'tests.OK.Escaped.{|KIND|}'
+    ok 'tests.OK.Escaped.{|symbol|}'
 fi
 
 # Escaped identifier with dots and no rule
@@ -41,11 +41,11 @@ if [ -z "$out" ]; then
 fi
 
 # Escaped identifier with rules
-out="$(${LAMBDAPI} 'tests.OK.Escaped.{|_set|}' 2>/dev/null)"
+out="$(${LAMBDAPI} 'tests.OK.Escaped.{|let|}' 2>/dev/null)"
 if [ "$?" = 1 ] || [ -z "$out" ]; then
-    ko 'tests.OK.Escaped.{|_set|}'
+    ko 'tests.OK.Escaped.{|let|}'
 else
-    ok 'tests.OK.Escaped.{|_set|}'
+    ok 'tests.OK.Escaped.{|let|}'
 fi
 
 # Ghost symbol

--- a/tests/export_dk.sh
+++ b/tests/export_dk.sh
@@ -52,6 +52,8 @@ do
         *) translate $f.lp;;
     esac
 done
+# remove when Dedukti 2.8 will be released
+rm -f require_symbol.dk
 cd ../..
 
 check() {

--- a/tests/export_dk.sh
+++ b/tests/export_dk.sh
@@ -51,8 +51,6 @@ do
         *) translate $f.lp;;
     esac
 done
-# remove when Dedukti 2.8 will be released
-rm -f require_symbol.dk
 cd ../..
 
 check() {


### PR DESCRIPTION
- lexing: fail when the user escape a regular identifier
- dk export: escape only identifiers that are not regular in Dedukti, fail if a module identifier is not valid in Dedukti