### PR TITLE
Fix indexing and query parsing issues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ Minor fixes after indexing_BO merge
 [X] notation was not working any more (Pratter was) because of bad way of requiring
   files in cli/lambdapi.ml
 [X] added position in error messages from query commands
-[] in case of syntax error the websearch now does not return the page
+[X] in case of syntax error the websearch now does not return the page
 
 
 Index and search

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@ Minor fixes after indexing_BO merge
 [X] notation was not working any more (Pratter was) because of bad way of requiring
   files in cli/lambdapi.ml
 [X] added position in error messages from query commands
-[] Error: End_of_file with query hyp = (forall x, _)
 [] Unexpected search result for query hyp >= (\Pi x:T, (U x -> T)) (but working for (\Pi _, _))
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ Minor fixes after indexing_BO merge
 [X] notation was not working any more (Pratter was) because of bad way of requiring
   files in cli/lambdapi.ml
 [X] added position in error messages from query commands
-[] Unexpected search result for query hyp >= (\Pi x:T, (U x -> T)) (but working for (\Pi _, _))
+[] in case of syntax error the websearch now does not return the page
 
 
 Index and search

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 TODO
 ====
 
-Minor fixes after indexing_BO merge
+Minor fixes after [indexing_BO](https://github.com/Deducteam/lambdapi/pull/1290) merge 
 ----------------
 
 [X] parsing was ignoring trailing characters after query

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,17 @@
 TODO
 ====
 
+Minor fixes after indexing_BO merge
+----------------
+
+[X] parsing was ignoring trailing characters after query
+[X] notation was not working any more (Pratter was) because of bad way of requiring
+  files in cli/lambdapi.ml
+[X] added position in error messages from query commands
+[] Error: End_of_file with query hyp = (forall x, _)
+[] Unexpected search result for query hyp >= (\Pi x:T, (U x -> T)) (but working for (\Pi _, _))
+
+
 Index and search
 ----------------
 

--- a/src/cli/lambdapi.ml
+++ b/src/cli/lambdapi.ml
@@ -23,11 +23,13 @@ struct
 let sig_state_of_require l : Sig_state.sig_state =
  (* Search for a package from the current working directory. *)
  Package.apply_config (Filename.concat (Sys.getcwd()) ".") ;
- let f ss req =
-    Core.Sig_state.of_sign (Compile.compile ss
-         (Parsing.Parser.path_of_string req)) in
  List.fold_left
-  f Core.Sig_state.dummy l
+  (fun ss req ->
+    Handle.Command.handle Compile.compile ss
+     (Pos.none
+      (Parsing.Syntax.P_require
+        (Some false, [Pos.none (Parsing.Parser.path_of_string req)]))))
+  Core.Sig_state.dummy l
 
 let search_cmd cfg rules require s dbpath_opt =
  Config.init cfg;

--- a/src/common/error.ml
+++ b/src/common/error.ml
@@ -66,6 +66,10 @@ let fatal_no_pos : ?err_desc:string -> ('a,'b) koutfmt -> 'a =
       raise (Fatal(None, Format.flush_str_formatter (), err_desc)) in
     Format.kfprintf cont Format.str_formatter fmt
 
+let fatal_optional_position pos = match pos with
+  | None -> fatal_no_pos
+  | Some p -> fatal p
+
 (** [handle_exceptions f] runs [f ()] in an exception handler and handles both
     expected and unexpected exceptions by displaying a graceful error message.
     In case of an error, the program is (irrecoverably) stopped with exit code

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -78,8 +78,8 @@ let check_sort : Pos.popt -> problem -> ctxt -> term -> term * term =
 type result = (unit -> string) option
 (** Result of query displayed on hover in the editor. *)
 
-(** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose level
-    1 and returns a function for printing [x] on a string using [pp]. *)
+(** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose
+level 1 and returns a function for printing [x] on a string using [pp]. *)
 let return : 'a pp -> 'a -> result =
  fun pp x ->
   Console.out 1 "%a" pp x;
@@ -167,8 +167,8 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
       (* Function to print a symbol declaration. *)
       let decl ppf s =
         out ppf "%a%a%asymbol %a : %a%a;%a%a" expo s.sym_expo prop s.sym_prop
-          match_strat s.sym_mstrat sym s sym_type s def !(s.sym_def) notation s
-          (rules sym_rule) s
+          match_strat s.sym_mstrat sym s sym_type s def !(s.sym_def)
+          notation s (rules sym_rule) s
       in
       let new_decl ppf s = out ppf "@.%a" decl s in
       (* Function to print constructors and the induction principle if [qid]
@@ -253,13 +253,14 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
         else begin
           List.iter (wrn pos "Cannot solve [%a]." constr) !p.unsolved;
           fatal pos
-            "[%a] has type [%a],@ [%a] has type [%a].@.Those two types are not \
-             unifiable."
+            "[%a] has type [%a],@ [%a] has type [%a].@.\
+            Those two types are not unifiable."
             term t term a term u term b
         end
       else
         fatal pos
-          "[%a] has type [%a],@ [%a] has type [%a].@.Those two types are not \
+          "[%a] has type [%a],@ [%a] has type [%a].@.\
+          Those two types are not \
            unifiable."
           term t term a term u term b;
       None

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -1,252 +1,275 @@
 (** Handling of queries. *)
 
-open Common open Error open Pos
-open Parsing open Syntax
-open Core open Term open Print
+open Common
+open Error
+open Pos
+open Parsing
+open Syntax
+open Core
+open Term
+open Print
 open Proof
-open Lplib open Base
+open Lplib
+open Base
 open Timed
 
 let infer : Pos.popt -> problem -> ctxt -> term -> term * term =
-  fun pos p ctx t ->
+ fun pos p ctx t ->
   match Infer.infer_noexn p ctx t with
   | None ->
-      let ids = Ctxt.names ctx in let term = term_in ids in
-      fatal pos "%a is not typable." term t
+    let ids = Ctxt.names ctx in
+    let term = term_in ids in
+    fatal pos "%a is not typable." term t
   | Some (t, a) ->
-      if Unif.solve_noexn p then
-        begin
-          if !p.unsolved = [] then (t, a)
-          else
-            begin
-              let ids = Ctxt.names ctx in let term = term_in ids in
-              List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
-              fatal pos "Failed to infer the type of %a." term t
-            end
-        end
-      else
-        let ids = Ctxt.names ctx in let term = term_in ids in
-        fatal pos "%a is not typable." term t
+    if Unif.solve_noexn p then
+      begin if !p.unsolved = [] then (t, a)
+      else begin
+        let ids = Ctxt.names ctx in
+        let term = term_in ids in
+        List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
+        fatal pos "Failed to infer the type of %a." term t
+      end
+      end
+    else
+      let ids = Ctxt.names ctx in
+      let term = term_in ids in
+      fatal pos "%a is not typable." term t
 
 let check : Pos.popt -> problem -> ctxt -> term -> term -> term =
-  fun pos p ctx t a ->
+ fun pos p ctx t a ->
   let die () =
-    let ids = Ctxt.names ctx in let term = term_in ids in
+    let ids = Ctxt.names ctx in
+    let term = term_in ids in
     fatal pos "[%a] does not have type [%a]." term t term a
   in
   match Infer.check_noexn p ctx t a with
   | Some t ->
     if Unif.solve_noexn p then
-      begin
-        if !p.unsolved = [] then t else
-          (List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
-           die ())
+      begin if !p.unsolved = [] then t
+      else (
+        List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
+        die ())
       end
     else die ()
   | None -> die ()
 
 let check_sort : Pos.popt -> problem -> ctxt -> term -> term * term =
-  fun pos p ctx t ->
+ fun pos p ctx t ->
   match Infer.check_sort_noexn p ctx t with
   | None ->
-      let ids = Ctxt.names ctx in let term = term_in ids in
+    let ids = Ctxt.names ctx in
+    let term = term_in ids in
+    fatal pos "[%a] is not typable by a sort." term t
+  | Some (t, s) ->
+    if Unif.solve_noexn p then
+      begin if !p.unsolved = [] then (t, s)
+      else begin
+        let ids = Ctxt.names ctx in
+        let term = term_in ids in
+        List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
+        fatal pos "Failed to check that [%a] is typable by a sort." term s
+      end
+      end
+    else
+      let ids = Ctxt.names ctx in
+      let term = term_in ids in
       fatal pos "[%a] is not typable by a sort." term t
-  | Some (t,s) ->
-      if Unif.solve_noexn p then
-        begin
-          if !p.unsolved = [] then (t, s) else
-            begin
-              let ids = Ctxt.names ctx in let term = term_in ids in
-              List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
-              fatal pos "Failed to check that [%a] is typable by a sort."
-                term s
-            end
-        end
-      else
-        let ids = Ctxt.names ctx in let term = term_in ids in
-        fatal pos "[%a] is not typable by a sort." term t
 
-(** Result of query displayed on hover in the editor. *)
 type result = (unit -> string) option
+(** Result of query displayed on hover in the editor. *)
 
-(** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose
-   level 1 and returns a function for printing [x] on a string using [pp]. *)
-let return : 'a pp -> 'a -> result = fun pp x ->
+(** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose level
+    1 and returns a function for printing [x] on a string using [pp]. *)
+let return : 'a pp -> 'a -> result =
+ fun pp x ->
   Console.out 1 "%a" pp x;
   Some (fun () -> Format.asprintf "%a" pp x)
 
 (** [handle_query ss ps q] *)
 let handle : Sig_state.t -> proof_state option -> p_query -> result =
-  fun ss ps {elt;pos} ->
+ fun ss ps { elt; pos } ->
   match elt with
-  | P_query_debug(_,"") ->
-      let f (k,d) = Printf.sprintf "\n%c: %s" k d in
-      let s = String.concat "" (List.map f (Logger.log_summary())) in
-      return string ("debug flags:"^s)
-  | P_query_debug(e,s) ->
-      String.iter (fun c -> if Logger.is_registered c then ()
-                            else fatal pos "Unknown debug flag \'%c\'" c) s;
-      Logger.set_debug e s;
-      Console.out 1 "debug %s%s" (if e then "+" else "-") s;
-      None
-  | P_query_verbose(i) ->
-      let i = try int_of_string i with Failure _ ->
-                fatal pos "Too big number (max is %d)." max_int in
-      if i < 0 then fatal pos "Negative number.";
-      if !Console.verbose = 0 then
-        (Console.verbose := i; Console.out 1 "verbose %i" i)
-      else (Console.out 1 "verbose %i" i; Console.verbose := i);
-      None
-  | P_query_flag("",_) ->
-      let f n _ l = n::l in
-      let l = Extra.StrMap.fold f Stdlib.(!Console.boolean_flags) [] in
-      let l = List.sort Stdlib.compare l in
-      let l = List.map (fun s -> "\""^s^"\"") l in
-      return string ("flags: "^String.concat ", " l)
-  | P_query_flag(id,b) ->
-      (try Console.set_flag id b
-       with Not_found -> fatal pos "Unknown flag \"%s\"." id);
-      Console.out 1 "flag \"%s\" %s" id (if b then "on" else "off");
-      None
-  | P_query_prover(s) -> Why3_tactic.default_prover := s; None
-  | P_query_prover_timeout(n) ->
-      let n = try int_of_string n with Failure _ ->
-                fatal pos "Too big number (max is %d)" max_int in
-      if n < 0 then fatal pos "Negative number";
-      Why3_tactic.timeout := n;
-      None
-  | P_query_print(None) ->
-      begin
-        match ps with
-        | None -> fatal pos "Not in a proof."
-        | Some ps -> return Proof.goals ps
-      end
-  | P_query_print(Some qid) ->
+  | P_query_debug (_, "") ->
+    let f (k, d) = Printf.sprintf "\n%c: %s" k d in
+    let s = String.concat "" (List.map f (Logger.log_summary ())) in
+    return string ("debug flags:" ^ s)
+  | P_query_debug (e, s) ->
+    String.iter
+      (fun c ->
+        if Logger.is_registered c then ()
+        else fatal pos "Unknown debug flag \'%c\'" c)
+      s;
+    Logger.set_debug e s;
+    Console.out 1 "debug %s%s" (if e then "+" else "-") s;
+    None
+  | P_query_verbose i ->
+    let i =
+      try int_of_string i
+      with Failure _ -> fatal pos "Too big number (max is %d)." max_int
+    in
+    if i < 0 then fatal pos "Negative number.";
+    if !Console.verbose = 0 then (
+      Console.verbose := i;
+      Console.out 1 "verbose %i" i)
+    else (
+      Console.out 1 "verbose %i" i;
+      Console.verbose := i);
+    None
+  | P_query_flag ("", _) ->
+    let f n _ l = n :: l in
+    let l = Extra.StrMap.fold f Stdlib.(!Console.boolean_flags) [] in
+    let l = List.sort Stdlib.compare l in
+    let l = List.map (fun s -> "\"" ^ s ^ "\"") l in
+    return string ("flags: " ^ String.concat ", " l)
+  | P_query_flag (id, b) ->
+    (try Console.set_flag id b
+     with Not_found -> fatal pos "Unknown flag \"%s\"." id);
+    Console.out 1 "flag \"%s\" %s" id (if b then "on" else "off");
+    None
+  | P_query_prover s ->
+    Why3_tactic.default_prover := s;
+    None
+  | P_query_prover_timeout n ->
+    let n =
+      try int_of_string n
+      with Failure _ -> fatal pos "Too big number (max is %d)" max_int
+    in
+    if n < 0 then fatal pos "Negative number";
+    Why3_tactic.timeout := n;
+    None
+  | P_query_print None ->
+    begin match ps with
+    | None -> fatal pos "Not in a proof."
+    | Some ps -> return Proof.goals ps
+    end
+  | P_query_print (Some qid) ->
     let m = snd qid.elt in
     if String.is_string_literal m then return string (String.remove_quotes m)
     else
-      let sym_info ppf s =
-        (* Function to print a definition. *)
-        let def ppf = Option.iter (out ppf "@ ≔ %a" term) in
-        (* Function to print a notation *)
-        let notation ppf s =
-          match !(s.sym_nota) with
-          | NoNotation -> ()
-          | n -> out ppf "@.notation %a %a;" sym s (notation float) n
-        in
-        (* Function to print rules. *)
-        let rules sym_rule ppf s =
-          match !(s.sym_rules) with
-          | [] -> ()
-          | r::rs ->
-            let rule ppf r = sym_rule ppf (s,r) in
-            let with_rule ppf r = out ppf "@.with %a" rule r in
-            out ppf "@.rule %a%a;" rule r (List.pp with_rule "") rs
-        in
-        (* Function to print a symbol declaration. *)
-        let decl ppf s =
-          out ppf "%a%a%asymbol %a : %a%a;%a%a"
-            expo s.sym_expo prop s.sym_prop
-            match_strat s.sym_mstrat sym s sym_type s
-            def !(s.sym_def) notation s (rules sym_rule) s
-        in
-        let new_decl ppf s = out ppf "@.%a" decl s in
-        (* Function to print constructors and the induction principle if [qid]
-           is an inductive type. *)
-        let ind ppf s =
-          let open Sign in
-          (* get the signature of [s] *)
-          let sign =
-            try Path.Map.find s.sym_path !loaded
-            with Not_found -> assert false
-          in
-          try
-            let ind = SymMap.find s !(sign.sign_ind) in
-            List.pp new_decl "" ppf ind.ind_cons;
-            new_decl ppf ind.ind_prop
-          with Not_found -> ()
-        in
-        if s == Unif_rule.equiv then
-          let sym_rule ppf r =
-            out ppf "%a ↪ [%a]" term (lhs r) term (rhs r) in
-          rules sym_rule ppf s
-        else if s == Coercion.coerce then rules sym_rule ppf s
-        else (decl ppf s; ind ppf s)
+    let sym_info ppf s =
+      (* Function to print a definition. *)
+      let def ppf = Option.iter (out ppf "@ ≔ %a" term) in
+      (* Function to print a notation *)
+      let notation ppf s =
+        match !(s.sym_nota) with
+        | NoNotation -> ()
+        | n -> out ppf "@.notation %a %a;" sym s (notation float) n
       in
-      return sym_info (Sig_state.find_sym ~prt:true ~prv:true ss qid)
-  | P_query_proofterm ->
-      (match ps with
-       | None -> fatal pos "Not in a proof"
-       | Some pst ->
-           match pst.proof_term with
-           | Some m ->
-               let ids = Env.names (Proof.focus_env ps) in
-               return (term_in ids) (mk_Meta(m,[||]))
-           | None -> fatal pos "Not in a definition")
-  | _ ->
-  let env = Proof.focus_env ps in
-  let mok =
+      (* Function to print rules. *)
+      let rules sym_rule ppf s =
+        match !(s.sym_rules) with
+        | [] -> ()
+        | r :: rs ->
+          let rule ppf r = sym_rule ppf (s, r) in
+          let with_rule ppf r = out ppf "@.with %a" rule r in
+          out ppf "@.rule %a%a;" rule r (List.pp with_rule "") rs
+      in
+      (* Function to print a symbol declaration. *)
+      let decl ppf s =
+        out ppf "%a%a%asymbol %a : %a%a;%a%a" expo s.sym_expo prop s.sym_prop
+          match_strat s.sym_mstrat sym s sym_type s def !(s.sym_def) notation s
+          (rules sym_rule) s
+      in
+      let new_decl ppf s = out ppf "@.%a" decl s in
+      (* Function to print constructors and the induction principle if [qid]
+           is an inductive type. *)
+      let ind ppf s =
+        let open Sign in
+        (* get the signature of [s] *)
+        let sign =
+          try Path.Map.find s.sym_path !loaded with Not_found -> assert false
+        in
+        try
+          let ind = SymMap.find s !(sign.sign_ind) in
+          List.pp new_decl "" ppf ind.ind_cons;
+          new_decl ppf ind.ind_prop
+        with Not_found -> ()
+      in
+      if s == Unif_rule.equiv then
+        let sym_rule ppf r = out ppf "%a ↪ [%a]" term (lhs r) term (rhs r) in
+        rules sym_rule ppf s
+      else if s == Coercion.coerce then rules sym_rule ppf s
+      else (
+        decl ppf s;
+        ind ppf s)
+    in
+    return sym_info (Sig_state.find_sym ~prt:true ~prv:true ss qid)
+  | P_query_proofterm -> (
     match ps with
-    | None -> fun _ -> None
-    | Some ps -> Proof.meta_of_key ps
-  in
-  let scope ?(typ=false) = Scope.scope_term ~typ ~mok true ss env in
-  let ctxt = Env.to_ctxt env in
-  let p = new_problem() in
-  match elt with
-  | P_query_search q ->
+    | None -> fatal pos "Not in a proof"
+    | Some pst -> (
+      match pst.proof_term with
+      | Some m ->
+        let ids = Env.names (Proof.focus_env ps) in
+        return (term_in ids) (mk_Meta (m, [||]))
+      | None -> fatal pos "Not in a definition"))
+  | _ -> (
+    let env = Proof.focus_env ps in
+    let mok =
+      match ps with None -> fun _ -> None | Some ps -> Proof.meta_of_key ps
+    in
+    let scope ?(typ = false) = Scope.scope_term ~typ ~mok true ss env in
+    let ctxt = Env.to_ctxt env in
+    let p = new_problem () in
+    match elt with
+    | P_query_search q ->
       let dbpath = Path.default_dbpath in
-      return string (Tool.Indexing.search_cmd_txt_query ss q ~dbpath)
-  | P_query_debug(_,_)
-  | P_query_verbose(_)
-  | P_query_flag(_,_)
-  | P_query_prover(_)
-  | P_query_prover_timeout(_)
-  | P_query_print(_)
-  | P_query_proofterm -> assert false (* already done *)
-  | P_query_assert(must_fail, P_assert_typing(pt,pa)) ->
+      return (Tool.Indexing.search_cmd_txt_query ss ~dbpath) q
+    | P_query_debug (_, _)
+    | P_query_verbose _
+    | P_query_flag (_, _)
+    | P_query_prover _ | P_query_prover_timeout _ | P_query_print _
+    | P_query_proofterm ->
+      assert false (* already done *)
+    | P_query_assert (must_fail, P_assert_typing (pt, pa)) ->
       let t = scope pt and a = scope ~typ:true pa in
-      Console.out 2 "assertion: it is %b that %a" (not must_fail)
-        typing (ctxt, t, a);
+      Console.out 2 "assertion: it is %b that %a" (not must_fail) typing
+        (ctxt, t, a);
       (* Check that [a] is typable by a sort. *)
-      let (a, _) = check_sort pos p ctxt a in
+      let a, _ = check_sort pos p ctxt a in
       let result =
-        try ignore (check pos p ctxt t a); true
+        try
+          ignore (check pos p ctxt t a);
+          true
         with Fatal _ -> false
       in
       if result = must_fail then fatal pos "Assertion failed.";
       None
-  | P_query_assert(must_fail, P_assert_conv(pt,pu)) ->
+    | P_query_assert (must_fail, P_assert_conv (pt, pu)) ->
       let t = scope pt and u = scope pu in
-      Console.out 2 "assertion: it is %b that %a" (not must_fail)
-        constr (ctxt, t, u);
+      Console.out 2 "assertion: it is %b that %a" (not must_fail) constr
+        (ctxt, t, u);
       (* Check that [t] is typable. *)
-      let (t, a) = infer pt.pos p ctxt t in
+      let t, a = infer pt.pos p ctxt t in
       (* Check that [u] is typable. *)
-      let (u, b) = infer pu.pos p ctxt u in
+      let u, b = infer pu.pos p ctxt u in
       (* Check that [t] and [u] have the same type. *)
-      p := {!p with to_solve = (ctxt,a,b)::!p.to_solve};
+      p := { !p with to_solve = (ctxt, a, b) :: !p.to_solve };
       if Unif.solve_noexn p then
-        if !p.unsolved = [] then begin
-          if Eval.eq_modulo ctxt t u = must_fail then
-             fatal pos "Assertion failed."
-        end else begin
+        if !p.unsolved = [] then
+          begin if Eval.eq_modulo ctxt t u = must_fail then
+            fatal pos "Assertion failed."
+          end
+        else begin
           List.iter (wrn pos "Cannot solve [%a]." constr) !p.unsolved;
-          fatal pos "[%a] has type [%a],@ [%a] has type [%a].@.\
-                    Those two types are not unifiable."
+          fatal pos
+            "[%a] has type [%a],@ [%a] has type [%a].@.Those two types are not \
+             unifiable."
             term t term a term u term b
-        end else
-          fatal pos "[%a] has type [%a],@ [%a] has type [%a].@.\
-                    Those two types are not unifiable."
-            term t term a term u term b;
+        end
+      else
+        fatal pos
+          "[%a] has type [%a],@ [%a] has type [%a].@.Those two types are not \
+           unifiable."
+          term t term a term u term b;
       None
-  | P_query_infer(pt, cfg) ->
+    | P_query_infer (pt, cfg) ->
       let t = scope pt in
       let t = Eval.eval cfg ctxt (snd (infer pt.pos p ctxt t)) in
       let ids = Env.names (Proof.focus_env ps) in
       return (term_in ids) t
-  | P_query_normalize(pt, cfg) ->
+    | P_query_normalize (pt, cfg) ->
       let t = scope pt in
       let t = Eval.eval cfg ctxt (fst (infer pt.pos p ctxt t)) in
       let ids = Env.names (Proof.focus_env ps) in
-      return (term_in ids) t
+      return (term_in ids) t)

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -1,276 +1,252 @@
 (** Handling of queries. *)
 
-open Common
-open Error
-open Pos
-open Parsing
-open Syntax
-open Core
-open Term
-open Print
+open Common open Error open Pos
+open Parsing open Syntax
+open Core open Term open Print
 open Proof
-open Lplib
-open Base
+open Lplib open Base
 open Timed
 
 let infer : Pos.popt -> problem -> ctxt -> term -> term * term =
- fun pos p ctx t ->
+  fun pos p ctx t ->
   match Infer.infer_noexn p ctx t with
   | None ->
-    let ids = Ctxt.names ctx in
-    let term = term_in ids in
-    fatal pos "%a is not typable." term t
-  | Some (t, a) ->
-    if Unif.solve_noexn p then
-      begin if !p.unsolved = [] then (t, a)
-      else begin
-        let ids = Ctxt.names ctx in
-        let term = term_in ids in
-        List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
-        fatal pos "Failed to infer the type of %a." term t
-      end
-      end
-    else
-      let ids = Ctxt.names ctx in
-      let term = term_in ids in
+      let ids = Ctxt.names ctx in let term = term_in ids in
       fatal pos "%a is not typable." term t
+  | Some (t, a) ->
+      if Unif.solve_noexn p then
+        begin
+          if !p.unsolved = [] then (t, a)
+          else
+            begin
+              let ids = Ctxt.names ctx in let term = term_in ids in
+              List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
+              fatal pos "Failed to infer the type of %a." term t
+            end
+        end
+      else
+        let ids = Ctxt.names ctx in let term = term_in ids in
+        fatal pos "%a is not typable." term t
 
 let check : Pos.popt -> problem -> ctxt -> term -> term -> term =
- fun pos p ctx t a ->
+  fun pos p ctx t a ->
   let die () =
-    let ids = Ctxt.names ctx in
-    let term = term_in ids in
+    let ids = Ctxt.names ctx in let term = term_in ids in
     fatal pos "[%a] does not have type [%a]." term t term a
   in
   match Infer.check_noexn p ctx t a with
   | Some t ->
     if Unif.solve_noexn p then
-      begin if !p.unsolved = [] then t
-      else (
-        List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
-        die ())
+      begin
+        if !p.unsolved = [] then t else
+          (List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
+           die ())
       end
     else die ()
   | None -> die ()
 
 let check_sort : Pos.popt -> problem -> ctxt -> term -> term * term =
- fun pos p ctx t ->
+  fun pos p ctx t ->
   match Infer.check_sort_noexn p ctx t with
   | None ->
-    let ids = Ctxt.names ctx in
-    let term = term_in ids in
-    fatal pos "[%a] is not typable by a sort." term t
-  | Some (t, s) ->
-    if Unif.solve_noexn p then
-      begin if !p.unsolved = [] then (t, s)
-      else begin
-        let ids = Ctxt.names ctx in
-        let term = term_in ids in
-        List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
-        fatal pos "Failed to check that [%a] is typable by a sort." term s
-      end
-      end
-    else
-      let ids = Ctxt.names ctx in
-      let term = term_in ids in
+      let ids = Ctxt.names ctx in let term = term_in ids in
       fatal pos "[%a] is not typable by a sort." term t
+  | Some (t,s) ->
+      if Unif.solve_noexn p then
+        begin
+          if !p.unsolved = [] then (t, s) else
+            begin
+              let ids = Ctxt.names ctx in let term = term_in ids in
+              List.iter (wrn pos "Cannot solve %a." constr) !p.unsolved;
+              fatal pos "Failed to check that [%a] is typable by a sort."
+                term s
+            end
+        end
+      else
+        let ids = Ctxt.names ctx in let term = term_in ids in
+        fatal pos "[%a] is not typable by a sort." term t
 
-type result = (unit -> string) option
 (** Result of query displayed on hover in the editor. *)
+type result = (unit -> string) option
 
 (** [return pp x] prints [x] using [pp] on [Stdlib.(!out_fmt)] at verbose
-level 1 and returns a function for printing [x] on a string using [pp]. *)
-let return : 'a pp -> 'a -> result =
- fun pp x ->
+   level 1 and returns a function for printing [x] on a string using [pp]. *)
+let return : 'a pp -> 'a -> result = fun pp x ->
   Console.out 1 "%a" pp x;
   Some (fun () -> Format.asprintf "%a" pp x)
 
 (** [handle_query ss ps q] *)
 let handle : Sig_state.t -> proof_state option -> p_query -> result =
- fun ss ps { elt; pos } ->
+  fun ss ps {elt;pos} ->
   match elt with
-  | P_query_debug (_, "") ->
-    let f (k, d) = Printf.sprintf "\n%c: %s" k d in
-    let s = String.concat "" (List.map f (Logger.log_summary ())) in
-    return string ("debug flags:" ^ s)
-  | P_query_debug (e, s) ->
-    String.iter
-      (fun c ->
-        if Logger.is_registered c then ()
-        else fatal pos "Unknown debug flag \'%c\'" c)
-      s;
-    Logger.set_debug e s;
-    Console.out 1 "debug %s%s" (if e then "+" else "-") s;
-    None
-  | P_query_verbose i ->
-    let i =
-      try int_of_string i
-      with Failure _ -> fatal pos "Too big number (max is %d)." max_int
-    in
-    if i < 0 then fatal pos "Negative number.";
-    if !Console.verbose = 0 then (
-      Console.verbose := i;
-      Console.out 1 "verbose %i" i)
-    else (
-      Console.out 1 "verbose %i" i;
-      Console.verbose := i);
-    None
-  | P_query_flag ("", _) ->
-    let f n _ l = n :: l in
-    let l = Extra.StrMap.fold f Stdlib.(!Console.boolean_flags) [] in
-    let l = List.sort Stdlib.compare l in
-    let l = List.map (fun s -> "\"" ^ s ^ "\"") l in
-    return string ("flags: " ^ String.concat ", " l)
-  | P_query_flag (id, b) ->
-    (try Console.set_flag id b
-     with Not_found -> fatal pos "Unknown flag \"%s\"." id);
-    Console.out 1 "flag \"%s\" %s" id (if b then "on" else "off");
-    None
-  | P_query_prover s ->
-    Why3_tactic.default_prover := s;
-    None
-  | P_query_prover_timeout n ->
-    let n =
-      try int_of_string n
-      with Failure _ -> fatal pos "Too big number (max is %d)" max_int
-    in
-    if n < 0 then fatal pos "Negative number";
-    Why3_tactic.timeout := n;
-    None
-  | P_query_print None ->
-    begin match ps with
-    | None -> fatal pos "Not in a proof."
-    | Some ps -> return Proof.goals ps
-    end
-  | P_query_print (Some qid) ->
+  | P_query_debug(_,"") ->
+      let f (k,d) = Printf.sprintf "\n%c: %s" k d in
+      let s = String.concat "" (List.map f (Logger.log_summary())) in
+      return string ("debug flags:"^s)
+  | P_query_debug(e,s) ->
+      String.iter (fun c -> if Logger.is_registered c then ()
+                            else fatal pos "Unknown debug flag \'%c\'" c) s;
+      Logger.set_debug e s;
+      Console.out 1 "debug %s%s" (if e then "+" else "-") s;
+      None
+  | P_query_verbose(i) ->
+      let i = try int_of_string i with Failure _ ->
+                fatal pos "Too big number (max is %d)." max_int in
+      if i < 0 then fatal pos "Negative number.";
+      if !Console.verbose = 0 then
+        (Console.verbose := i; Console.out 1 "verbose %i" i)
+      else (Console.out 1 "verbose %i" i; Console.verbose := i);
+      None
+  | P_query_flag("",_) ->
+      let f n _ l = n::l in
+      let l = Extra.StrMap.fold f Stdlib.(!Console.boolean_flags) [] in
+      let l = List.sort Stdlib.compare l in
+      let l = List.map (fun s -> "\""^s^"\"") l in
+      return string ("flags: "^String.concat ", " l)
+  | P_query_flag(id,b) ->
+      (try Console.set_flag id b
+       with Not_found -> fatal pos "Unknown flag \"%s\"." id);
+      Console.out 1 "flag \"%s\" %s" id (if b then "on" else "off");
+      None
+  | P_query_prover(s) -> Why3_tactic.default_prover := s; None
+  | P_query_prover_timeout(n) ->
+      let n = try int_of_string n with Failure _ ->
+                fatal pos "Too big number (max is %d)" max_int in
+      if n < 0 then fatal pos "Negative number";
+      Why3_tactic.timeout := n;
+      None
+  | P_query_print(None) ->
+      begin
+        match ps with
+        | None -> fatal pos "Not in a proof."
+        | Some ps -> return Proof.goals ps
+      end
+  | P_query_print(Some qid) ->
     let m = snd qid.elt in
     if String.is_string_literal m then return string (String.remove_quotes m)
     else
-    let sym_info ppf s =
-      (* Function to print a definition. *)
-      let def ppf = Option.iter (out ppf "@ ≔ %a" term) in
-      (* Function to print a notation *)
-      let notation ppf s =
-        match !(s.sym_nota) with
-        | NoNotation -> ()
-        | n -> out ppf "@.notation %a %a;" sym s (notation float) n
-      in
-      (* Function to print rules. *)
-      let rules sym_rule ppf s =
-        match !(s.sym_rules) with
-        | [] -> ()
-        | r :: rs ->
-          let rule ppf r = sym_rule ppf (s, r) in
-          let with_rule ppf r = out ppf "@.with %a" rule r in
-          out ppf "@.rule %a%a;" rule r (List.pp with_rule "") rs
-      in
-      (* Function to print a symbol declaration. *)
-      let decl ppf s =
-        out ppf "%a%a%asymbol %a : %a%a;%a%a" expo s.sym_expo prop s.sym_prop
-          match_strat s.sym_mstrat sym s sym_type s def !(s.sym_def)
-          notation s (rules sym_rule) s
-      in
-      let new_decl ppf s = out ppf "@.%a" decl s in
-      (* Function to print constructors and the induction principle if [qid]
-           is an inductive type. *)
-      let ind ppf s =
-        let open Sign in
-        (* get the signature of [s] *)
-        let sign =
-          try Path.Map.find s.sym_path !loaded with Not_found -> assert false
+      let sym_info ppf s =
+        (* Function to print a definition. *)
+        let def ppf = Option.iter (out ppf "@ ≔ %a" term) in
+        (* Function to print a notation *)
+        let notation ppf s =
+          match !(s.sym_nota) with
+          | NoNotation -> ()
+          | n -> out ppf "@.notation %a %a;" sym s (notation float) n
         in
-        try
-          let ind = SymMap.find s !(sign.sign_ind) in
-          List.pp new_decl "" ppf ind.ind_cons;
-          new_decl ppf ind.ind_prop
-        with Not_found -> ()
+        (* Function to print rules. *)
+        let rules sym_rule ppf s =
+          match !(s.sym_rules) with
+          | [] -> ()
+          | r::rs ->
+            let rule ppf r = sym_rule ppf (s,r) in
+            let with_rule ppf r = out ppf "@.with %a" rule r in
+            out ppf "@.rule %a%a;" rule r (List.pp with_rule "") rs
+        in
+        (* Function to print a symbol declaration. *)
+        let decl ppf s =
+          out ppf "%a%a%asymbol %a : %a%a;%a%a"
+            expo s.sym_expo prop s.sym_prop
+            match_strat s.sym_mstrat sym s sym_type s
+            def !(s.sym_def) notation s (rules sym_rule) s
+        in
+        let new_decl ppf s = out ppf "@.%a" decl s in
+        (* Function to print constructors and the induction principle if [qid]
+           is an inductive type. *)
+        let ind ppf s =
+          let open Sign in
+          (* get the signature of [s] *)
+          let sign =
+            try Path.Map.find s.sym_path !loaded
+            with Not_found -> assert false
+          in
+          try
+            let ind = SymMap.find s !(sign.sign_ind) in
+            List.pp new_decl "" ppf ind.ind_cons;
+            new_decl ppf ind.ind_prop
+          with Not_found -> ()
+        in
+        if s == Unif_rule.equiv then
+          let sym_rule ppf r =
+            out ppf "%a ↪ [%a]" term (lhs r) term (rhs r) in
+          rules sym_rule ppf s
+        else if s == Coercion.coerce then rules sym_rule ppf s
+        else (decl ppf s; ind ppf s)
       in
-      if s == Unif_rule.equiv then
-        let sym_rule ppf r = out ppf "%a ↪ [%a]" term (lhs r) term (rhs r) in
-        rules sym_rule ppf s
-      else if s == Coercion.coerce then rules sym_rule ppf s
-      else (
-        decl ppf s;
-        ind ppf s)
-    in
-    return sym_info (Sig_state.find_sym ~prt:true ~prv:true ss qid)
-  | P_query_proofterm -> (
+      return sym_info (Sig_state.find_sym ~prt:true ~prv:true ss qid)
+  | P_query_proofterm ->
+      (match ps with
+       | None -> fatal pos "Not in a proof"
+       | Some pst ->
+           match pst.proof_term with
+           | Some m ->
+               let ids = Env.names (Proof.focus_env ps) in
+               return (term_in ids) (mk_Meta(m,[||]))
+           | None -> fatal pos "Not in a definition")
+  | _ ->
+  let env = Proof.focus_env ps in
+  let mok =
     match ps with
-    | None -> fatal pos "Not in a proof"
-    | Some pst -> (
-      match pst.proof_term with
-      | Some m ->
-        let ids = Env.names (Proof.focus_env ps) in
-        return (term_in ids) (mk_Meta (m, [||]))
-      | None -> fatal pos "Not in a definition"))
-  | _ -> (
-    let env = Proof.focus_env ps in
-    let mok =
-      match ps with None -> fun _ -> None | Some ps -> Proof.meta_of_key ps
-    in
-    let scope ?(typ = false) = Scope.scope_term ~typ ~mok true ss env in
-    let ctxt = Env.to_ctxt env in
-    let p = new_problem () in
-    match elt with
-    | P_query_search q ->
+    | None -> fun _ -> None
+    | Some ps -> Proof.meta_of_key ps
+  in
+  let scope ?(typ=false) = Scope.scope_term ~typ ~mok true ss env in
+  let ctxt = Env.to_ctxt env in
+  let p = new_problem() in
+  match elt with
+  | P_query_search q ->
       let dbpath = Path.default_dbpath in
       return (Tool.Indexing.search_cmd_txt_query ss ~dbpath) q
-    | P_query_debug (_, _)
-    | P_query_verbose _
-    | P_query_flag (_, _)
-    | P_query_prover _ | P_query_prover_timeout _ | P_query_print _
-    | P_query_proofterm ->
-      assert false (* already done *)
-    | P_query_assert (must_fail, P_assert_typing (pt, pa)) ->
+  | P_query_debug(_,_)
+  | P_query_verbose(_)
+  | P_query_flag(_,_)
+  | P_query_prover(_)
+  | P_query_prover_timeout(_)
+  | P_query_print(_)
+  | P_query_proofterm -> assert false (* already done *)
+  | P_query_assert(must_fail, P_assert_typing(pt,pa)) ->
       let t = scope pt and a = scope ~typ:true pa in
-      Console.out 2 "assertion: it is %b that %a" (not must_fail) typing
-        (ctxt, t, a);
+      Console.out 2 "assertion: it is %b that %a" (not must_fail)
+        typing (ctxt, t, a);
       (* Check that [a] is typable by a sort. *)
-      let a, _ = check_sort pos p ctxt a in
+      let (a, _) = check_sort pos p ctxt a in
       let result =
-        try
-          ignore (check pos p ctxt t a);
-          true
+        try ignore (check pos p ctxt t a); true
         with Fatal _ -> false
       in
       if result = must_fail then fatal pos "Assertion failed.";
       None
-    | P_query_assert (must_fail, P_assert_conv (pt, pu)) ->
+  | P_query_assert(must_fail, P_assert_conv(pt,pu)) ->
       let t = scope pt and u = scope pu in
-      Console.out 2 "assertion: it is %b that %a" (not must_fail) constr
-        (ctxt, t, u);
+      Console.out 2 "assertion: it is %b that %a" (not must_fail)
+        constr (ctxt, t, u);
       (* Check that [t] is typable. *)
-      let t, a = infer pt.pos p ctxt t in
+      let (t, a) = infer pt.pos p ctxt t in
       (* Check that [u] is typable. *)
-      let u, b = infer pu.pos p ctxt u in
+      let (u, b) = infer pu.pos p ctxt u in
       (* Check that [t] and [u] have the same type. *)
-      p := { !p with to_solve = (ctxt, a, b) :: !p.to_solve };
+      p := {!p with to_solve = (ctxt,a,b)::!p.to_solve};
       if Unif.solve_noexn p then
-        if !p.unsolved = [] then
-          begin if Eval.eq_modulo ctxt t u = must_fail then
-            fatal pos "Assertion failed."
-          end
-        else begin
+        if !p.unsolved = [] then begin
+          if Eval.eq_modulo ctxt t u = must_fail then
+             fatal pos "Assertion failed."
+        end else begin
           List.iter (wrn pos "Cannot solve [%a]." constr) !p.unsolved;
-          fatal pos
-            "[%a] has type [%a],@ [%a] has type [%a].@.\
-            Those two types are not unifiable."
+          fatal pos "[%a] has type [%a],@ [%a] has type [%a].@.\
+                    Those two types are not unifiable."
             term t term a term u term b
-        end
-      else
-        fatal pos
-          "[%a] has type [%a],@ [%a] has type [%a].@.\
-          Those two types are not \
-           unifiable."
-          term t term a term u term b;
+        end else
+          fatal pos "[%a] has type [%a],@ [%a] has type [%a].@.\
+                    Those two types are not unifiable."
+            term t term a term u term b;
       None
-    | P_query_infer (pt, cfg) ->
+  | P_query_infer(pt, cfg) ->
       let t = scope pt in
       let t = Eval.eval cfg ctxt (snd (infer pt.pos p ctxt t)) in
       let ids = Env.names (Proof.focus_env ps) in
       return (term_in ids) t
-    | P_query_normalize (pt, cfg) ->
+  | P_query_normalize(pt, cfg) ->
       let t = scope pt in
       let t = Eval.eval cfg ctxt (fst (infer pt.pos p ctxt t)) in
       let ids = Env.names (Proof.focus_env ps) in
-      return (term_in ids) t)
+      return (term_in ids) t

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -193,9 +193,6 @@ let consume (token:token) (lb:lexbuf): unit =
 let prefix (token:token) (elt:lexbuf -> 'a) (lb:lexbuf): 'a =
   consume token lb; elt lb
 
-let alone (entry:lexbuf -> 'a) (lb:lexbuf): 'a =
-  let x = entry lb in if current_token() != EOF then expected "" [EOF] else x
-
 (* parsing functions *)
 
 let consume_STRINGLIT (lb:lexbuf): string =

--- a/src/parsing/rocqLexer.ml
+++ b/src/parsing/rocqLexer.ml
@@ -155,7 +155,7 @@ let rec token lb =
 
   (* other tokens *)
   | int -> INT(Utf8.lexeme lb)
-  | string -> STRINGLIT(Utf8.sub_lexeme lb 1 (lexeme_length lb - 2))
+  | string -> STRINGLIT(Utf8.lexeme lb)
 
   (* symbols *)
   | 0x2254 (* ≔ *) -> ASSIGN

--- a/src/parsing/rocqParser.ml
+++ b/src/parsing/rocqParser.ml
@@ -843,10 +843,14 @@ and search (lb:lexbuf): search =
     if p = [] then n
     else Format.asprintf "%a.%a" Print.path p Print.uid n
   in
-  List.fold_left
+  let res = List.fold_left
     (fun x qid ->
         let p,n = qid.elt in
         if p = [""] then
             QFilter(x,RegExp(n))
         else
             QFilter(x,Path(path_of_qid qid))) q qids
+  in if current_token() = EOF then
+    res
+  else
+    expected "" [VBAR; IN; WITH]

--- a/src/parsing/rocqParser.ml
+++ b/src/parsing/rocqParser.ml
@@ -165,6 +165,24 @@ let qid (lb:lexbuf): (string list * string) loc =
   | _ ->
       expected "" [UID"";QID[]]
 
+let qid_or_regexp (lb:lexbuf): (string list * string) loc =
+  if log_enabled() then log "%s" __FUNCTION__;
+  match current_token() with
+  | UID s ->
+      let pos1 = current_pos() in
+      consume_token lb;
+      make_pos pos1 ([], s)
+  | QID p ->
+      let pos1 = current_pos() in
+      consume_token lb;
+      qid_of_path pos1 p
+  | STRINGLIT s ->
+      let pos1 = current_pos() in
+      consume_token lb;
+      make_pos pos1 ([""], s)
+  | _ ->
+      expected "" [UID"";QID[];STRINGLIT""]
+
 let qid_expl (lb:lexbuf): (string list * string) loc =
   if log_enabled() then log "%s" __FUNCTION__;
   match current_token() with
@@ -766,45 +784,35 @@ and asearch (lb:lexbuf): search =
       let t = term lb in
       QBase(QSearch(t,g,Some(QXhs(r,None))))
   | UID "spine" ->
-    begin
-        consume_token lb;
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QType(Some(Spine r)))))
-    end
   | UID "concl" ->
-    begin
-        consume_token lb;
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QType(Some(Conclusion r)))))
-    end
   | UID "hyp" ->
-    begin
-        consume_token lb;
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QType(Some(Hypothesis r)))))
-    end
   | UID "lhs" ->
-    begin
-        consume_token lb;
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QXhs(r,Some Lhs))))
-    end
   | UID "rhs" ->
-    begin
-        consume_token lb;
+      consume_token lb;
       let r = relation lb in
       let g = generalize lb in
       let t = term lb in
       QBase(QSearch(t,g,Some(QXhs(r,Some Rhs))))
-    end
   | L_PAREN ->
       consume_token lb;
       let q = search lb in
@@ -837,7 +845,7 @@ and search (lb:lexbuf): search =
   (*  expected "prbolem " []*)
    if log_enabled() then log "%s" __FUNCTION__;
   let q = ssearch lb in
-  let qids = list (prefix IN qid) lb in
+  let qids = list (prefix IN qid_or_regexp) lb in
   let path_of_qid qid =
     let p,n = qid.elt in
     if p = [] then n

--- a/src/parsing/rocqParser.ml
+++ b/src/parsing/rocqParser.ml
@@ -179,7 +179,7 @@ let qid_or_regexp (lb:lexbuf): (string list * string) loc =
   | STRINGLIT s ->
       let pos1 = current_pos() in
       consume_token lb;
-      make_pos pos1 ([""], s)
+      make_pos pos1 ([], s)
   | _ ->
       expected "" [UID"";QID[];STRINGLIT""]
 
@@ -842,23 +842,16 @@ and ssearch (lb:lexbuf): search =
       cq
 
 and search (lb:lexbuf): search =
-  (*  expected "prbolem " []*)
    if log_enabled() then log "%s" __FUNCTION__;
   let q = ssearch lb in
   let qids = list (prefix IN qid_or_regexp) lb in
-  let path_of_qid qid =
-    let p,n = qid.elt in
-    if p = [] then n
-    else Format.asprintf "%a.%a" Print.path p Print.uid n
-  in
-  let res = List.fold_left
+  let res =
+    List.fold_left
     (fun x qid ->
-        let p,n = qid.elt in
-        if p = [""] then
-            QFilter(x,RegExp(n))
-        else
-            QFilter(x,Path(path_of_qid qid))) q qids
-  in if current_token() = EOF then
-    res
-  else
-    expected "" [VBAR; IN; WITH]
+       let n = snd qid.elt in
+       if String.is_string_literal n then
+         QFilter(x,RegExp(String.remove_quotes n))
+       else QFilter(x,Path(Format.asprintf "%a" Pretty.qident qid)))
+    q qids
+  in
+  if current_token() = EOF then res else expected "" [VBAR; IN; WITH]

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -153,7 +153,8 @@ module Index = struct
       IRigid (r, insert_index i (s' @ s) v)
     | _, _ -> raise NoMatch
 
-  let insert (namemap, index) term v = (namemap, insert_index index [ term ] v)
+  let insert (namemap, index) term v =
+    (namemap, insert_index index [ term ] v)
 
   let insert_name (namemap, index) name v =
     let vs =
@@ -200,7 +201,8 @@ module Index = struct
     match (node, term) with
     | _, Patt _ ->
       List.concat
-        (List.map (fun i -> search_index ~generalize i s) (match_flexible node))
+        (List.map (fun i -> search_index ~generalize i s)
+        (match_flexible node))
     | IHOLE i, _ when generalize -> search_index ~generalize i s
     | IHOLE i, t -> search_node ~generalize (IRigid (IVar, i)) t s
     | IRigid (r, i), t -> (
@@ -278,9 +280,8 @@ module DB = struct
   let restore_from_disk () =
     try restore_from ~filename:Stdlib.(!the_dbpath)
     with Sys_error msg ->
-      Common.Error.wrn None
-        "%s.\nType \"lambdapi index --help\" to learn how to create the index."
-        msg;
+      Common.Error.wrn None "%s.\n\
+       Type \"lambdapi index --help\" to learn how to create the index." msg;
       (Sym_nameMap.empty, Index.empty)
 
   (* The persistent database *)
@@ -315,7 +316,9 @@ module DB = struct
     let idx =
       Index.remove ~what:(fun (((sym_path, _), _), _) -> keep sym_path) idx
     in
-    let sidx = Sym_nameMap.filter (fun (sym_path, _) _ -> keep sym_path) sidx in
+    let sidx = Sym_nameMap.filter (fun (sym_path, _) _ ->
+      keep sym_path) sidx
+    in
     db := lazy (sidx, idx)
 
   let set_of_list ~generalize k l =
@@ -359,7 +362,8 @@ module DB = struct
            let start_line = int_of_string start_line in
            let end_line = int_of_string end_line in
            sidx :=
-             Sym_nameMap.add lpid (sourceid, fname, start_line, end_line) !sidx
+             Sym_nameMap.add lpid (sourceid, fname, start_line, end_line)
+             !sidx
          | _ ->
            raise
              (Common.Error.Fatal
@@ -371,7 +375,8 @@ module DB = struct
       raise
         (Common.Error.Fatal
            ( None,
-             "wrong file format for source map file: " ^ Printexc.to_string exn,
+             "wrong file format for source map file: "
+             ^ Printexc.to_string exn,
              "" ))
     | End_of_file -> close_in ch);
     db := lazy (!sidx, idx)
@@ -519,7 +524,8 @@ let elim_duplicates_up_to_normalization res =
       (fun ((((mp, name), sympos), l) as inp) ->
         let s = mk_bogus_sym mp name sympos in
         match !normalize_fun (Core.Term.mk_Symb s) with
-        | Symb { sym_path; sym_name; _ } -> (((sym_path, sym_name), sympos), l)
+        | Symb { sym_path; sym_name; _ } ->
+          (((sym_path, sym_name), sympos), l)
         | _ -> inp)
       resl
   in
@@ -542,10 +548,12 @@ let find_sym ~prt ~prv sig_state ({ elt = mp, name; pos } as s) =
       | [] -> (
         let res_orig = DB.locate_name name in
         let res = elim_duplicates_up_to_normalization res_orig in
-        if DB.ItemSet.cardinal res > 1 then raise (Overloaded (name, res_orig));
+        if DB.ItemSet.cardinal res > 1 then
+          raise (Overloaded (name, res_orig));
         match DB.ItemSet.choose_opt res with
         | None -> Common.Error.fatal pos "Unknown symbol %s." name
-        | Some (((mp, name), sympos), [ (_, _, DB.Name) ]) -> (sympos, mp, name)
+        | Some (((mp, name), sympos), [ (_, _, DB.Name) ]) ->
+          (sympos, mp, name)
         | Some _ -> assert false
         (* locate only returns DB.Name*))
       | _ :: _ -> (None, mp, name)
@@ -616,7 +624,8 @@ let _ = normalize_fun := normalize
 let search_pterm ~generalize ~mok ss env pterm =
   let env = ("V#", (new_var "V#", Term.mk_Type, None)) :: env in
   Dream.log "QUERY before scoping: %a@." Parsing.Pretty.term pterm;
-  let query = Parsing.Scope.scope_search_pattern ~find_sym ~mok ss env pterm in
+  let query =
+    Parsing.Scope.scope_search_pattern ~find_sym ~mok ss env pterm in
   Dream.log "QUERY before normalize: %a" Core.Print.term query;
   let query = normalize query in
   Dream.log "QUERY to be executed: %a" Core.Print.term query;
@@ -674,13 +683,14 @@ let subterms_to_index ~is_spine t =
       match where with
       | Spine _ ->
         let t2 = subst b (Core.Term.mk_Patt (None, "dummy", [||])) in
-        aux ~where:(enter_pi_source where) t
-        @ aux ~where:(enter_pi_target ~is_prod:(Core.Term.is_prod t2) where) t2
+        aux ~where:(enter_pi_source where) t @ aux
+        ~where:(enter_pi_target ~is_prod:(Core.Term.is_prod t2) where) t2
       | _ ->
         let _, t2 = unbind b in
         aux ~where:(enter_pi_source where) t
         @ aux ~where:(enter_pi_target ~is_prod:false where) t2)
-    | Appl (t1, t2) -> aux ~where:(enter where) t1 @ aux ~where:(enter where) t2
+    | Appl (t1, t2) ->
+        aux ~where:(enter where) t1 @ aux ~where:(enter where) t2
     | Patt (_var, _varname, args) ->
       List.concat (List.map (aux ~where:(enter where)) (Array.to_list args))
     | LLet (t1, t2, b) ->
@@ -890,7 +900,8 @@ module UserLevelQueries = struct
               "Overloaded symbol %s. Please rewrite the query replacing %s \
                with a fully qualified identifier among the following:@."
               name name)
-           ~err_desc:(Format.asprintf "%a@." pp_results (ItemSet.bindings res)))
+           ~err_desc:(Format.asprintf "%a@." pp_results
+            (ItemSet.bindings res)))
     | Stack_overflow ->
       Lplib.Base.out fmt "%s"
         (fail None
@@ -941,7 +952,8 @@ module UserLevelQueries = struct
     let s = transform_ascii_to_unicode s in
     Stdlib.(the_dbpath := dbpath);
     search_cmd_gen_string ss ~from:0 ~how_many:999999
-      ~fail:(fun pos ?err_desc x -> Common.Error.fatal_optional_position pos ?err_desc "%s" x)
+      ~fail:(fun pos ?err_desc x ->
+          Common.Error.fatal_optional_position pos ?err_desc "%s" x)
       ~pp_results:pp_results_list ~tag:("", "") fmt s
 
 end

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -1,36 +1,35 @@
-open Core open Term
-open Common open Pos
+open Core
+open Term
+open Common
+open Pos
 open Timed
 
-let lsp_input = Stdlib.ref ("","")
+let lsp_input = Stdlib.ref ("", "")
 
 type sym_name = Common.Path.t * string
 
 let string_of_path x = Format.asprintf "%a" Common.Path.pp x
-let string_of_sym_name (p,n) = string_of_path p ^ "." ^ n
-
-let is_path_prefix patt p =
- Lplib.String.is_prefix patt (string_of_path p)
+let string_of_sym_name (p, n) = string_of_path p ^ "." ^ n
+let is_path_prefix patt p = Lplib.String.is_prefix patt (string_of_path p)
 
 let re_matches_sym_name re sym_name =
- try
-  ignore (Str.search_forward re (string_of_sym_name sym_name) 0) ;
-  true
- with Not_found -> false
+  try
+    ignore (Str.search_forward re (string_of_sym_name sym_name) 0);
+    true
+  with Not_found -> false
 
- let (@) = Lplib.List.(@)
-
+let ( @ ) = Lplib.List.( @ )
 let name_of_sym s = (s.sym_path, s.sym_name)
 
 let dump_to ~filename i =
- let ch = open_out_bin filename in
- Marshal.to_channel ch i [] ;
- close_out ch
+  let ch = open_out_bin filename in
+  Marshal.to_channel ch i [];
+  close_out ch
 
 let restore_from ~filename =
   let ch = open_in_bin filename in
   let i = Marshal.from_channel ch in
-  close_in ch ;
+  close_in ch;
   i
 
 (* discrimination tree *)
@@ -50,476 +49,459 @@ let restore_from ~filename =
 *)
 
 module Index = struct
+  type 'a index = Leaf of 'a list | Choice of 'a node list
+  and 'a node = IHOLE of 'a index | IRigid of rigid * 'a index
+  and rigid = IVar | IKind | IType | ISymb of sym_name | IAppl | IAbst | IProd
 
-type 'a index =
- | Leaf of 'a list
- | Choice of 'a node list
+  type 'a db = 'a list Lplib.Extra.StrMap.t * 'a index
 
-and 'a node =
- | IHOLE of 'a index
- | IRigid of rigid * 'a index
+  let empty : 'a db = (Lplib.Extra.StrMap.empty, Choice [])
 
-and rigid =
- | IVar
- | IKind
- | IType
- | ISymb of sym_name
- | IAppl
- | IAbst
- | IProd
-
-type 'a db = 'a list Lplib.Extra.StrMap.t * 'a index
-
-let empty : 'a db =  Lplib.Extra.StrMap.empty, Choice []
-
-let rec node_of_stack t s v =
- match unfold t with
- | Kind -> IRigid(IKind, index_of_stack s v)
- | Type -> IRigid(IType, index_of_stack s v)
- | Vari _ -> IRigid(IVar, index_of_stack s v)
- | Symb sym  -> IRigid(ISymb (name_of_sym sym), index_of_stack s v)
- | Appl(t1,t2) -> IRigid(IAppl, index_of_stack (t1::t2::s) v)
- | Abst(t1,bind) ->
-    let _, t2 = unbind bind in
-    IRigid(IAbst, index_of_stack (t1::t2::s) v)
- | Prod(t1,bind) ->
-    let _, t2 = unbind bind in
-    IRigid(IProd, index_of_stack (t1::t2::s) v)
- | Patt (_var,_varname,_args) ->
-    IHOLE (index_of_stack s v)
- | LLet (_typ, bod, bind) ->
-    (* Let-ins are expanded during indexing *)
-    node_of_stack (subst bind bod) s v
- | Meta _ -> assert false
- | Plac _ ->
-    (* this may happen in a rewriting rule that uses a _ in the r.h.s.
+  let rec node_of_stack t s v =
+    match unfold t with
+    | Kind -> IRigid (IKind, index_of_stack s v)
+    | Type -> IRigid (IType, index_of_stack s v)
+    | Vari _ -> IRigid (IVar, index_of_stack s v)
+    | Symb sym -> IRigid (ISymb (name_of_sym sym), index_of_stack s v)
+    | Appl (t1, t2) -> IRigid (IAppl, index_of_stack (t1 :: t2 :: s) v)
+    | Abst (t1, bind) ->
+      let _, t2 = unbind bind in
+      IRigid (IAbst, index_of_stack (t1 :: t2 :: s) v)
+    | Prod (t1, bind) ->
+      let _, t2 = unbind bind in
+      IRigid (IProd, index_of_stack (t1 :: t2 :: s) v)
+    | Patt (_var, _varname, _args) -> IHOLE (index_of_stack s v)
+    | LLet (_typ, bod, bind) ->
+      (* Let-ins are expanded during indexing *)
+      node_of_stack (subst bind bod) s v
+    | Meta _ -> assert false
+    | Plac _ ->
+      (* this may happen in a rewriting rule that uses a _ in the r.h.s.
        that is NOT instantiated; the rule is meant to open a proof
        obligation.
 
        Tentative implementation: a placeholder is seen as a variable *)
-    IRigid(IVar, index_of_stack s v)
- | Wild -> assert false (* used only by tactics and reduction *)
- | TRef _  -> assert false (* destroyed by unfold *)
- | Bvar _ -> assert false
+      IRigid (IVar, index_of_stack s v)
+    | Wild -> assert false (* used only by tactics and reduction *)
+    | TRef _ -> assert false (* destroyed by unfold *)
+    | Bvar _ -> assert false
 
-and index_of_stack stack v =
- match stack with
- | [] -> Leaf [v]
- | t::s -> Choice [node_of_stack t s v]
+  and index_of_stack stack v =
+    match stack with
+    | [] -> Leaf [ v ]
+    | t :: s -> Choice [ node_of_stack t s v ]
 
-exception NoMatch
+  exception NoMatch
 
-(* match a rigid with a term, either raising NoMatch or returning the
+  (* match a rigid with a term, either raising NoMatch or returning the
    (ordered) list of immediate subterms of the term *)
-let rec match_rigid r term =
- match r, unfold term with
- | IKind, Kind -> []
- | IType, Type -> []
- | IVar, Vari _ -> []
- | ISymb n, Symb sym  when n = name_of_sym sym -> []
- | IAppl, Appl(t1,t2) -> [t1;t2]
- | IAbst, Abst(t1,bind) -> let _, t2 = unbind bind in [t1;t2]
- | IProd, Prod(t1,bind) -> let _, t2 = unbind bind in [t1;t2]
- | _, LLet (_typ, bod, bind) -> match_rigid r (subst bind bod)
- | IVar, Plac _ ->
-    (* this may happen in a rewriting rule that uses a _ in the r.h.s.
+  let rec match_rigid r term =
+    match (r, unfold term) with
+    | IKind, Kind -> []
+    | IType, Type -> []
+    | IVar, Vari _ -> []
+    | ISymb n, Symb sym when n = name_of_sym sym -> []
+    | IAppl, Appl (t1, t2) -> [ t1; t2 ]
+    | IAbst, Abst (t1, bind) ->
+      let _, t2 = unbind bind in
+      [ t1; t2 ]
+    | IProd, Prod (t1, bind) ->
+      let _, t2 = unbind bind in
+      [ t1; t2 ]
+    | _, LLet (_typ, bod, bind) -> match_rigid r (subst bind bod)
+    | IVar, Plac _ ->
+      (* this may happen in a rewriting rule that uses a _ in the r.h.s.
        that is NOT instantiated; the rule is meant to open a proof
        obligation.
 
        Tentative implementation: a placeholder is seen as a variable *)
-    []
- | _, (Meta _ | Wild | TRef _) -> assert false
- | _, _ -> raise NoMatch
+      []
+    | _, (Meta _ | Wild | TRef _) -> assert false
+    | _, _ -> raise NoMatch
 
-(* match anything with a flexible term *)
-let rec match_flexible =
- function
-    IHOLE i -> [i]
-  | IRigid(r,i) ->
-     match r with
-      | IVar
-      | IKind
-      | IType
-      | ISymb _ -> [i]
-      | IAppl
-      | IAbst
-      | IProd ->
-          List.concat (List.map match_flexible_index (match_flexible_index i))
+  (* match anything with a flexible term *)
+  let rec match_flexible = function
+    | IHOLE i -> [ i ]
+    | IRigid (r, i) -> (
+      match r with
+      | IVar | IKind | IType | ISymb _ -> [ i ]
+      | IAppl | IAbst | IProd ->
+        List.concat (List.map match_flexible_index (match_flexible_index i)))
 
-and match_flexible_index =
- function
-    Leaf _ -> assert false (* ill-typed term *)
-  | Choice nodes ->
-     List.concat (List.map match_flexible nodes)
+  and match_flexible_index = function
+    | Leaf _ -> assert false (* ill-typed term *)
+    | Choice nodes -> List.concat (List.map match_flexible nodes)
 
-let rec insert_index index stack v =
- match index,stack with
- | Leaf vs, [] -> Leaf(v::vs)
- | Choice l, t::s ->
-    let rec aux =
-     function
-     | [] -> [node_of_stack t s v]
-     | n::nl ->
-       try
-        insert_node n t s v :: nl
-       with
-        NoMatch -> n :: aux nl
-    in Choice(aux l)
- | _, _ -> assert false (* ill-typed term *)
+  let rec insert_index index stack v =
+    match (index, stack) with
+    | Leaf vs, [] -> Leaf (v :: vs)
+    | Choice l, t :: s ->
+      let rec aux = function
+        | [] -> [ node_of_stack t s v ]
+        | n :: nl -> (
+          try insert_node n t s v :: nl with NoMatch -> n :: aux nl)
+      in
+      Choice (aux l)
+    | _, _ -> assert false (* ill-typed term *)
 
-and insert_node node term s v =
- match node,term with
- (* Patterns are holes, holes are patterns *)
- | IHOLE i, Patt _ -> IHOLE (insert_index i s v)
- | IRigid(r,i), t ->
-    let s' = match_rigid r t in
-    IRigid(r,insert_index i (s'@s) v)
- | _, _ -> raise NoMatch
+  and insert_node node term s v =
+    match (node, term) with
+    (* Patterns are holes, holes are patterns *)
+    | IHOLE i, Patt _ -> IHOLE (insert_index i s v)
+    | IRigid (r, i), t ->
+      let s' = match_rigid r t in
+      IRigid (r, insert_index i (s' @ s) v)
+    | _, _ -> raise NoMatch
 
-let insert (namemap,index) term v =
- namemap, insert_index index [term] v
+  let insert (namemap, index) term v = (namemap, insert_index index [ term ] v)
 
-let insert_name (namemap,index) name v =
- let vs =
-  match Lplib.Extra.StrMap.find_opt name namemap with
-     None -> []
-   | Some l -> l in
- Lplib.Extra.StrMap.add name (v::vs) namemap, index
+  let insert_name (namemap, index) name v =
+    let vs =
+      match Lplib.Extra.StrMap.find_opt name namemap with
+      | None -> []
+      | Some l -> l
+    in
+    (Lplib.Extra.StrMap.add name (v :: vs) namemap, index)
 
-let rec remove_index ~what =
- function
-  | Leaf l ->
-     let l' = List.filter what l in
-     (match l' with
-       | [] -> Choice []
-       | _::_ -> Leaf l')
-  | Choice l ->
-     Choice (List.filter_map (remove_node ~what) l)
+  let rec remove_index ~what = function
+    | Leaf l -> (
+      let l' = List.filter what l in
+      match l' with [] -> Choice [] | _ :: _ -> Leaf l')
+    | Choice l -> Choice (List.filter_map (remove_node ~what) l)
 
-and remove_node ~what =
- function
-  | IHOLE i ->
-     (match remove_index ~what i with
-       | Choice [] -> None
-       | i' -> Some (IHOLE i'))
-  | IRigid (r,i) ->
-     (match remove_index ~what i with
-       | Choice [] -> None
-       | i' -> Some (IRigid (r,i')))
+  and remove_node ~what = function
+    | IHOLE i -> (
+      match remove_index ~what i with
+      | Choice [] -> None
+      | i' -> Some (IHOLE i'))
+    | IRigid (r, i) -> (
+      match remove_index ~what i with
+      | Choice [] -> None
+      | i' -> Some (IRigid (r, i')))
 
-let remove_from_name_index ~what i =
- Lplib.Extra.StrMap.filter_map
-  (fun _ l ->
-    let f x = if what x then Some x else None in
-    match List.filter_map f l with
-     | [] -> None
-     | l' -> Some l') i
+  let remove_from_name_index ~what i =
+    Lplib.Extra.StrMap.filter_map
+      (fun _ l ->
+        let f x = if what x then Some x else None in
+        match List.filter_map f l with [] -> None | l' -> Some l')
+      i
 
-let remove ~what (dbname, index) =
- remove_from_name_index ~what dbname, remove_index ~what index
+  let remove ~what (dbname, index) =
+    (remove_from_name_index ~what dbname, remove_index ~what index)
 
-let rec search_index ~generalize index stack =
- match index,stack with
- | Leaf vs, [] -> vs
- | Choice l, t::s ->
-    List.fold_right
-     (fun n res -> search_node ~generalize n t s @ res) l []
- | _, _ -> assert false (* ill-typed term *)
+  let rec search_index ~generalize index stack =
+    match (index, stack) with
+    | Leaf vs, [] -> vs
+    | Choice l, t :: s ->
+      List.fold_right (fun n res -> search_node ~generalize n t s @ res) l []
+    | _, _ -> assert false (* ill-typed term *)
 
-and search_node ~generalize node term s =
- match node,term with
- | _, Patt _ ->
-     List.concat
-      (List.map
-        (fun i -> search_index ~generalize i s) (match_flexible node))
- | IHOLE i, _ when generalize -> search_index ~generalize i s
- | IHOLE i, t -> search_node ~generalize (IRigid(IVar,i)) t s
- | IRigid(r,i), t ->
-     match match_rigid r t with
-     | s' -> search_index ~generalize i (s'@s)
-     | exception NoMatch -> []
+  and search_node ~generalize node term s =
+    match (node, term) with
+    | _, Patt _ ->
+      List.concat
+        (List.map (fun i -> search_index ~generalize i s) (match_flexible node))
+    | IHOLE i, _ when generalize -> search_index ~generalize i s
+    | IHOLE i, t -> search_node ~generalize (IRigid (IVar, i)) t s
+    | IRigid (r, i), t -> (
+      match match_rigid r t with
+      | s' -> search_index ~generalize i (s' @ s)
+      | exception NoMatch -> [])
 
-(* when [~generalize] is false, all holes in the index are matched
+  (* when [~generalize] is false, all holes in the index are matched
    only by variables, i.e. the pattern is not matched up to generalization *)
-let search ~generalize (_,index) term =
- search_index ~generalize index [term]
+  let search ~generalize (_, index) term =
+    search_index ~generalize index [ term ]
 
-let locate_name (namemap,_) name =
-  match Lplib.Extra.StrMap.find_opt name namemap with None -> [] | Some l -> l
-
+  let locate_name (namemap, _) name =
+    match Lplib.Extra.StrMap.find_opt name namemap with
+    | None -> []
+    | Some l -> l
 end
 
 module DB = struct
- (* fix codomain type *)
+  (* fix codomain type *)
 
- type side = Parsing.Syntax.side = Lhs | Rhs
+  type side = Parsing.Syntax.side = Lhs | Rhs
+  type relation = Parsing.Syntax.relation = Exact | Inside
 
- type relation = Parsing.Syntax.relation = Exact | Inside
+  type 'relation where = 'relation Parsing.Syntax.where =
+    | Spine of 'relation
+    | Conclusion of 'relation
+    | Hypothesis of 'relation
 
- type 'relation where = 'relation Parsing.Syntax.where =
-  | Spine of 'relation
-  | Conclusion of 'relation
-  | Hypothesis of 'relation
-
- type position =
-  | Name
-  | Type of relation where
-  | Xhs  of relation * side
-
- type item = sym_name * Common.Pos.pos option
- (* the "name" in the sym_name of rules is just the printed position of
+  type position = Name | Type of relation where | Xhs of relation * side
+  type item = sym_name * Common.Pos.pos option
+  (* the "name" in the sym_name of rules is just the printed position of
     the rule; the associated position is never None *)
 
- let pp_side fmt =
-  function
-   | Lhs -> Lplib.Base.out fmt "lhs"
-   | Rhs -> Lplib.Base.out fmt "rhs"
+  let pp_side fmt = function
+    | Lhs -> Lplib.Base.out fmt "lhs"
+    | Rhs -> Lplib.Base.out fmt "rhs"
 
- let pp_relation fmt =
-  function
+  let pp_relation fmt = function
     | Exact -> Lplib.Base.out fmt "as the exact"
     | Inside -> Lplib.Base.out fmt "inside the"
 
- let pp_where fmt =
-  function
-   | Spine ins -> Lplib.Base.out fmt "%a spine of" pp_relation ins
-   | Hypothesis ins -> Lplib.Base.out fmt "%a hypothesis of" pp_relation ins
-   | Conclusion ins -> Lplib.Base.out fmt "%a conclusion of" pp_relation ins
+  let pp_where fmt = function
+    | Spine ins -> Lplib.Base.out fmt "%a spine of" pp_relation ins
+    | Hypothesis ins -> Lplib.Base.out fmt "%a hypothesis of" pp_relation ins
+    | Conclusion ins -> Lplib.Base.out fmt "%a conclusion of" pp_relation ins
 
- module ItemSet =
-  struct
-   include Map.Make(struct type t = item let compare = compare end)
+  module ItemSet = struct
+    include Map.Make (struct
+      type t = item
 
-   let of_list l =
-    List.fold_left
-     (fun m (k,v) ->
-       update k
-        (function
-          | None -> Some v
-          | Some l -> Some (v@l))
-        m) empty l
+      let compare = compare
+    end)
+
+    let of_list l =
+      List.fold_left
+        (fun m (k, v) ->
+          update k (function None -> Some v | Some l -> Some (v @ l)) m)
+        empty l
   end
 
- module Sym_nameMap =
-   Map.Make(struct type t = sym_name let compare = compare end)
+  module Sym_nameMap = Map.Make (struct
+    type t = sym_name
 
- type answer = ((*generalized:*)bool * term * position) list
+    let compare = compare
+  end)
 
- (* disk persistence *)
+  type answer = (*generalized:*) (bool * term * position) list
 
- let the_dbpath : string Stdlib.ref = Stdlib.ref Path.default_dbpath
+  (* disk persistence *)
 
- let rwpaths = Stdlib.ref []
+  let the_dbpath : string Stdlib.ref = Stdlib.ref Path.default_dbpath
+  let rwpaths = Stdlib.ref []
 
- let restore_from_disk () =
-  try restore_from ~filename:Stdlib.(!the_dbpath)
-  with Sys_error msg ->
-     Common.Error.wrn None "%s.\n\
-      Type \"lambdapi index --help\" to learn how to create the index." msg ;
-     Sym_nameMap.empty, Index.empty
+  let restore_from_disk () =
+    try restore_from ~filename:Stdlib.(!the_dbpath)
+    with Sys_error msg ->
+      Common.Error.wrn None
+        "%s.\nType \"lambdapi index --help\" to learn how to create the index."
+        msg;
+      (Sym_nameMap.empty, Index.empty)
 
- (* The persistent database *)
- let db :
-  ((string * string * int * int) Sym_nameMap.t *
-   (item * position list) Index.db) Lazy.t ref =
-   ref (lazy (restore_from_disk ()))
+  (* The persistent database *)
+  let db :
+      ((string * string * int * int) Sym_nameMap.t
+      * (item * position list) Index.db)
+      Lazy.t
+      ref =
+    ref (lazy (restore_from_disk ()))
 
- let preserving_index f x =
-   let saved_db = !db in
-   let res = f x in
-   db := saved_db ;
-   res
+  let preserving_index f x =
+    let saved_db = !db in
+    let res = f x in
+    db := saved_db;
+    res
 
- let empty () = db := lazy (Sym_nameMap.empty,Index.empty)
+  let empty () = db := lazy (Sym_nameMap.empty, Index.empty)
 
- let insert k v =
-   let sidx,idx = Lazy.force !db in
-   let db' = sidx, Index.insert idx k v in
-   db := lazy db'
+  let insert k v =
+    let sidx, idx = Lazy.force !db in
+    let db' = (sidx, Index.insert idx k v) in
+    db := lazy db'
 
- let insert_name k v =
-   let sidx,idx = Lazy.force !db in
-   let db' = sidx, Index.insert_name idx k v in
-   db := lazy db'
+  let insert_name k v =
+    let sidx, idx = Lazy.force !db in
+    let db' = (sidx, Index.insert_name idx k v) in
+    db := lazy db'
 
- let remove path =
-   let sidx,idx = Lazy.force !db in
-   let keep sym_path = not (is_path_prefix path sym_path) in
-   let idx =
-     Index.remove
-      ~what:(fun (((sym_path,_),_),_) -> keep sym_path ) idx in
-   let sidx =
-    Sym_nameMap.filter (fun (sym_path,_) _ -> keep sym_path) sidx in
-   db := lazy (sidx,idx)
+  let remove path =
+    let sidx, idx = Lazy.force !db in
+    let keep sym_path = not (is_path_prefix path sym_path) in
+    let idx =
+      Index.remove ~what:(fun (((sym_path, _), _), _) -> keep sym_path) idx
+    in
+    let sidx = Sym_nameMap.filter (fun (sym_path, _) _ -> keep sym_path) sidx in
+    db := lazy (sidx, idx)
 
- let set_of_list ~generalize k l =
-  (* rev_map is used because it is tail recursive *)
-  ItemSet.of_list
-   (List.rev_map
-     (fun (i,pos) ->
-       i, List.map (fun x -> generalize,k,x) pos) l)
+  let set_of_list ~generalize k l =
+    (* rev_map is used because it is tail recursive *)
+    ItemSet.of_list
+      (List.rev_map
+         (fun (i, pos) -> (i, List.map (fun x -> (generalize, k, x)) pos))
+         l)
 
- let search ~generalize k =
-  set_of_list ~generalize k
-   (Index.search ~generalize (snd (Lazy.force !db)) k)
+  let search ~generalize k =
+    set_of_list ~generalize k
+      (Index.search ~generalize (snd (Lazy.force !db)) k)
 
- let dump ~dbpath () =
-  dump_to ~filename:dbpath (Lazy.force !db)
+  let dump ~dbpath () = dump_to ~filename:dbpath (Lazy.force !db)
 
- let locate_name name =
-  let k = Term.mk_Wild (* dummy, unused *) in
-  set_of_list ~generalize:false k
-   (Index.locate_name (snd (Lazy.force !db)) name)
+  let locate_name name =
+    let k =
+      Term.mk_Wild
+      (* dummy, unused *)
+    in
+    set_of_list ~generalize:false k
+      (Index.locate_name (snd (Lazy.force !db)) name)
 
- let parse_source_map filename =
-  let sidx,idx = Lazy.force !db in
-  let sidx = ref sidx in
-  let ch = open_in filename in
-  (try
-   while true do
-     let line = input_line ch in
-     match String.split_on_char ' ' line with
-      | [fname; start_line; end_line; sourceid; lpid] ->
-          let rec sym_name_of =
-           function
+  let parse_source_map filename =
+    let sidx, idx = Lazy.force !db in
+    let sidx = ref sidx in
+    let ch = open_in filename in
+    (try
+       while true do
+         let line = input_line ch in
+         match String.split_on_char ' ' line with
+         | [ fname; start_line; end_line; sourceid; lpid ] ->
+           let rec sym_name_of = function
              | [] -> assert false
-             | [name] -> [],name
-             | hd::tl -> let path,name = sym_name_of tl in hd::path,name in
-          let lpid = sym_name_of (String.split_on_char '.' lpid) in
-          let start_line = int_of_string start_line in
-          let end_line = int_of_string end_line in
-          sidx :=
-           Sym_nameMap.add lpid (sourceid,fname,start_line,end_line) !sidx
-      | _ ->
-         raise
-          (Common.Error.Fatal
-            (None,"wrong file format for source map file", ""))
-   done ;
-  with
-   | Failure _ as exn ->
+             | [ name ] -> ([], name)
+             | hd :: tl ->
+               let path, name = sym_name_of tl in
+               (hd :: path, name)
+           in
+           let lpid = sym_name_of (String.split_on_char '.' lpid) in
+           let start_line = int_of_string start_line in
+           let end_line = int_of_string end_line in
+           sidx :=
+             Sym_nameMap.add lpid (sourceid, fname, start_line, end_line) !sidx
+         | _ ->
+           raise
+             (Common.Error.Fatal
+                (None, "wrong file format for source map file", ""))
+       done
+     with
+    | Failure _ as exn ->
       close_in ch;
       raise
-       (Common.Error.Fatal(None,"wrong file format for source map file: " ^
-         Printexc.to_string exn, ""))
-   | End_of_file -> close_in ch) ;
-  db := lazy (!sidx,idx)
+        (Common.Error.Fatal
+           ( None,
+             "wrong file format for source map file: " ^ Printexc.to_string exn,
+             "" ))
+    | End_of_file -> close_in ch);
+    db := lazy (!sidx, idx)
 
+  type ho_pp = { run : 'a. 'a Lplib.Base.pp -> 'a Lplib.Base.pp }
 
- type ho_pp = { run : 'a. 'a Lplib.Base.pp -> 'a Lplib.Base.pp }
+  let identity_escaper : ho_pp = { run = (fun x -> x) }
 
- let identity_escaper : ho_pp =
-  { run = fun x -> x }
+  let html_escaper : ho_pp =
+    {
+      run =
+        (fun pp fmt x ->
+          let res = Dream.html_escape (Format.asprintf "%a" pp x) in
+          Format.pp_print_string fmt res);
+    }
 
- let html_escaper : ho_pp =
-  { run  = fun pp fmt x ->
-     let res = Dream.html_escape (Format.asprintf "%a" pp x) in
-     Format.pp_print_string fmt res
-  }
-
- let source_infos_of_sym_name sym_name =
-  match Sym_nameMap.find_opt sym_name (fst (Lazy.force !db)) with
-   | None -> None, None
-   | Some (sourceid, fname, start_line, end_line) ->
+  let source_infos_of_sym_name sym_name =
+    match Sym_nameMap.find_opt sym_name (fst (Lazy.force !db)) with
+    | None -> (None, None)
+    | Some (sourceid, fname, start_line, end_line) ->
       let start_col = 0 in
-      let end_col = -1 in (* to the end of line *)
+      let end_col = -1 in
+      (* to the end of line *)
       (* FIX ME *)
-      let start_offset, end_offset = 0, 0 in
-      Some sourceid,
-       Some { fname=Some fname; start_line; start_col; end_line;
-              end_col; start_offset; end_offset }
+      let start_offset, end_offset = (0, 0) in
+      ( Some sourceid,
+        Some
+          {
+            fname = Some fname;
+            start_line;
+            start_col;
+            end_line;
+            end_col;
+            start_offset;
+            end_offset;
+          } )
 
- let generic_pp_of_position_list ~escaper ~sep =
-  Lplib.List.pp
-   (fun ppf position ->
-     Print.no_qualif (fun () ->
-     match position with
-      | _,_,Name ->
-         Lplib.Base.out ppf "Name"
-      | generalize,term,Type where ->
-         Lplib.Base.out ppf "%a occurs %s%a the type"
-          (escaper.run Print.term) term
-          (if generalize then "generalized " else "")
-          pp_where where
-      | generalize,term,Xhs (relation,side) ->
-         Lplib.Base.out ppf "%a occurs %s %a %a"
-          (escaper.run Print.term) term
-          (if generalize then "generalized" else "")
-          pp_relation relation pp_side side))
-   sep
+  let generic_pp_of_position_list ~escaper ~sep =
+    Lplib.List.pp
+      (fun ppf position ->
+        Print.no_qualif (fun () ->
+            match position with
+            | _, _, Name -> Lplib.Base.out ppf "Name"
+            | generalize, term, Type where ->
+              Lplib.Base.out ppf "%a occurs %s%a the type"
+                (escaper.run Print.term) term
+                (if generalize then "generalized " else "")
+                pp_where where
+            | generalize, term, Xhs (relation, side) ->
+              Lplib.Base.out ppf "%a occurs %s %a %a" (escaper.run Print.term)
+                term
+                (if generalize then "generalized" else "")
+                pp_relation relation pp_side side))
+      sep
 
- (* given a filename/URI it returns the stream of lines
+  (* given a filename/URI it returns the stream of lines
     and a function to close the resources *)
- let parse_file fname =
-  if String.starts_with ~prefix:"file:///" fname then
-   (assert (fst Stdlib.(!lsp_input) = fname) ;
-   let text = snd Stdlib.(!lsp_input) in
-   let lines = ref (String.split_on_char '\n' text) in
-   (fun () ->
-     match !lines with
-      | [] -> raise End_of_file
-      | he::tl -> lines := tl ; he),
-   (fun () -> ()))
-  else
-   let ch = open_in fname in
-   (fun () -> input_line ch), (fun () -> close_in ch)
+  let parse_file fname =
+    if String.starts_with ~prefix:"file:///" fname then (
+      assert (fst Stdlib.(!lsp_input) = fname);
+      let text = snd Stdlib.(!lsp_input) in
+      let lines = ref (String.split_on_char '\n' text) in
+      ( (fun () ->
+          match !lines with
+          | [] -> raise End_of_file
+          | he :: tl ->
+            lines := tl;
+            he),
+        fun () -> () ))
+    else
+      let ch = open_in fname in
+      ((fun () -> input_line ch), fun () -> close_in ch)
 
- let generic_pp_of_item_list ~escape ~escaper ~separator ~sep ~delimiters
-  ~lis:(lisb,lise) ~pres:(preb,pree)
-  ~bold:(boldb,bolde) ~code:(codeb,codee) ?(colorizer=Lplib.Extra.default)
-  fmt l =
-  if l = [] then
-   Lplib.Base.out fmt "Nothing found"
-  else
-    Lplib.List.pp (fun ppf (((p,n) as sym_name,pos),(positions : answer)) ->
-      let sourceid,sourcepos = source_infos_of_sym_name sym_name in
-      (* let n_pp = (Lplib.Color.red "%s") n in *)
-      Lplib.Base.out ppf
-      ("%s%a.%s"
-      ^^
-      (colorizer "%s")
-      ^^ "%s@%s%s%a%s%s%s%a%s%a%s%a%s%s%s%s@.")
-      lisb (escaper.run Core.Print.path) p boldb n bolde
-      (popt_to_string ~print_dirname:false pos)
-      separator (generic_pp_of_position_list ~escaper ~sep) positions
-      separator preb codeb
-      (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
-      ~complain_if_location_unknown:true) pos
-      separator
-      (fun ppf opt ->
-        match opt with
-        | None -> Lplib.Base.string ppf ""
-        | Some sourceid ->
-          Lplib.Base.string ppf ("Translated to " ^ sourceid)) sourceid
-          separator
-          (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
-          ~complain_if_location_unknown:false) sourcepos
-          codee pree lise separator)
-    "" fmt l
+  let generic_pp_of_item_list ~escape ~escaper ~separator ~sep ~delimiters
+      ~lis:(lisb, lise) ~pres:(preb, pree) ~bold:(boldb, bolde)
+      ~code:(codeb, codee) ?(colorizer = Lplib.Extra.default) fmt l =
+    if l = [] then Lplib.Base.out fmt "Nothing found"
+    else
+      Lplib.List.pp
+        (fun ppf ((((p, n) as sym_name), pos), (positions : answer)) ->
+          let sourceid, sourcepos = source_infos_of_sym_name sym_name in
+          (* let n_pp = (Lplib.Color.red "%s") n in *)
+          Lplib.Base.out ppf
+            ("%s%a.%s" ^^ colorizer "%s"
+           ^^ "%s@%s%s%a%s%s%s%a%s%s%a%s%s%a%s%s%s%s@.")
+            lisb
+            (escaper.run Core.Print.path)
+            p boldb n bolde
+            (popt_to_string ~print_dirname:false pos)
+            separator
+            (generic_pp_of_position_list ~escaper ~sep)
+            positions separator preb codeb
+            (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
+               ~complain_if_location_unknown:true)
+            pos separator
+            codee
+            (fun ppf opt ->
+              match opt with
+              | None -> Lplib.Base.string ppf ""
+              | Some sourceid ->
+                Lplib.Base.string ppf ("Translated to " ^ sourceid)) sourceid
+            codeb
+            separator
+            (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
+               ~complain_if_location_unknown:false)
+            sourcepos codee pree lise separator)
+        "" fmt l
 
- let html_of_item_list =
-  generic_pp_of_item_list ~escape:Dream.html_escape ~escaper:html_escaper
-   ~separator:"<br>\n" ~sep:" and<br>\n" ~delimiters:("<p>","</p>")
-   ~lis:("<li>","</li>") ~pres:("<pre>","</pre>") ~bold:("<b>","</b>")
-   ~code:("<code>","</code>") ~colorizer: Lplib.Extra.default
+  let html_of_item_list =
+    generic_pp_of_item_list ~escape:Dream.html_escape ~escaper:html_escaper
+      ~separator:"<br>\n" ~sep:" and<br>\n" ~delimiters:("<p>", "</p>")
+      ~lis:("<li>", "</li>") ~pres:("<pre>", "</pre>") ~bold:("<b>", "</b>")
+      ~code:("<code>", "</code>") ~colorizer:Lplib.Extra.default
 
- let pp_item_list fmt l =
-  generic_pp_of_item_list ~escape:(fun x -> x) ~escaper:identity_escaper
-   ~separator:"\n" ~sep:" and\n" ~delimiters:("","")
-   ~lis:("* ","") ~pres:("","")
-   ~bold:("","")
-    ~code:("","")
-    ~colorizer:
-      (if Stdlib.(!Common.Console.lsp_mod) || Unix.isatty Unix.stdout then
-        Lplib.Color.red
-      else
-        Lplib.Extra.default)
-    fmt l
+  let pp_item_list fmt l =
+    generic_pp_of_item_list
+      ~escape:(fun x -> x)
+      ~escaper:identity_escaper ~separator:"\n" ~sep:" and\n"
+      ~delimiters:("", "") ~lis:("* ", "") ~pres:("", "") ~bold:("", "")
+      ~code:("", "")
+      ~colorizer:
+        (if Stdlib.(!Common.Console.lsp_mod) || Unix.isatty Unix.stdout then
+           Lplib.Color.red
+         else Lplib.Extra.default)
+      fmt l
 
- let pp_results_list fmt l = pp_item_list fmt l
+  let pp_results_list fmt l = pp_item_list fmt l
 
- let html_of_results_list from fmt l =
-  Lplib.Base.out fmt "<ol start=\"%d\">%a</ol>" from html_of_item_list l
-
+  let html_of_results_list from fmt l =
+    Lplib.Base.out fmt "<ol start=\"%d\">%a</ol>" from html_of_item_list l
 end
 
 exception Overloaded of string * DB.answer DB.ItemSet.t
@@ -527,275 +509,282 @@ exception Overloaded of string * DB.answer DB.ItemSet.t
 let normalize_fun = ref (fun _ -> assert false)
 
 let mk_bogus_sym mp name pos =
- Core.Term.create_sym mp Core.Term.Public Core.Term.Defin Core.Term.Sequen
-  false (Common.Pos.make pos name) None Core.Term.mk_Type []
+  Core.Term.create_sym mp Core.Term.Public Core.Term.Defin Core.Term.Sequen
+    false (Common.Pos.make pos name) None Core.Term.mk_Type []
 
 let elim_duplicates_up_to_normalization res =
- let resl = DB.ItemSet.bindings res in
- let norm =
-  List.map
-   (fun ((((mp,name),sympos),l) as inp) ->
-     let s = mk_bogus_sym mp name sympos in
-     match !normalize_fun (Core.Term.mk_Symb s) with
-     | Symb {sym_path ; sym_name ; _} ->
-        (((sym_path,sym_name),sympos), l)
-     | _ -> inp) resl in
- let res = List.sort (fun ((x,_),_) ((y,_),_) -> compare x y) norm in
- let res =
-  let rec uniq =
-   function
-    | [] | [_] as l -> l
-    | ((x,_),_)::(((y,_),_)::_ as l) when x=y -> uniq l
-    | i::l -> i::uniq l in
-   uniq res in
- DB.ItemSet.of_list res
+  let resl = DB.ItemSet.bindings res in
+  let norm =
+    List.map
+      (fun ((((mp, name), sympos), l) as inp) ->
+        let s = mk_bogus_sym mp name sympos in
+        match !normalize_fun (Core.Term.mk_Symb s) with
+        | Symb { sym_path; sym_name; _ } -> (((sym_path, sym_name), sympos), l)
+        | _ -> inp)
+      resl
+  in
+  let res = List.sort (fun ((x, _), _) ((y, _), _) -> compare x y) norm in
+  let res =
+    let rec uniq = function
+      | ([] | [ _ ]) as l -> l
+      | ((x, _), _) :: (((y, _), _) :: _ as l) when x = y -> uniq l
+      | i :: l -> i :: uniq l
+    in
+    uniq res
+  in
+  DB.ItemSet.of_list res
 
-let find_sym ~prt ~prv sig_state ({elt=(mp,name); pos} as s) =
- try
-  Core.Sig_state.find_sym ~prt ~prv sig_state s
- with
-  Common.Error.Fatal _ ->
-   let pos,mp,name =
-    match mp with
-      [] ->
-       let res_orig = DB.locate_name name in
-       let res = elim_duplicates_up_to_normalization res_orig in
-       if DB.ItemSet.cardinal res > 1 then
-         raise (Overloaded (name,res_orig)) ;
-       (match DB.ItemSet.choose_opt res with
-         | None -> Common.Error.fatal pos "Unknown symbol %s." name
-         | Some (((mp,name),sympos),[_,_,DB.Name]) -> sympos,mp,name
-         | Some _ -> assert false) (* locate only returns DB.Name*)
-    | _::_ -> None,mp,name
-   in
+let find_sym ~prt ~prv sig_state ({ elt = mp, name; pos } as s) =
+  try Core.Sig_state.find_sym ~prt ~prv sig_state s
+  with Common.Error.Fatal _ ->
+    let pos, mp, name =
+      match mp with
+      | [] -> (
+        let res_orig = DB.locate_name name in
+        let res = elim_duplicates_up_to_normalization res_orig in
+        if DB.ItemSet.cardinal res > 1 then raise (Overloaded (name, res_orig));
+        match DB.ItemSet.choose_opt res with
+        | None -> Common.Error.fatal pos "Unknown symbol %s." name
+        | Some (((mp, name), sympos), [ (_, _, DB.Name) ]) -> (sympos, mp, name)
+        | Some _ -> assert false
+        (* locate only returns DB.Name*))
+      | _ :: _ -> (None, mp, name)
+    in
     mk_bogus_sym mp name pos
 
-module QNameMap =
- Map.Make(struct type t = sym_name let compare = Stdlib.compare end)
+module QNameMap = Map.Make (struct
+  type t = sym_name
+
+  let compare = Stdlib.compare
+end)
 
 let no_implicits_in_term t =
- let res = ref true in
- Core.LibTerm.iter
-  (function
-    | Plac _ -> res := false
-    | Wild | TRef _ -> assert false
-    | _ -> ()) t ;
- !res
+  let res = ref true in
+  Core.LibTerm.iter
+    (function
+      | Plac _ -> res := false | Wild | TRef _ -> assert false | _ -> ())
+    t;
+  !res
 
-let check_rule : Parsing.Syntax.p_rule -> sym_rule = fun pr ->
- let ss = Core.Sig_state.dummy in
- let (_,r) as sr = Parsing.Scope.scope_rule ~find_sym false ss pr in
- if no_implicits_in_term r.rhs then sr
- else
-  Common.Error.fatal pr.pos
-   "The rule has implicit terms in the right-hand-side: %a"
-   (Parsing.Pretty.rule "") pr
+let check_rule : Parsing.Syntax.p_rule -> sym_rule =
+ fun pr ->
+  let ss = Core.Sig_state.dummy in
+  let ((_, r) as sr) = Parsing.Scope.scope_rule ~find_sym false ss pr in
+  if no_implicits_in_term r.rhs then sr
+  else
+    Common.Error.fatal pr.pos
+      "The rule has implicit terms in the right-hand-side: %a"
+      (Parsing.Pretty.rule "") pr
 
 let load_meta_rules () =
- let rules = ref [] in
- List.iter (fun rwpath ->
-  let cmdstream = Parsing.Parser.Lp.parse_file rwpath in
-  Stream.iter
-   (fun {elt ; _ } ->
-     match elt with
-       Parsing.Syntax.P_rules r -> rules := List.rev_append r !rules
-     | _ -> ())
-   cmdstream) Stdlib.(!DB.rwpaths) ;
- let rules = List.rev !rules in
- let handle_rule map r =
-   let (s,r) = check_rule r in
-   let h = function Some rs -> Some(r::rs) | None -> Some[r] in
-   SymMap.update s h map in
- let map = List.fold_left handle_rule SymMap.empty rules in
- SymMap.iter Tree.update_dtree map;
- SymMap.fold
-  (fun sym _rs map' ->
-    QNameMap.add (name_of_sym sym) (Timed.(!(sym.sym_dtree))) map')
-  map QNameMap.empty
+  let rules = ref [] in
+  List.iter
+    (fun rwpath ->
+      let cmdstream = Parsing.Parser.Lp.parse_file rwpath in
+      Stream.iter
+        (fun { elt; _ } ->
+          match elt with
+          | Parsing.Syntax.P_rules r -> rules := List.rev_append r !rules
+          | _ -> ())
+        cmdstream)
+    Stdlib.(!DB.rwpaths);
+  let rules = List.rev !rules in
+  let handle_rule map r =
+    let s, r = check_rule r in
+    let h = function Some rs -> Some (r :: rs) | None -> Some [ r ] in
+    SymMap.update s h map
+  in
+  let map = List.fold_left handle_rule SymMap.empty rules in
+  SymMap.iter Tree.update_dtree map;
+  SymMap.fold
+    (fun sym _rs map' ->
+      QNameMap.add (name_of_sym sym) Timed.(!(sym.sym_dtree)) map')
+    map QNameMap.empty
 
 let meta_rules = lazy (load_meta_rules ())
-
 let force_meta_rules_loading () = ignore (Lazy.force meta_rules)
 
 let normalize typ =
- let dtree sym =
-  try QNameMap.find (name_of_sym sym) (Lazy.force meta_rules)
-  with Not_found -> Core.Tree_type.empty_dtree in
- Core.Eval.snf ~dtree ~tags:[`NoExpand] [] typ
+  let dtree sym =
+    try QNameMap.find (name_of_sym sym) (Lazy.force meta_rules)
+    with Not_found -> Core.Tree_type.empty_dtree
+  in
+  Core.Eval.snf ~dtree ~tags:[ `NoExpand ] [] typ
 
 let _ = normalize_fun := normalize
 
 let search_pterm ~generalize ~mok ss env pterm =
- let env =
-  ("V#",(new_var "V#",Term.mk_Type,None))::env in
- Dream.log "QUERY before scoping: %a@." Parsing.Pretty.term pterm ;
- let query =
-  Parsing.Scope.scope_search_pattern ~find_sym ~mok ss env pterm in
- Dream.log "QUERY before normalize: %a" Core.Print.term query ;
- let query = normalize query in
- Dream.log "QUERY to be executed: %a" Core.Print.term query ;
- DB.search ~generalize query
+  let env = ("V#", (new_var "V#", Term.mk_Type, None)) :: env in
+  Dream.log "QUERY before scoping: %a@." Parsing.Pretty.term pterm;
+  let query = Parsing.Scope.scope_search_pattern ~find_sym ~mok ss env pterm in
+  Dream.log "QUERY before normalize: %a" Core.Print.term query;
+  let query = normalize query in
+  Dream.log "QUERY to be executed: %a" Core.Print.term query;
+  DB.search ~generalize query
 
 let rec is_flexible t =
- match Core.Term.unfold t with
+  match Core.Term.unfold t with
   | Patt _ -> true
-  | Appl(t,_) -> is_flexible t
-  | LLet(_,_,b) -> let _, t = unbind b in is_flexible t
+  | Appl (t, _) -> is_flexible t
+  | LLet (_, _, b) ->
+    let _, t = unbind b in
+    is_flexible t
   | Vari _ | Type | Kind | Symb _ | Prod _ | Abst _ -> false
   | Plac _ ->
-     (* this may happen in a rewriting rule that uses a _ in the r.h.s.
+    (* this may happen in a rewriting rule that uses a _ in the r.h.s.
         that is NOT instantiated; the rule is meant to open a proof
         obligation
 
        Tentative implementation: a placeholder is seen as a variable *)
-     false
+    false
   | Meta _ | Wild | TRef _ | Bvar _ -> assert false
 
 let enter =
- DB.(function
-  | Hypothesis _ -> Hypothesis Inside
-  | Spine _
-  | Conclusion _ -> Conclusion Inside)
+  DB.(
+    function
+    | Hypothesis _ -> Hypothesis Inside
+    | Spine _ | Conclusion _ -> Conclusion Inside)
 
 let enter_pi_source =
- DB.(function
-  | Spine _ -> Hypothesis Exact
-  | Hypothesis _ -> Hypothesis Inside
-  | Conclusion _ -> Conclusion Inside)
+  DB.(
+    function
+    | Spine _ -> Hypothesis Exact
+    | Hypothesis _ -> Hypothesis Inside
+    | Conclusion _ -> Conclusion Inside)
 
 let enter_pi_target ~is_prod =
- DB.(function
-  | Spine _ when is_prod -> Spine Inside
-  | Spine _ -> Conclusion Exact
-  | Hypothesis _ -> Hypothesis Inside
-  | Conclusion _ -> Conclusion Inside)
+  DB.(
+    function
+    | Spine _ when is_prod -> Spine Inside
+    | Spine _ -> Conclusion Exact
+    | Hypothesis _ -> Hypothesis Inside
+    | Conclusion _ -> Conclusion Inside)
 
 let subterms_to_index ~is_spine t =
- let rec aux ~where t =
-  let t = Core.Term.unfold t in
-  [where,t] @
-  match t with
-  | Bvar _
-  | Vari _
-  | Type
-  | Kind
-  | Plac _
-  | Symb _ -> []
-  | Abst(t,b) ->
-     let _, t2 = unbind b in
-     aux ~where:(enter where) t @ aux ~where:(enter where) t2
-  | Prod(t,b) ->
-     (match where with
-       | Spine _ ->
-          let t2 = subst b (Core.Term.mk_Patt (None,"dummy",[||])) in
-          aux ~where:(enter_pi_source where) t @
-           aux ~where:(enter_pi_target ~is_prod:(Core.Term.is_prod t2) where)
-            t2
-       | _ ->
-         let _, t2 = unbind b in
-         aux ~where:(enter_pi_source where) t @
-          aux ~where:(enter_pi_target ~is_prod:false where) t2)
-  | Appl(t1,t2) ->
-     aux ~where:(enter where) t1 @ aux ~where:(enter where) t2
-  | Patt (_var,_varname,args) ->
-     List.concat (List.map (aux ~where:(enter where)) (Array.to_list args))
-  | LLet (t1,t2,b) ->
-     (* we do not expand the let-in when indexing subterms *)
-     let _, t3 = unbind b in
-     aux ~where:(enter where) t1 @ aux ~where:(enter where) t2 @
-      aux ~where:(enter where) t3
-  | Meta _ | Wild | TRef _ -> assert false
- in aux ~where:(if is_spine then Spine Exact else Conclusion Exact) t
+  let rec aux ~where t =
+    let t = Core.Term.unfold t in
+    [ (where, t) ]
+    @
+    match t with
+    | Bvar _ | Vari _ | Type | Kind | Plac _ | Symb _ -> []
+    | Abst (t, b) ->
+      let _, t2 = unbind b in
+      aux ~where:(enter where) t @ aux ~where:(enter where) t2
+    | Prod (t, b) -> (
+      match where with
+      | Spine _ ->
+        let t2 = subst b (Core.Term.mk_Patt (None, "dummy", [||])) in
+        aux ~where:(enter_pi_source where) t
+        @ aux ~where:(enter_pi_target ~is_prod:(Core.Term.is_prod t2) where) t2
+      | _ ->
+        let _, t2 = unbind b in
+        aux ~where:(enter_pi_source where) t
+        @ aux ~where:(enter_pi_target ~is_prod:false where) t2)
+    | Appl (t1, t2) -> aux ~where:(enter where) t1 @ aux ~where:(enter where) t2
+    | Patt (_var, _varname, args) ->
+      List.concat (List.map (aux ~where:(enter where)) (Array.to_list args))
+    | LLet (t1, t2, b) ->
+      (* we do not expand the let-in when indexing subterms *)
+      let _, t3 = unbind b in
+      aux ~where:(enter where) t1
+      @ aux ~where:(enter where) t2
+      @ aux ~where:(enter where) t3
+    | Meta _ | Wild | TRef _ -> assert false
+  in
+  aux ~where:(if is_spine then Spine Exact else Conclusion Exact) t
 
 let insert_rigid t v =
- if not (is_flexible t) then begin
-  DB.insert t v
-  (* assert (List.mem v (DB.search t)); *)
- end
+  if not (is_flexible t) then begin DB.insert t v
+    (* assert (List.mem v (DB.search t)); *)
+  end
 
 let index_term_and_subterms ~is_spine t item =
- let tn = normalize t in
- (*
+  let tn = normalize t in
+  (*
  let pp_item ppf (((p,n),_ ), _) =
    Lplib.Base.out ppf "%a.%s" Core.Print.path p n in
  Format.printf "%a :(%a) REWRITTEN TO (%a)@."
   pp_item (item (DB.Conclusion DB.Exact))
   Core.Print.term t Core.Print.term tn ;
  *)
- let cmp (where1,t1) (where2,t2) =
-  let res = compare where1 where2 in
-  if res = 0 then Core.Term.cmp t1 t2 else res in
- let subterms =
-  List.sort_uniq cmp (subterms_to_index ~is_spine tn) in
- List.iter (fun (where,s) -> insert_rigid s (item where)) subterms
+  let cmp (where1, t1) (where2, t2) =
+    let res = compare where1 where2 in
+    if res = 0 then Core.Term.cmp t1 t2 else res
+  in
+  let subterms = List.sort_uniq cmp (subterms_to_index ~is_spine tn) in
+  List.iter (fun (where, s) -> insert_rigid s (item where)) subterms
 
-let index_rule sym ({Core.Term.lhs=lhsargs ; rule_pos ; _} as rule) =
- let rule_pos =
-   match rule_pos with
-    | None -> assert false (* this probably may happen, but it is BAD!
+let index_rule sym ({ Core.Term.lhs = lhsargs; rule_pos; _ } as rule) =
+  let rule_pos =
+    match rule_pos with
+    | None ->
+      assert false
+      (* this probably may happen, but it is BAD!
                               I leave the assert false to detect when it
                               happens and let the team decide what to do *)
-    | Some pos -> pos in
- let lhs = Core.Term.add_args (Core.Term.mk_Symb sym) lhsargs in
- let rhs = rule.rhs in
- let get_relation = function | DB.Conclusion r -> r | _ -> assert false in
- let filename = Option.get rule_pos.fname in
- let filename =
-   if String.starts_with ~prefix:"file:///" filename then
-    let n = String.length "file://" in
-    String.sub filename n (String.length filename - n)
-   else
-    filename in
- let path = Library.path_of_file Parsing.LpLexer.escape filename in
- let rule_name = (path,Common.Pos.to_string ~print_fname:false rule_pos) in
- index_term_and_subterms ~is_spine:false lhs
-  (fun where -> ((rule_name,Some rule_pos),[Xhs(get_relation where,Lhs)])) ;
- index_term_and_subterms ~is_spine:false rhs
-  (fun where -> ((rule_name,Some rule_pos),[Xhs(get_relation where,Rhs)]))
+    | Some pos -> pos
+  in
+  let lhs = Core.Term.add_args (Core.Term.mk_Symb sym) lhsargs in
+  let rhs = rule.rhs in
+  let get_relation = function DB.Conclusion r -> r | _ -> assert false in
+  let filename = Option.get rule_pos.fname in
+  let filename =
+    if String.starts_with ~prefix:"file:///" filename then
+      let n = String.length "file://" in
+      String.sub filename n (String.length filename - n)
+    else filename
+  in
+  let path = Library.path_of_file Parsing.LpLexer.escape filename in
+  let rule_name = (path, Common.Pos.to_string ~print_fname:false rule_pos) in
+  index_term_and_subterms ~is_spine:false lhs (fun where ->
+      ((rule_name, Some rule_pos), [ Xhs (get_relation where, Lhs) ]));
+  index_term_and_subterms ~is_spine:false rhs (fun where ->
+      ((rule_name, Some rule_pos), [ Xhs (get_relation where, Rhs) ]))
 
 let _ =
- Stdlib.(Core.Sign.add_rules_callback :=
-   fun sym rules -> List.iter (index_rule sym) rules)
+  Stdlib.(
+    Core.Sign.add_rules_callback :=
+      fun sym rules -> List.iter (index_rule sym) rules)
 
 let index_sym sym =
- let qname = name_of_sym sym in
- (* Name *)
- if List.exists (fun ((sn,_),_) -> sn=qname)
-     (DB.ItemSet.bindings (DB.locate_name (snd qname)))
+  let qname = name_of_sym sym in
+  (* Name *)
+  if
+    List.exists
+      (fun ((sn, _), _) -> sn = qname)
+      (DB.ItemSet.bindings (DB.locate_name (snd qname)))
   then
-   raise
-    (Common.Error.Fatal
-      (None,string_of_sym_name qname ^ " already indexed", ""));
- DB.insert_name (snd qname) ((qname,sym.sym_decl_pos),[Name]) ;
- (* Type + InType *)
- let typ = Timed.(!(sym.Core.Term.sym_type)) in
- index_term_and_subterms ~is_spine:true typ
-  (fun where -> ((qname,sym.sym_decl_pos),[Type where])) ;
- (* InBody??? sym.sym_def : term option ref
+    raise
+      (Common.Error.Fatal
+         (None, string_of_sym_name qname ^ " already indexed", ""));
+  DB.insert_name (snd qname) ((qname, sym.sym_decl_pos), [ Name ]);
+  (* Type + InType *)
+  let typ = Timed.(!(sym.Core.Term.sym_type)) in
+  index_term_and_subterms ~is_spine:true typ (fun where ->
+      ((qname, sym.sym_decl_pos), [ Type where ]));
+  (* InBody??? sym.sym_def : term option ref
     but all the subterms are too much; collect only the constants? *)
- (* Rules *)
- List.iter (index_rule sym) Timed.(!(sym.Core.Term.sym_rules))
+  (* Rules *)
+  List.iter (index_rule sym) Timed.(!(sym.Core.Term.sym_rules))
 
 let _ = Stdlib.(Core.Sign.add_symbol_callback := index_sym)
-
-let load_rewriting_rules rwrules =
- Stdlib.(DB.rwpaths := rwrules)
+let load_rewriting_rules rwrules = Stdlib.(DB.rwpaths := rwrules)
 
 let index_sign sign =
- (*Console.set_flag "print_domains" true ;
+  (*Console.set_flag "print_domains" true ;
  Console.set_flag "print_implicits" true ;
  Common.Logger.set_debug true "e" ;*)
- let syms = Timed.(!(sign.Core.Sign.sign_symbols)) in
- let deps = Timed.(!(sign.Core.Sign.sign_deps)) in
- Lplib.Extra.StrMap.iter (fun _ sym -> index_sym sym) syms ;
- Common.Path.Map.iter
-  (fun path d ->
-    Lplib.Extra.StrMap.iter
-     (fun name sd ->
-       let sym = Core.Sign.find_qualified path name in
-       List.iter (index_rule sym) sd.Sign.rules)
-     d.Sign.dep_symbols)
-  deps
+  let syms = Timed.(!(sign.Core.Sign.sign_symbols)) in
+  let deps = Timed.(!(sign.Core.Sign.sign_deps)) in
+  Lplib.Extra.StrMap.iter (fun _ sym -> index_sym sym) syms;
+  Common.Path.Map.iter
+    (fun path d ->
+      Lplib.Extra.StrMap.iter
+        (fun name sd ->
+          let sym = Core.Sign.find_qualified path name in
+          List.iter (index_rule sym) sd.Sign.rules)
+        d.Sign.dep_symbols)
+    deps
 
 let deindex_path path = DB.remove path
 
@@ -803,134 +792,137 @@ let deindex_path path = DB.remove path
 include DB
 
 module QueryLanguage = struct
+  open Parsing.Syntax
 
- open Parsing.Syntax
+  let match_opt p x = match (p, x) with None, _ -> true | Some x', x -> x = x'
 
- let match_opt p x =
-  match p,x with
-  | None, _ -> true
-  | Some x', x -> x=x'
-
- let match_where p x =
-  match p with
-  | None -> true
-  | Some p ->
-     match p,x with
+  let match_where p x =
+    match p with
+    | None -> true
+    | Some p -> (
+      match (p, x) with
       | Spine insp, Spine ins
       | Conclusion insp, Conclusion ins
-      | Hypothesis insp, Hypothesis ins -> match_opt insp ins
-      | _, _ -> false
+      | Hypothesis insp, Hypothesis ins ->
+        match_opt insp ins
+      | _, _ -> false)
 
- let filter_constr constr _ positions =
-  Option.map (fun x -> [x])
-   (match constr with
-    | QType wherep ->
-       List.find_opt
-        (function
-          | _,_,Type where -> match_where wherep where
-          | _ -> false) positions
-    | QXhs (insp,sidep) ->
-       List.find_opt
-        (function
-          | _,_,Xhs (ins,side) -> match_opt insp ins && match_opt sidep side
-          | _ -> false) positions)
-
- let answer_base_query ~mok ss env =
-  function
-   | QName s -> locate_name s
-   | QSearch (patt,generalize,constr) ->
-      let res = search_pterm ~generalize ~mok ss env patt in
+  let filter_constr constr _ positions =
+    Option.map
+      (fun x -> [ x ])
       (match constr with
-        | None -> res
-        | Some constr -> ItemSet.filter_map (filter_constr constr) res)
+      | QType wherep ->
+        List.find_opt
+          (function _, _, Type where -> match_where wherep where | _ -> false)
+          positions
+      | QXhs (insp, sidep) ->
+        List.find_opt
+          (function
+            | _, _, Xhs (ins, side) ->
+              match_opt insp ins && match_opt sidep side
+            | _ -> false)
+          positions)
 
- let perform_op =
-  function
-   | Intersect ->
-       ItemSet.merge
-        (fun _ positions1 positions2 ->
-          match positions1, positions2 with
-           | Some l1, Some l2 -> Some (l1@l2)
-           | _,_ -> None)
-   | Union ->
-       ItemSet.union
-        (fun _ positions1 positions2 -> Some (positions1 @ positions2))
+  let answer_base_query ~mok ss env = function
+    | QName s -> locate_name s
+    | QSearch (patt, generalize, constr) -> (
+      let res = search_pterm ~generalize ~mok ss env patt in
+      match constr with
+      | None -> res
+      | Some constr -> ItemSet.filter_map (filter_constr constr) res)
 
- let filter set f =
-  let g ((p',_ as name),_) _ =
-   match f with
-    | Path p -> is_path_prefix p p'
-    | RegExp s -> let re = Str.regexp s in re_matches_sym_name re name in
-  ItemSet.filter g set
+  let perform_op = function
+    | Intersect ->
+      ItemSet.merge (fun _ positions1 positions2 ->
+          match (positions1, positions2) with
+          | Some l1, Some l2 -> Some (l1 @ l2)
+          | _, _ -> None)
+    | Union ->
+      ItemSet.union (fun _ positions1 positions2 ->
+          Some (positions1 @ positions2))
 
- let answer_query ~mok ss env =
-  let rec aux =
-   function
-    | QBase bq -> answer_base_query ~mok ss env bq
-    | QOp (q1,op,q2) -> perform_op op (aux q1) (aux q2)
-    | QFilter (q,f) -> filter (aux q) f
-  in
-   aux
+  let filter set f =
+    let g (((p', _) as name), _) _ =
+      match f with
+      | Path p -> is_path_prefix p p'
+      | RegExp s ->
+        let re = Str.regexp s in
+        re_matches_sym_name re name
+    in
+    ItemSet.filter g set
 
+  let answer_query ~mok ss env =
+    let rec aux = function
+      | QBase bq -> answer_base_query ~mok ss env bq
+      | QOp (q1, op, q2) -> perform_op op (aux q1) (aux q2)
+      | QFilter (q, f) -> filter (aux q) f
+    in
+    aux
 end
 
 (* let's flatten the interface *)
 include QueryLanguage
 
 module UserLevelQueries = struct
-
- let search_cmd_gen ss ~from ~how_many
-  ~(fail:Pos.popt option -> ?err_desc:string -> string -> string)
-  ~pp_results ~tag:(hb,he) q fmt s =
-  try
-   let mok _ = None in
-   let q = match q with
-   | None -> Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s
-   | Some q -> q in
-   let items = ItemSet.bindings (answer_query ~mok ss [] q) in
-   let resultsno = List.length items in
-   let _,items = Lplib.List.cut items from in
-   let items,_ = Lplib.List.cut items how_many in
-   Lplib.Base.out fmt "%sNumber of results: %d%s@.%a@."
-    hb resultsno he pp_results items
-  with
-   | Stream.Failure ->
+  let search_cmd_gen ss ~from ~how_many
+      ~(fail : Pos.popt option -> ?err_desc:string -> string -> string)
+      ~pp_results ~tag:(hb, he) q fmt s =
+    try
+      let mok _ = None in
+      let q =
+        match q with
+        | None -> Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s
+        | Some q -> q
+      in
+      let items = ItemSet.bindings (answer_query ~mok ss [] q) in
+      let resultsno = List.length items in
+      let _, items = Lplib.List.cut items from in
+      let items, _ = Lplib.List.cut items how_many in
+      Lplib.Base.out fmt "%sNumber of results: %d%s@.%a@." hb resultsno he
+        pp_results items
+    with
+    | Stream.Failure ->
       Lplib.Base.out fmt "%s"
-       (fail None (Format.asprintf "Syntax error: a query was expected@."))
-   | Common.Error.Fatal(pos,msg, _) ->
+        (fail None (Format.asprintf "Syntax error: a query was expected@."))
+    | Common.Error.Fatal (pos, msg, _) ->
       Lplib.Base.out fmt "%s" (fail pos (Format.asprintf "Error: %s@." msg))
-   | Overloaded(name,res) ->
-      Lplib.Base.out fmt "%s" (fail None (Format.asprintf
-       "Overloaded symbol %s. Please rewrite the query replacing %s \
-        with a fully qualified identifier among the following:@."
-        name name)
-        ~err_desc:(Format.asprintf "%a@." pp_results (ItemSet.bindings res))
-        )
-   | Stack_overflow ->
-      Lplib.Base.out fmt "%s" (fail None
-       (Format.asprintf
-         "Error: too many results. Please refine your query.@." ))
-   | exn ->
+    | Overloaded (name, res) ->
       Lplib.Base.out fmt "%s"
-       (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
+        (fail None
+           (Format.asprintf
+              "Overloaded symbol %s. Please rewrite the query replacing %s \
+               with a fully qualified identifier among the following:@."
+              name name)
+           ~err_desc:(Format.asprintf "%a@." pp_results (ItemSet.bindings res)))
+    | Stack_overflow ->
+      Lplib.Base.out fmt "%s"
+        (fail None
+           (Format.asprintf
+              "Error: too many results. Please refine your query.@."))
+    | exn ->
+      Lplib.Base.out fmt "%s"
+        (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
 
   let search_cmd_txt_string ss ~dbpath s =
-  Stdlib.(the_dbpath := dbpath);
-  Format.asprintf "%a" (search_cmd_gen ss ~from:0 ~how_many:999999
-   ~fail:(fun pos ?err_desc x ->
-    Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-   ~pp_results:pp_results_list ~tag:("","") None) s
+    Stdlib.(the_dbpath := dbpath);
+    Format.asprintf "%a"
+      (search_cmd_gen ss ~from:0 ~how_many:999999
+         ~fail:(fun pos ?err_desc x ->
+           Common.Error.fatal_optional_position pos ?err_desc "%s" x)
+         ~pp_results:pp_results_list ~tag:("", "") None)
+      s
 
   let search_cmd_txt_query ss ~dbpath q =
-  Stdlib.(the_dbpath := dbpath);
-  Format.asprintf "%a" (search_cmd_gen ss ~from:0 ~how_many:999999
-   ~fail:(fun pos ?err_desc x ->
-    Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-   ~pp_results:pp_results_list ~tag:("","") (Some q)) ""
+    Stdlib.(the_dbpath := dbpath);
+    Format.asprintf "%a"
+      (search_cmd_gen ss ~from:0 ~how_many:999999
+         ~fail:(fun pos ?err_desc x ->
+           Common.Error.fatal_optional_position pos ?err_desc "%s" x)
+         ~pp_results:pp_results_list ~tag:("", "") (Some q))
+      ""
 
-
- (** [transform_ascii_to_unicode s] replaces all the occurences of ["->"] and
-     ["forall"] with ["→"] and ["Π"] in the search query [s] *)
+  (** [transform_ascii_to_unicode s] replaces all the occurences of ["->"] and
+      ["forall"] with ["→"] and ["Π"] in the search query [s] *)
   let transform_ascii_to_unicode : string -> string =
     let arrow = Str.regexp_string " -> "
     and forall = Str.regexp "\\bforall\\b" in
@@ -944,24 +936,22 @@ module UserLevelQueries = struct
     assert (transform_ascii_to_unicode "forall.x, y" = "Π.x, y");
     assert (transform_ascii_to_unicode "((forall x, y" = "((Π x, y")
 
- let search_cmd_html ss ~from ~how_many s ~dbpath =
-  Stdlib.(the_dbpath := dbpath);
+  let search_cmd_html ss ~from ~how_many s ~dbpath =
+    Stdlib.(the_dbpath := dbpath);
     Format.asprintf "%a"
-    (search_cmd_gen ss ~from ~how_many
-      ~fail:(fun pos ?err_desc x -> "<font color=\"red\">" ^ x ^ "</font>"
-          ^ (match pos with | None ->"" | Some p -> popt_to_string p)
-          ^ (Option.value err_desc ~default:"")
-   )
-      ~pp_results:(html_of_results_list from)
-      ~tag:("<h1>","</h1")
-      None)
+      (search_cmd_gen ss ~from ~how_many
+         ~fail:(fun pos ?err_desc x ->
+           "<font color=\"red\">" ^ x ^ "</font>"
+           ^ (match pos with None -> "" | Some p -> popt_to_string p)
+           ^ Option.value err_desc ~default:"")
+         ~pp_results:(html_of_results_list from)
+         ~tag:("<h1>", "</h1") None)
       s
 
- let search_cmd_txt ss ~dbpath (fmt:Format.formatter) s =
-  Stdlib.(the_dbpath := dbpath);
-  Lplib.Base.string fmt
-    (search_cmd_txt_string ss ~dbpath
-      (transform_ascii_to_unicode s))
+  let search_cmd_txt ss ~dbpath (fmt : Format.formatter) s =
+    Stdlib.(the_dbpath := dbpath);
+    Lplib.Base.string fmt
+      (search_cmd_txt_string ss ~dbpath (transform_ascii_to_unicode s))
 end
 
 (* let's flatten the interface *)

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -1,35 +1,36 @@
-open Core
-open Term
-open Common
-open Pos
+open Core open Term
+open Common open Pos
 open Timed
 
-let lsp_input = Stdlib.ref ("", "")
+let lsp_input = Stdlib.ref ("","")
 
 type sym_name = Common.Path.t * string
 
 let string_of_path x = Format.asprintf "%a" Common.Path.pp x
-let string_of_sym_name (p, n) = string_of_path p ^ "." ^ n
-let is_path_prefix patt p = Lplib.String.is_prefix patt (string_of_path p)
+let string_of_sym_name (p,n) = string_of_path p ^ "." ^ n
+
+let is_path_prefix patt p =
+ Lplib.String.is_prefix patt (string_of_path p)
 
 let re_matches_sym_name re sym_name =
-  try
-    ignore (Str.search_forward re (string_of_sym_name sym_name) 0);
-    true
-  with Not_found -> false
+ try
+  ignore (Str.search_forward re (string_of_sym_name sym_name) 0) ;
+  true
+ with Not_found -> false
 
-let ( @ ) = Lplib.List.( @ )
+ let (@) = Lplib.List.(@)
+
 let name_of_sym s = (s.sym_path, s.sym_name)
 
 let dump_to ~filename i =
-  let ch = open_out_bin filename in
-  Marshal.to_channel ch i [];
-  close_out ch
+ let ch = open_out_bin filename in
+ Marshal.to_channel ch i [] ;
+ close_out ch
 
 let restore_from ~filename =
   let ch = open_in_bin filename in
   let i = Marshal.from_channel ch in
-  close_in ch;
+  close_in ch ;
   i
 
 (* discrimination tree *)
@@ -49,464 +50,478 @@ let restore_from ~filename =
 *)
 
 module Index = struct
-  type 'a index = Leaf of 'a list | Choice of 'a node list
-  and 'a node = IHOLE of 'a index | IRigid of rigid * 'a index
-  and rigid = IVar | IKind | IType | ISymb of sym_name | IAppl | IAbst | IProd
 
-  type 'a db = 'a list Lplib.Extra.StrMap.t * 'a index
+type 'a index =
+ | Leaf of 'a list
+ | Choice of 'a node list
 
-  let empty : 'a db = (Lplib.Extra.StrMap.empty, Choice [])
+and 'a node =
+ | IHOLE of 'a index
+ | IRigid of rigid * 'a index
 
-  let rec node_of_stack t s v =
-    match unfold t with
-    | Kind -> IRigid (IKind, index_of_stack s v)
-    | Type -> IRigid (IType, index_of_stack s v)
-    | Vari _ -> IRigid (IVar, index_of_stack s v)
-    | Symb sym -> IRigid (ISymb (name_of_sym sym), index_of_stack s v)
-    | Appl (t1, t2) -> IRigid (IAppl, index_of_stack (t1 :: t2 :: s) v)
-    | Abst (t1, bind) ->
-      let _, t2 = unbind bind in
-      IRigid (IAbst, index_of_stack (t1 :: t2 :: s) v)
-    | Prod (t1, bind) ->
-      let _, t2 = unbind bind in
-      IRigid (IProd, index_of_stack (t1 :: t2 :: s) v)
-    | Patt (_var, _varname, _args) -> IHOLE (index_of_stack s v)
-    | LLet (_typ, bod, bind) ->
-      (* Let-ins are expanded during indexing *)
-      node_of_stack (subst bind bod) s v
-    | Meta _ -> assert false
-    | Plac _ ->
-      (* this may happen in a rewriting rule that uses a _ in the r.h.s.
+and rigid =
+ | IVar
+ | IKind
+ | IType
+ | ISymb of sym_name
+ | IAppl
+ | IAbst
+ | IProd
+
+type 'a db = 'a list Lplib.Extra.StrMap.t * 'a index
+
+let empty : 'a db =  Lplib.Extra.StrMap.empty, Choice []
+
+let rec node_of_stack t s v =
+ match unfold t with
+ | Kind -> IRigid(IKind, index_of_stack s v)
+ | Type -> IRigid(IType, index_of_stack s v)
+ | Vari _ -> IRigid(IVar, index_of_stack s v)
+ | Symb sym  -> IRigid(ISymb (name_of_sym sym), index_of_stack s v)
+ | Appl(t1,t2) -> IRigid(IAppl, index_of_stack (t1::t2::s) v)
+ | Abst(t1,bind) ->
+    let _, t2 = unbind bind in
+    IRigid(IAbst, index_of_stack (t1::t2::s) v)
+ | Prod(t1,bind) ->
+    let _, t2 = unbind bind in
+    IRigid(IProd, index_of_stack (t1::t2::s) v)
+ | Patt (_var,_varname,_args) ->
+    IHOLE (index_of_stack s v)
+ | LLet (_typ, bod, bind) ->
+    (* Let-ins are expanded during indexing *)
+    node_of_stack (subst bind bod) s v
+ | Meta _ -> assert false
+ | Plac _ ->
+    (* this may happen in a rewriting rule that uses a _ in the r.h.s.
        that is NOT instantiated; the rule is meant to open a proof
        obligation.
 
        Tentative implementation: a placeholder is seen as a variable *)
-      IRigid (IVar, index_of_stack s v)
-    | Wild -> assert false (* used only by tactics and reduction *)
-    | TRef _ -> assert false (* destroyed by unfold *)
-    | Bvar _ -> assert false
+    IRigid(IVar, index_of_stack s v)
+ | Wild -> assert false (* used only by tactics and reduction *)
+ | TRef _  -> assert false (* destroyed by unfold *)
+ | Bvar _ -> assert false
 
-  and index_of_stack stack v =
-    match stack with
-    | [] -> Leaf [ v ]
-    | t :: s -> Choice [ node_of_stack t s v ]
+and index_of_stack stack v =
+ match stack with
+ | [] -> Leaf [v]
+ | t::s -> Choice [node_of_stack t s v]
 
-  exception NoMatch
+exception NoMatch
 
-  (* match a rigid with a term, either raising NoMatch or returning the
+(* match a rigid with a term, either raising NoMatch or returning the
    (ordered) list of immediate subterms of the term *)
-  let rec match_rigid r term =
-    match (r, unfold term) with
-    | IKind, Kind -> []
-    | IType, Type -> []
-    | IVar, Vari _ -> []
-    | ISymb n, Symb sym when n = name_of_sym sym -> []
-    | IAppl, Appl (t1, t2) -> [ t1; t2 ]
-    | IAbst, Abst (t1, bind) ->
-      let _, t2 = unbind bind in
-      [ t1; t2 ]
-    | IProd, Prod (t1, bind) ->
-      let _, t2 = unbind bind in
-      [ t1; t2 ]
-    | _, LLet (_typ, bod, bind) -> match_rigid r (subst bind bod)
-    | IVar, Plac _ ->
-      (* this may happen in a rewriting rule that uses a _ in the r.h.s.
+let rec match_rigid r term =
+ match r, unfold term with
+ | IKind, Kind -> []
+ | IType, Type -> []
+ | IVar, Vari _ -> []
+ | ISymb n, Symb sym  when n = name_of_sym sym -> []
+ | IAppl, Appl(t1,t2) -> [t1;t2]
+ | IAbst, Abst(t1,bind) -> let _, t2 = unbind bind in [t1;t2]
+ | IProd, Prod(t1,bind) -> let _, t2 = unbind bind in [t1;t2]
+ | _, LLet (_typ, bod, bind) -> match_rigid r (subst bind bod)
+ | IVar, Plac _ ->
+    (* this may happen in a rewriting rule that uses a _ in the r.h.s.
        that is NOT instantiated; the rule is meant to open a proof
        obligation.
 
        Tentative implementation: a placeholder is seen as a variable *)
-      []
-    | _, (Meta _ | Wild | TRef _) -> assert false
-    | _, _ -> raise NoMatch
+    []
+ | _, (Meta _ | Wild | TRef _) -> assert false
+ | _, _ -> raise NoMatch
 
-  (* match anything with a flexible term *)
-  let rec match_flexible = function
-    | IHOLE i -> [ i ]
-    | IRigid (r, i) -> (
-      match r with
-      | IVar | IKind | IType | ISymb _ -> [ i ]
-      | IAppl | IAbst | IProd ->
-        List.concat (List.map match_flexible_index (match_flexible_index i)))
+(* match anything with a flexible term *)
+let rec match_flexible =
+ function
+    IHOLE i -> [i]
+  | IRigid(r,i) ->
+     match r with
+      | IVar
+      | IKind
+      | IType
+      | ISymb _ -> [i]
+      | IAppl
+      | IAbst
+      | IProd ->
+          List.concat (List.map match_flexible_index (match_flexible_index i))
 
-  and match_flexible_index = function
-    | Leaf _ -> assert false (* ill-typed term *)
-    | Choice nodes -> List.concat (List.map match_flexible nodes)
+and match_flexible_index =
+ function
+    Leaf _ -> assert false (* ill-typed term *)
+  | Choice nodes ->
+     List.concat (List.map match_flexible nodes)
 
-  let rec insert_index index stack v =
-    match (index, stack) with
-    | Leaf vs, [] -> Leaf (v :: vs)
-    | Choice l, t :: s ->
-      let rec aux = function
-        | [] -> [ node_of_stack t s v ]
-        | n :: nl -> (
-          try insert_node n t s v :: nl with NoMatch -> n :: aux nl)
-      in
-      Choice (aux l)
-    | _, _ -> assert false (* ill-typed term *)
+let rec insert_index index stack v =
+ match index,stack with
+ | Leaf vs, [] -> Leaf(v::vs)
+ | Choice l, t::s ->
+    let rec aux =
+     function
+     | [] -> [node_of_stack t s v]
+     | n::nl ->
+       try
+        insert_node n t s v :: nl
+       with
+        NoMatch -> n :: aux nl
+    in Choice(aux l)
+ | _, _ -> assert false (* ill-typed term *)
 
-  and insert_node node term s v =
-    match (node, term) with
-    (* Patterns are holes, holes are patterns *)
-    | IHOLE i, Patt _ -> IHOLE (insert_index i s v)
-    | IRigid (r, i), t ->
-      let s' = match_rigid r t in
-      IRigid (r, insert_index i (s' @ s) v)
-    | _, _ -> raise NoMatch
+and insert_node node term s v =
+ match node,term with
+ (* Patterns are holes, holes are patterns *)
+ | IHOLE i, Patt _ -> IHOLE (insert_index i s v)
+ | IRigid(r,i), t ->
+    let s' = match_rigid r t in
+    IRigid(r,insert_index i (s'@s) v)
+ | _, _ -> raise NoMatch
 
-  let insert (namemap, index) term v =
-    (namemap, insert_index index [ term ] v)
+let insert (namemap,index) term v =
+ namemap, insert_index index [term] v
 
-  let insert_name (namemap, index) name v =
-    let vs =
-      match Lplib.Extra.StrMap.find_opt name namemap with
-      | None -> []
-      | Some l -> l
-    in
-    (Lplib.Extra.StrMap.add name (v :: vs) namemap, index)
+let insert_name (namemap,index) name v =
+ let vs =
+  match Lplib.Extra.StrMap.find_opt name namemap with
+     None -> []
+   | Some l -> l in
+ Lplib.Extra.StrMap.add name (v::vs) namemap, index
 
-  let rec remove_index ~what = function
-    | Leaf l -> (
-      let l' = List.filter what l in
-      match l' with [] -> Choice [] | _ :: _ -> Leaf l')
-    | Choice l -> Choice (List.filter_map (remove_node ~what) l)
+let rec remove_index ~what =
+ function
+  | Leaf l ->
+     let l' = List.filter what l in
+     (match l' with
+       | [] -> Choice []
+       | _::_ -> Leaf l')
+  | Choice l ->
+     Choice (List.filter_map (remove_node ~what) l)
 
-  and remove_node ~what = function
-    | IHOLE i -> (
-      match remove_index ~what i with
-      | Choice [] -> None
-      | i' -> Some (IHOLE i'))
-    | IRigid (r, i) -> (
-      match remove_index ~what i with
-      | Choice [] -> None
-      | i' -> Some (IRigid (r, i')))
+and remove_node ~what =
+ function
+  | IHOLE i ->
+     (match remove_index ~what i with
+       | Choice [] -> None
+       | i' -> Some (IHOLE i'))
+  | IRigid (r,i) ->
+     (match remove_index ~what i with
+       | Choice [] -> None
+       | i' -> Some (IRigid (r,i')))
 
-  let remove_from_name_index ~what i =
-    Lplib.Extra.StrMap.filter_map
-      (fun _ l ->
-        let f x = if what x then Some x else None in
-        match List.filter_map f l with [] -> None | l' -> Some l')
-      i
+let remove_from_name_index ~what i =
+ Lplib.Extra.StrMap.filter_map
+  (fun _ l ->
+    let f x = if what x then Some x else None in
+    match List.filter_map f l with
+     | [] -> None
+     | l' -> Some l') i
 
-  let remove ~what (dbname, index) =
-    (remove_from_name_index ~what dbname, remove_index ~what index)
+let remove ~what (dbname, index) =
+ remove_from_name_index ~what dbname, remove_index ~what index
 
-  let rec search_index ~generalize index stack =
-    match (index, stack) with
-    | Leaf vs, [] -> vs
-    | Choice l, t :: s ->
-      List.fold_right (fun n res -> search_node ~generalize n t s @ res) l []
-    | _, _ -> assert false (* ill-typed term *)
+let rec search_index ~generalize index stack =
+ match index,stack with
+ | Leaf vs, [] -> vs
+ | Choice l, t::s ->
+    List.fold_right
+     (fun n res -> search_node ~generalize n t s @ res) l []
+ | _, _ -> assert false (* ill-typed term *)
 
-  and search_node ~generalize node term s =
-    match (node, term) with
-    | _, Patt _ ->
-      List.concat
-        (List.map (fun i -> search_index ~generalize i s)
-        (match_flexible node))
-    | IHOLE i, _ when generalize -> search_index ~generalize i s
-    | IHOLE i, t -> search_node ~generalize (IRigid (IVar, i)) t s
-    | IRigid (r, i), t -> (
-      match match_rigid r t with
-      | s' -> search_index ~generalize i (s' @ s)
-      | exception NoMatch -> [])
+and search_node ~generalize node term s =
+ match node,term with
+ | _, Patt _ ->
+     List.concat
+      (List.map
+        (fun i -> search_index ~generalize i s) (match_flexible node))
+ | IHOLE i, _ when generalize -> search_index ~generalize i s
+ | IHOLE i, t -> search_node ~generalize (IRigid(IVar,i)) t s
+ | IRigid(r,i), t ->
+     match match_rigid r t with
+     | s' -> search_index ~generalize i (s'@s)
+     | exception NoMatch -> []
 
-  (* when [~generalize] is false, all holes in the index are matched
+(* when [~generalize] is false, all holes in the index are matched
    only by variables, i.e. the pattern is not matched up to generalization *)
-  let search ~generalize (_, index) term =
-    search_index ~generalize index [ term ]
+let search ~generalize (_,index) term =
+ search_index ~generalize index [term]
 
-  let locate_name (namemap, _) name =
-    match Lplib.Extra.StrMap.find_opt name namemap with
-    | None -> []
-    | Some l -> l
+let locate_name (namemap,_) name =
+  match Lplib.Extra.StrMap.find_opt name namemap with None -> [] | Some l -> l
+
 end
 
 module DB = struct
-  (* fix codomain type *)
+ (* fix codomain type *)
 
-  type side = Parsing.Syntax.side = Lhs | Rhs
-  type relation = Parsing.Syntax.relation = Exact | Inside
+ type side = Parsing.Syntax.side = Lhs | Rhs
 
-  type 'relation where = 'relation Parsing.Syntax.where =
-    | Spine of 'relation
-    | Conclusion of 'relation
-    | Hypothesis of 'relation
+ type relation = Parsing.Syntax.relation = Exact | Inside
 
-  type position = Name | Type of relation where | Xhs of relation * side
-  type item = sym_name * Common.Pos.pos option
-  (* the "name" in the sym_name of rules is just the printed position of
+ type 'relation where = 'relation Parsing.Syntax.where =
+  | Spine of 'relation
+  | Conclusion of 'relation
+  | Hypothesis of 'relation
+
+ type position =
+  | Name
+  | Type of relation where
+  | Xhs  of relation * side
+
+ type item = sym_name * Common.Pos.pos option
+ (* the "name" in the sym_name of rules is just the printed position of
     the rule; the associated position is never None *)
 
-  let pp_side fmt = function
-    | Lhs -> Lplib.Base.out fmt "lhs"
-    | Rhs -> Lplib.Base.out fmt "rhs"
+ let pp_side fmt =
+  function
+   | Lhs -> Lplib.Base.out fmt "lhs"
+   | Rhs -> Lplib.Base.out fmt "rhs"
 
-  let pp_relation fmt = function
+ let pp_relation fmt =
+  function
     | Exact -> Lplib.Base.out fmt "as the exact"
     | Inside -> Lplib.Base.out fmt "inside the"
 
-  let pp_where fmt = function
-    | Spine ins -> Lplib.Base.out fmt "%a spine of" pp_relation ins
-    | Hypothesis ins -> Lplib.Base.out fmt "%a hypothesis of" pp_relation ins
-    | Conclusion ins -> Lplib.Base.out fmt "%a conclusion of" pp_relation ins
+ let pp_where fmt =
+  function
+   | Spine ins -> Lplib.Base.out fmt "%a spine of" pp_relation ins
+   | Hypothesis ins -> Lplib.Base.out fmt "%a hypothesis of" pp_relation ins
+   | Conclusion ins -> Lplib.Base.out fmt "%a conclusion of" pp_relation ins
 
-  module ItemSet = struct
-    include Map.Make (struct
-      type t = item
+ module ItemSet =
+  struct
+   include Map.Make(struct type t = item let compare = compare end)
 
-      let compare = compare
-    end)
-
-    let of_list l =
-      List.fold_left
-        (fun m (k, v) ->
-          update k (function None -> Some v | Some l -> Some (v @ l)) m)
-        empty l
+   let of_list l =
+    List.fold_left
+     (fun m (k,v) ->
+       update k
+        (function
+          | None -> Some v
+          | Some l -> Some (v@l))
+        m) empty l
   end
 
-  module Sym_nameMap = Map.Make (struct
-    type t = sym_name
+ module Sym_nameMap =
+   Map.Make(struct type t = sym_name let compare = compare end)
 
-    let compare = compare
-  end)
+ type answer = ((*generalized:*)bool * term * position) list
 
-  type answer = (*generalized:*) (bool * term * position) list
+ (* disk persistence *)
 
-  (* disk persistence *)
+ let the_dbpath : string Stdlib.ref = Stdlib.ref Path.default_dbpath
 
-  let the_dbpath : string Stdlib.ref = Stdlib.ref Path.default_dbpath
-  let rwpaths = Stdlib.ref []
+ let rwpaths = Stdlib.ref []
 
-  let restore_from_disk () =
-    try restore_from ~filename:Stdlib.(!the_dbpath)
-    with Sys_error msg ->
-      Common.Error.wrn None "%s.\n\
-       Type \"lambdapi index --help\" to learn how to create the index." msg;
-      (Sym_nameMap.empty, Index.empty)
+ let restore_from_disk () =
+  try restore_from ~filename:Stdlib.(!the_dbpath)
+  with Sys_error msg ->
+     Common.Error.wrn None "%s.\n\
+      Type \"lambdapi index --help\" to learn how to create the index." msg ;
+     Sym_nameMap.empty, Index.empty
 
-  (* The persistent database *)
-  let db :
-      ((string * string * int * int) Sym_nameMap.t
-      * (item * position list) Index.db)
-      Lazy.t
-      ref =
-    ref (lazy (restore_from_disk ()))
+ (* The persistent database *)
+ let db :
+  ((string * string * int * int) Sym_nameMap.t *
+   (item * position list) Index.db) Lazy.t ref =
+   ref (lazy (restore_from_disk ()))
 
-  let preserving_index f x =
-    let saved_db = !db in
-    let res = f x in
-    db := saved_db;
-    res
+ let preserving_index f x =
+   let saved_db = !db in
+   let res = f x in
+   db := saved_db ;
+   res
 
-  let empty () = db := lazy (Sym_nameMap.empty, Index.empty)
+ let empty () = db := lazy (Sym_nameMap.empty,Index.empty)
 
-  let insert k v =
-    let sidx, idx = Lazy.force !db in
-    let db' = (sidx, Index.insert idx k v) in
-    db := lazy db'
+ let insert k v =
+   let sidx,idx = Lazy.force !db in
+   let db' = sidx, Index.insert idx k v in
+   db := lazy db'
 
-  let insert_name k v =
-    let sidx, idx = Lazy.force !db in
-    let db' = (sidx, Index.insert_name idx k v) in
-    db := lazy db'
+ let insert_name k v =
+   let sidx,idx = Lazy.force !db in
+   let db' = sidx, Index.insert_name idx k v in
+   db := lazy db'
 
-  let remove path =
-    let sidx, idx = Lazy.force !db in
-    let keep sym_path = not (is_path_prefix path sym_path) in
-    let idx =
-      Index.remove ~what:(fun (((sym_path, _), _), _) -> keep sym_path) idx
-    in
-    let sidx = Sym_nameMap.filter (fun (sym_path, _) _ ->
-      keep sym_path) sidx
-    in
-    db := lazy (sidx, idx)
+ let remove path =
+   let sidx,idx = Lazy.force !db in
+   let keep sym_path = not (is_path_prefix path sym_path) in
+   let idx =
+     Index.remove
+      ~what:(fun (((sym_path,_),_),_) -> keep sym_path ) idx in
+   let sidx =
+    Sym_nameMap.filter (fun (sym_path,_) _ -> keep sym_path) sidx in
+   db := lazy (sidx,idx)
 
-  let set_of_list ~generalize k l =
-    (* rev_map is used because it is tail recursive *)
-    ItemSet.of_list
-      (List.rev_map
-         (fun (i, pos) -> (i, List.map (fun x -> (generalize, k, x)) pos))
-         l)
+ let set_of_list ~generalize k l =
+  (* rev_map is used because it is tail recursive *)
+  ItemSet.of_list
+   (List.rev_map
+     (fun (i,pos) ->
+       i, List.map (fun x -> generalize,k,x) pos) l)
 
-  let search ~generalize k =
-    set_of_list ~generalize k
-      (Index.search ~generalize (snd (Lazy.force !db)) k)
+ let search ~generalize k =
+  set_of_list ~generalize k
+   (Index.search ~generalize (snd (Lazy.force !db)) k)
 
-  let dump ~dbpath () = dump_to ~filename:dbpath (Lazy.force !db)
+ let dump ~dbpath () =
+  dump_to ~filename:dbpath (Lazy.force !db)
 
-  let locate_name name =
-    let k =
-      Term.mk_Wild
-      (* dummy, unused *)
-    in
-    set_of_list ~generalize:false k
-      (Index.locate_name (snd (Lazy.force !db)) name)
+ let locate_name name =
+  let k = Term.mk_Wild (* dummy, unused *) in
+  set_of_list ~generalize:false k
+   (Index.locate_name (snd (Lazy.force !db)) name)
 
-  let parse_source_map filename =
-    let sidx, idx = Lazy.force !db in
-    let sidx = ref sidx in
-    let ch = open_in filename in
-    (try
-       while true do
-         let line = input_line ch in
-         match String.split_on_char ' ' line with
-         | [ fname; start_line; end_line; sourceid; lpid ] ->
-           let rec sym_name_of = function
+ let parse_source_map filename =
+  let sidx,idx = Lazy.force !db in
+  let sidx = ref sidx in
+  let ch = open_in filename in
+  (try
+   while true do
+     let line = input_line ch in
+     match String.split_on_char ' ' line with
+      | [fname; start_line; end_line; sourceid; lpid] ->
+          let rec sym_name_of =
+           function
              | [] -> assert false
-             | [ name ] -> ([], name)
-             | hd :: tl ->
-               let path, name = sym_name_of tl in
-               (hd :: path, name)
-           in
-           let lpid = sym_name_of (String.split_on_char '.' lpid) in
-           let start_line = int_of_string start_line in
-           let end_line = int_of_string end_line in
-           sidx :=
-             Sym_nameMap.add lpid (sourceid, fname, start_line, end_line)
-             !sidx
-         | _ ->
-           raise
-             (Common.Error.Fatal
-                (None, "wrong file format for source map file", ""))
-       done
-     with
-    | Failure _ as exn ->
+             | [name] -> [],name
+             | hd::tl -> let path,name = sym_name_of tl in hd::path,name in
+          let lpid = sym_name_of (String.split_on_char '.' lpid) in
+          let start_line = int_of_string start_line in
+          let end_line = int_of_string end_line in
+          sidx :=
+           Sym_nameMap.add lpid (sourceid,fname,start_line,end_line) !sidx
+      | _ ->
+         raise
+          (Common.Error.Fatal
+            (None,"wrong file format for source map file", ""))
+   done ;
+  with
+   | Failure _ as exn ->
       close_in ch;
       raise
-        (Common.Error.Fatal
-           ( None,
-             "wrong file format for source map file: "
-             ^ Printexc.to_string exn,
-             "" ))
-    | End_of_file -> close_in ch);
-    db := lazy (!sidx, idx)
+       (Common.Error.Fatal(None,"wrong file format for source map file: " ^
+         Printexc.to_string exn, ""))
+   | End_of_file -> close_in ch) ;
+  db := lazy (!sidx,idx)
 
-  type ho_pp = { run : 'a. 'a Lplib.Base.pp -> 'a Lplib.Base.pp }
 
-  let identity_escaper : ho_pp = { run = (fun x -> x) }
+ type ho_pp = { run : 'a. 'a Lplib.Base.pp -> 'a Lplib.Base.pp }
 
-  let html_escaper : ho_pp =
-    {
-      run =
-        (fun pp fmt x ->
-          let res = Dream.html_escape (Format.asprintf "%a" pp x) in
-          Format.pp_print_string fmt res);
-    }
+ let identity_escaper : ho_pp =
+  { run = fun x -> x }
 
-  let source_infos_of_sym_name sym_name =
-    match Sym_nameMap.find_opt sym_name (fst (Lazy.force !db)) with
-    | None -> (None, None)
-    | Some (sourceid, fname, start_line, end_line) ->
+ let html_escaper : ho_pp =
+  { run  = fun pp fmt x ->
+     let res = Dream.html_escape (Format.asprintf "%a" pp x) in
+     Format.pp_print_string fmt res
+  }
+
+ let source_infos_of_sym_name sym_name =
+  match Sym_nameMap.find_opt sym_name (fst (Lazy.force !db)) with
+   | None -> None, None
+   | Some (sourceid, fname, start_line, end_line) ->
       let start_col = 0 in
-      let end_col = -1 in
-      (* to the end of line *)
+      let end_col = -1 in (* to the end of line *)
       (* FIX ME *)
-      let start_offset, end_offset = (0, 0) in
-      ( Some sourceid,
-        Some
-          {
-            fname = Some fname;
-            start_line;
-            start_col;
-            end_line;
-            end_col;
-            start_offset;
-            end_offset;
-          } )
+      let start_offset, end_offset = 0, 0 in
+      Some sourceid,
+       Some { fname=Some fname; start_line; start_col; end_line;
+              end_col; start_offset; end_offset }
 
-  let generic_pp_of_position_list ~escaper ~sep =
-    Lplib.List.pp
-      (fun ppf position ->
-        Print.no_qualif (fun () ->
-            match position with
-            | _, _, Name -> Lplib.Base.out ppf "Name"
-            | generalize, term, Type where ->
-              Lplib.Base.out ppf "%a occurs %s%a the type"
-                (escaper.run Print.term) term
-                (if generalize then "generalized " else "")
-                pp_where where
-            | generalize, term, Xhs (relation, side) ->
-              Lplib.Base.out ppf "%a occurs %s %a %a" (escaper.run Print.term)
-                term
-                (if generalize then "generalized" else "")
-                pp_relation relation pp_side side))
-      sep
+ let generic_pp_of_position_list ~escaper ~sep =
+  Lplib.List.pp
+   (fun ppf position ->
+     Print.no_qualif (fun () ->
+     match position with
+      | _,_,Name ->
+         Lplib.Base.out ppf "Name"
+      | generalize,term,Type where ->
+         Lplib.Base.out ppf "%a occurs %s%a the type"
+          (escaper.run Print.term) term
+          (if generalize then "generalized " else "")
+          pp_where where
+      | generalize,term,Xhs (relation,side) ->
+         Lplib.Base.out ppf "%a occurs %s %a %a"
+          (escaper.run Print.term) term
+          (if generalize then "generalized" else "")
+          pp_relation relation pp_side side))
+   sep
 
-  (* given a filename/URI it returns the stream of lines
+ (* given a filename/URI it returns the stream of lines
     and a function to close the resources *)
-  let parse_file fname =
-    if String.starts_with ~prefix:"file:///" fname then (
-      assert (fst Stdlib.(!lsp_input) = fname);
-      let text = snd Stdlib.(!lsp_input) in
-      let lines = ref (String.split_on_char '\n' text) in
-      ( (fun () ->
-          match !lines with
-          | [] -> raise End_of_file
-          | he :: tl ->
-            lines := tl;
-            he),
-        fun () -> () ))
-    else
-      let ch = open_in fname in
-      ((fun () -> input_line ch), fun () -> close_in ch)
+ let parse_file fname =
+  if String.starts_with ~prefix:"file:///" fname then
+   (assert (fst Stdlib.(!lsp_input) = fname) ;
+   let text = snd Stdlib.(!lsp_input) in
+   let lines = ref (String.split_on_char '\n' text) in
+   (fun () ->
+     match !lines with
+      | [] -> raise End_of_file
+      | he::tl -> lines := tl ; he),
+   (fun () -> ()))
+  else
+   let ch = open_in fname in
+   (fun () -> input_line ch), (fun () -> close_in ch)
 
-  let generic_pp_of_item_list ~escape ~escaper ~separator ~sep ~delimiters
-      ~lis:(lisb, lise) ~pres:(preb, pree) ~bold:(boldb, bolde)
-      ~code:(codeb, codee) ?(colorizer = Lplib.Extra.default) fmt l =
-    if l = [] then Lplib.Base.out fmt "Nothing found"
-    else
-      Lplib.List.pp
-        (fun ppf ((((p, n) as sym_name), pos), (positions : answer)) ->
-          let sourceid, sourcepos = source_infos_of_sym_name sym_name in
-          (* let n_pp = (Lplib.Color.red "%s") n in *)
-          Lplib.Base.out ppf
-            ("%s%a.%s" ^^ colorizer "%s"
-           ^^ "%s@%s%s%a%s%s%s%a%s%s%a%s%s%a%s%s%s%s@.")
-            lisb
-            (escaper.run Core.Print.path)
-            p boldb n bolde
-            (popt_to_string ~print_dirname:false pos)
-            separator
-            (generic_pp_of_position_list ~escaper ~sep)
-            positions separator preb codeb
-            (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
-               ~complain_if_location_unknown:true)
-            pos separator
-            codee
-            (fun ppf opt ->
-              match opt with
-              | None -> Lplib.Base.string ppf ""
-              | Some sourceid ->
-                Lplib.Base.string ppf ("Translated to " ^ sourceid)) sourceid
-            codeb
-            separator
-            (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
-               ~complain_if_location_unknown:false)
-            sourcepos codee pree lise separator)
-        "" fmt l
+ let generic_pp_of_item_list ~escape ~escaper ~separator ~sep ~delimiters
+  ~lis:(lisb,lise) ~pres:(preb,pree)
+  ~bold:(boldb,bolde) ~code:(codeb,codee) ?(colorizer=Lplib.Extra.default)
+  fmt l =
+  if l = [] then
+   Lplib.Base.out fmt "Nothing found"
+  else
+    Lplib.List.pp (fun ppf (((p,n) as sym_name,pos),(positions : answer)) ->
+      let sourceid,sourcepos = source_infos_of_sym_name sym_name in
+      (* let n_pp = (Lplib.Color.red "%s") n in *)
+      Lplib.Base.out ppf
+      ("%s%a.%s"
+      ^^
+      (colorizer "%s")
+      ^^ "%s@%s%s%a%s%s%s%a%s%s%a%s%s%a%s%s%s%s@.")
+      lisb (escaper.run Core.Print.path) p boldb n bolde
+      (popt_to_string ~print_dirname:false pos)
+      separator (generic_pp_of_position_list ~escaper ~sep) positions
+      separator preb codeb
+      (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
+      ~complain_if_location_unknown:true) pos
+      separator
+      codee
+      (fun ppf opt ->
+        match opt with
+        | None -> Lplib.Base.string ppf ""
+        | Some sourceid ->
+          Lplib.Base.string ppf ("Translated to " ^ sourceid)) sourceid
+      codeb
+          separator
+          (Common.Pos.print_file_contents ~parse_file ~escape ~delimiters
+          ~complain_if_location_unknown:false) sourcepos
+          codee pree lise separator)
+    "" fmt l
 
-  let html_of_item_list =
-    generic_pp_of_item_list ~escape:Dream.html_escape ~escaper:html_escaper
-      ~separator:"<br>\n" ~sep:" and<br>\n" ~delimiters:("<p>", "</p>")
-      ~lis:("<li>", "</li>") ~pres:("<pre>", "</pre>") ~bold:("<b>", "</b>")
-      ~code:("<code>", "</code>") ~colorizer:Lplib.Extra.default
+ let html_of_item_list =
+  generic_pp_of_item_list ~escape:Dream.html_escape ~escaper:html_escaper
+   ~separator:"<br>\n" ~sep:" and<br>\n" ~delimiters:("<p>","</p>")
+   ~lis:("<li>","</li>") ~pres:("<pre>","</pre>") ~bold:("<b>","</b>")
+   ~code:("<code>","</code>") ~colorizer: Lplib.Extra.default
 
-  let pp_item_list fmt l =
-    generic_pp_of_item_list
-      ~escape:(fun x -> x)
-      ~escaper:identity_escaper ~separator:"\n" ~sep:" and\n"
-      ~delimiters:("", "") ~lis:("* ", "") ~pres:("", "") ~bold:("", "")
-      ~code:("", "")
-      ~colorizer:
-        (if Stdlib.(!Common.Console.lsp_mod) || Unix.isatty Unix.stdout then
-           Lplib.Color.red
-         else Lplib.Extra.default)
-      fmt l
+ let pp_item_list fmt l =
+  generic_pp_of_item_list ~escape:(fun x -> x) ~escaper:identity_escaper
+   ~separator:"\n" ~sep:" and\n" ~delimiters:("","")
+   ~lis:("* ","") ~pres:("","")
+   ~bold:("","")
+    ~code:("","")
+    ~colorizer:
+      (if Stdlib.(!Common.Console.lsp_mod) || Unix.isatty Unix.stdout then
+        Lplib.Color.red
+      else
+        Lplib.Extra.default)
+    fmt l
 
-  let pp_results_list fmt l = pp_item_list fmt l
+ let pp_results_list fmt l = pp_item_list fmt l
 
-  let html_of_results_list from fmt l =
-    Lplib.Base.out fmt "<ol start=\"%d\">%a</ol>" from html_of_item_list l
+ let html_of_results_list from fmt l =
+  Lplib.Base.out fmt "<ol start=\"%d\">%a</ol>" from html_of_item_list l
+
 end
 
 exception Overloaded of string * DB.answer DB.ItemSet.t
@@ -514,287 +529,275 @@ exception Overloaded of string * DB.answer DB.ItemSet.t
 let normalize_fun = ref (fun _ -> assert false)
 
 let mk_bogus_sym mp name pos =
-  Core.Term.create_sym mp Core.Term.Public Core.Term.Defin Core.Term.Sequen
-    false (Common.Pos.make pos name) None Core.Term.mk_Type []
+ Core.Term.create_sym mp Core.Term.Public Core.Term.Defin Core.Term.Sequen
+  false (Common.Pos.make pos name) None Core.Term.mk_Type []
 
 let elim_duplicates_up_to_normalization res =
-  let resl = DB.ItemSet.bindings res in
-  let norm =
-    List.map
-      (fun ((((mp, name), sympos), l) as inp) ->
-        let s = mk_bogus_sym mp name sympos in
-        match !normalize_fun (Core.Term.mk_Symb s) with
-        | Symb { sym_path; sym_name; _ } ->
-          (((sym_path, sym_name), sympos), l)
-        | _ -> inp)
-      resl
-  in
-  let res = List.sort (fun ((x, _), _) ((y, _), _) -> compare x y) norm in
-  let res =
-    let rec uniq = function
-      | ([] | [ _ ]) as l -> l
-      | ((x, _), _) :: (((y, _), _) :: _ as l) when x = y -> uniq l
-      | i :: l -> i :: uniq l
-    in
-    uniq res
-  in
-  DB.ItemSet.of_list res
+ let resl = DB.ItemSet.bindings res in
+ let norm =
+  List.map
+   (fun ((((mp,name),sympos),l) as inp) ->
+     let s = mk_bogus_sym mp name sympos in
+     match !normalize_fun (Core.Term.mk_Symb s) with
+     | Symb {sym_path ; sym_name ; _} ->
+        (((sym_path,sym_name),sympos), l)
+     | _ -> inp) resl in
+ let res = List.sort (fun ((x,_),_) ((y,_),_) -> compare x y) norm in
+ let res =
+  let rec uniq =
+   function
+    | [] | [_] as l -> l
+    | ((x,_),_)::(((y,_),_)::_ as l) when x=y -> uniq l
+    | i::l -> i::uniq l in
+   uniq res in
+ DB.ItemSet.of_list res
 
-let find_sym ~prt ~prv sig_state ({ elt = mp, name; pos } as s) =
-  try Core.Sig_state.find_sym ~prt ~prv sig_state s
-  with Common.Error.Fatal _ ->
-    let pos, mp, name =
-      match mp with
-      | [] -> (
-        let res_orig = DB.locate_name name in
-        let res = elim_duplicates_up_to_normalization res_orig in
-        if DB.ItemSet.cardinal res > 1 then
-          raise (Overloaded (name, res_orig));
-        match DB.ItemSet.choose_opt res with
-        | None -> Common.Error.fatal pos "Unknown symbol %s." name
-        | Some (((mp, name), sympos), [ (_, _, DB.Name) ]) ->
-          (sympos, mp, name)
-        | Some _ -> assert false
-        (* locate only returns DB.Name*))
-      | _ :: _ -> (None, mp, name)
-    in
+let find_sym ~prt ~prv sig_state ({elt=(mp,name); pos} as s) =
+ try
+  Core.Sig_state.find_sym ~prt ~prv sig_state s
+ with
+  Common.Error.Fatal _ ->
+   let pos,mp,name =
+    match mp with
+      [] ->
+       let res_orig = DB.locate_name name in
+       let res = elim_duplicates_up_to_normalization res_orig in
+       if DB.ItemSet.cardinal res > 1 then
+         raise (Overloaded (name,res_orig)) ;
+       (match DB.ItemSet.choose_opt res with
+         | None -> Common.Error.fatal pos "Unknown symbol %s." name
+         | Some (((mp,name),sympos),[_,_,DB.Name]) -> sympos,mp,name
+         | Some _ -> assert false) (* locate only returns DB.Name*)
+    | _::_ -> None,mp,name
+   in
     mk_bogus_sym mp name pos
 
-module QNameMap = Map.Make (struct
-  type t = sym_name
-
-  let compare = Stdlib.compare
-end)
+module QNameMap =
+ Map.Make(struct type t = sym_name let compare = Stdlib.compare end)
 
 let no_implicits_in_term t =
-  let res = ref true in
-  Core.LibTerm.iter
-    (function
-      | Plac _ -> res := false | Wild | TRef _ -> assert false | _ -> ())
-    t;
-  !res
+ let res = ref true in
+ Core.LibTerm.iter
+  (function
+    | Plac _ -> res := false
+    | Wild | TRef _ -> assert false
+    | _ -> ()) t ;
+ !res
 
-let check_rule : Parsing.Syntax.p_rule -> sym_rule =
- fun pr ->
-  let ss = Core.Sig_state.dummy in
-  let ((_, r) as sr) = Parsing.Scope.scope_rule ~find_sym false ss pr in
-  if no_implicits_in_term r.rhs then sr
-  else
-    Common.Error.fatal pr.pos
-      "The rule has implicit terms in the right-hand-side: %a"
-      (Parsing.Pretty.rule "") pr
+let check_rule : Parsing.Syntax.p_rule -> sym_rule = fun pr ->
+ let ss = Core.Sig_state.dummy in
+ let (_,r) as sr = Parsing.Scope.scope_rule ~find_sym false ss pr in
+ if no_implicits_in_term r.rhs then sr
+ else
+  Common.Error.fatal pr.pos
+   "The rule has implicit terms in the right-hand-side: %a"
+   (Parsing.Pretty.rule "") pr
 
 let load_meta_rules () =
-  let rules = ref [] in
-  List.iter
-    (fun rwpath ->
-      let cmdstream = Parsing.Parser.Lp.parse_file rwpath in
-      Stream.iter
-        (fun { elt; _ } ->
-          match elt with
-          | Parsing.Syntax.P_rules r -> rules := List.rev_append r !rules
-          | _ -> ())
-        cmdstream)
-    Stdlib.(!DB.rwpaths);
-  let rules = List.rev !rules in
-  let handle_rule map r =
-    let s, r = check_rule r in
-    let h = function Some rs -> Some (r :: rs) | None -> Some [ r ] in
-    SymMap.update s h map
-  in
-  let map = List.fold_left handle_rule SymMap.empty rules in
-  SymMap.iter Tree.update_dtree map;
-  SymMap.fold
-    (fun sym _rs map' ->
-      QNameMap.add (name_of_sym sym) Timed.(!(sym.sym_dtree)) map')
-    map QNameMap.empty
+ let rules = ref [] in
+ List.iter (fun rwpath ->
+  let cmdstream = Parsing.Parser.Lp.parse_file rwpath in
+  Stream.iter
+   (fun {elt ; _ } ->
+     match elt with
+       Parsing.Syntax.P_rules r -> rules := List.rev_append r !rules
+     | _ -> ())
+   cmdstream) Stdlib.(!DB.rwpaths) ;
+ let rules = List.rev !rules in
+ let handle_rule map r =
+   let (s,r) = check_rule r in
+   let h = function Some rs -> Some(r::rs) | None -> Some[r] in
+   SymMap.update s h map in
+ let map = List.fold_left handle_rule SymMap.empty rules in
+ SymMap.iter Tree.update_dtree map;
+ SymMap.fold
+  (fun sym _rs map' ->
+    QNameMap.add (name_of_sym sym) (Timed.(!(sym.sym_dtree))) map')
+  map QNameMap.empty
 
 let meta_rules = lazy (load_meta_rules ())
+
 let force_meta_rules_loading () = ignore (Lazy.force meta_rules)
 
 let normalize typ =
-  let dtree sym =
-    try QNameMap.find (name_of_sym sym) (Lazy.force meta_rules)
-    with Not_found -> Core.Tree_type.empty_dtree
-  in
-  Core.Eval.snf ~dtree ~tags:[ `NoExpand ] [] typ
+ let dtree sym =
+  try QNameMap.find (name_of_sym sym) (Lazy.force meta_rules)
+  with Not_found -> Core.Tree_type.empty_dtree in
+ Core.Eval.snf ~dtree ~tags:[`NoExpand] [] typ
 
 let _ = normalize_fun := normalize
 
 let search_pterm ~generalize ~mok ss env pterm =
-  let env = ("V#", (new_var "V#", Term.mk_Type, None)) :: env in
-  Dream.log "QUERY before scoping: %a@." Parsing.Pretty.term pterm;
-  let query =
-    Parsing.Scope.scope_search_pattern ~find_sym ~mok ss env pterm in
-  Dream.log "QUERY before normalize: %a" Core.Print.term query;
-  let query = normalize query in
-  Dream.log "QUERY to be executed: %a" Core.Print.term query;
-  DB.search ~generalize query
+ let env =
+  ("V#",(new_var "V#",Term.mk_Type,None))::env in
+ Dream.log "QUERY before scoping: %a@." Parsing.Pretty.term pterm ;
+ let query =
+  Parsing.Scope.scope_search_pattern ~find_sym ~mok ss env pterm in
+ Dream.log "QUERY before normalize: %a" Core.Print.term query ;
+ let query = normalize query in
+ Dream.log "QUERY to be executed: %a" Core.Print.term query ;
+ DB.search ~generalize query
 
 let rec is_flexible t =
-  match Core.Term.unfold t with
+ match Core.Term.unfold t with
   | Patt _ -> true
-  | Appl (t, _) -> is_flexible t
-  | LLet (_, _, b) ->
-    let _, t = unbind b in
-    is_flexible t
+  | Appl(t,_) -> is_flexible t
+  | LLet(_,_,b) -> let _, t = unbind b in is_flexible t
   | Vari _ | Type | Kind | Symb _ | Prod _ | Abst _ -> false
   | Plac _ ->
-    (* this may happen in a rewriting rule that uses a _ in the r.h.s.
+     (* this may happen in a rewriting rule that uses a _ in the r.h.s.
         that is NOT instantiated; the rule is meant to open a proof
         obligation
 
        Tentative implementation: a placeholder is seen as a variable *)
-    false
+     false
   | Meta _ | Wild | TRef _ | Bvar _ -> assert false
 
 let enter =
-  DB.(
-    function
-    | Hypothesis _ -> Hypothesis Inside
-    | Spine _ | Conclusion _ -> Conclusion Inside)
+ DB.(function
+  | Hypothesis _ -> Hypothesis Inside
+  | Spine _
+  | Conclusion _ -> Conclusion Inside)
 
 let enter_pi_source =
-  DB.(
-    function
-    | Spine _ -> Hypothesis Exact
-    | Hypothesis _ -> Hypothesis Inside
-    | Conclusion _ -> Conclusion Inside)
+ DB.(function
+  | Spine _ -> Hypothesis Exact
+  | Hypothesis _ -> Hypothesis Inside
+  | Conclusion _ -> Conclusion Inside)
 
 let enter_pi_target ~is_prod =
-  DB.(
-    function
-    | Spine _ when is_prod -> Spine Inside
-    | Spine _ -> Conclusion Exact
-    | Hypothesis _ -> Hypothesis Inside
-    | Conclusion _ -> Conclusion Inside)
+ DB.(function
+  | Spine _ when is_prod -> Spine Inside
+  | Spine _ -> Conclusion Exact
+  | Hypothesis _ -> Hypothesis Inside
+  | Conclusion _ -> Conclusion Inside)
 
 let subterms_to_index ~is_spine t =
-  let rec aux ~where t =
-    let t = Core.Term.unfold t in
-    [ (where, t) ]
-    @
-    match t with
-    | Bvar _ | Vari _ | Type | Kind | Plac _ | Symb _ -> []
-    | Abst (t, b) ->
-      let _, t2 = unbind b in
-      aux ~where:(enter where) t @ aux ~where:(enter where) t2
-    | Prod (t, b) -> (
-      match where with
-      | Spine _ ->
-        let t2 = subst b (Core.Term.mk_Patt (None, "dummy", [||])) in
-        aux ~where:(enter_pi_source where) t @ aux
-        ~where:(enter_pi_target ~is_prod:(Core.Term.is_prod t2) where) t2
-      | _ ->
-        let _, t2 = unbind b in
-        aux ~where:(enter_pi_source where) t
-        @ aux ~where:(enter_pi_target ~is_prod:false where) t2)
-    | Appl (t1, t2) ->
-        aux ~where:(enter where) t1 @ aux ~where:(enter where) t2
-    | Patt (_var, _varname, args) ->
-      List.concat (List.map (aux ~where:(enter where)) (Array.to_list args))
-    | LLet (t1, t2, b) ->
-      (* we do not expand the let-in when indexing subterms *)
-      let _, t3 = unbind b in
-      aux ~where:(enter where) t1
-      @ aux ~where:(enter where) t2
-      @ aux ~where:(enter where) t3
-    | Meta _ | Wild | TRef _ -> assert false
-  in
-  aux ~where:(if is_spine then Spine Exact else Conclusion Exact) t
+ let rec aux ~where t =
+  let t = Core.Term.unfold t in
+  [where,t] @
+  match t with
+  | Bvar _
+  | Vari _
+  | Type
+  | Kind
+  | Plac _
+  | Symb _ -> []
+  | Abst(t,b) ->
+     let _, t2 = unbind b in
+     aux ~where:(enter where) t @ aux ~where:(enter where) t2
+  | Prod(t,b) ->
+     (match where with
+       | Spine _ ->
+          let t2 = subst b (Core.Term.mk_Patt (None,"dummy",[||])) in
+          aux ~where:(enter_pi_source where) t @
+           aux ~where:(enter_pi_target ~is_prod:(Core.Term.is_prod t2) where)
+            t2
+       | _ ->
+         let _, t2 = unbind b in
+         aux ~where:(enter_pi_source where) t @
+          aux ~where:(enter_pi_target ~is_prod:false where) t2)
+  | Appl(t1,t2) ->
+     aux ~where:(enter where) t1 @ aux ~where:(enter where) t2
+  | Patt (_var,_varname,args) ->
+     List.concat (List.map (aux ~where:(enter where)) (Array.to_list args))
+  | LLet (t1,t2,b) ->
+     (* we do not expand the let-in when indexing subterms *)
+     let _, t3 = unbind b in
+     aux ~where:(enter where) t1 @ aux ~where:(enter where) t2 @
+      aux ~where:(enter where) t3
+  | Meta _ | Wild | TRef _ -> assert false
+ in aux ~where:(if is_spine then Spine Exact else Conclusion Exact) t
 
 let insert_rigid t v =
-  if not (is_flexible t) then begin DB.insert t v
-    (* assert (List.mem v (DB.search t)); *)
-  end
+ if not (is_flexible t) then begin
+  DB.insert t v
+  (* assert (List.mem v (DB.search t)); *)
+ end
 
 let index_term_and_subterms ~is_spine t item =
-  let tn = normalize t in
-  (*
+ let tn = normalize t in
+ (*
  let pp_item ppf (((p,n),_ ), _) =
    Lplib.Base.out ppf "%a.%s" Core.Print.path p n in
  Format.printf "%a :(%a) REWRITTEN TO (%a)@."
   pp_item (item (DB.Conclusion DB.Exact))
   Core.Print.term t Core.Print.term tn ;
  *)
-  let cmp (where1, t1) (where2, t2) =
-    let res = compare where1 where2 in
-    if res = 0 then Core.Term.cmp t1 t2 else res
-  in
-  let subterms = List.sort_uniq cmp (subterms_to_index ~is_spine tn) in
-  List.iter (fun (where, s) -> insert_rigid s (item where)) subterms
+ let cmp (where1,t1) (where2,t2) =
+  let res = compare where1 where2 in
+  if res = 0 then Core.Term.cmp t1 t2 else res in
+ let subterms =
+  List.sort_uniq cmp (subterms_to_index ~is_spine tn) in
+ List.iter (fun (where,s) -> insert_rigid s (item where)) subterms
 
-let index_rule sym ({ Core.Term.lhs = lhsargs; rule_pos; _ } as rule) =
-  let rule_pos =
-    match rule_pos with
-    | None ->
-      assert false
-      (* this probably may happen, but it is BAD!
+let index_rule sym ({Core.Term.lhs=lhsargs ; rule_pos ; _} as rule) =
+ let rule_pos =
+   match rule_pos with
+    | None -> assert false (* this probably may happen, but it is BAD!
                               I leave the assert false to detect when it
                               happens and let the team decide what to do *)
-    | Some pos -> pos
-  in
-  let lhs = Core.Term.add_args (Core.Term.mk_Symb sym) lhsargs in
-  let rhs = rule.rhs in
-  let get_relation = function DB.Conclusion r -> r | _ -> assert false in
-  let filename = Option.get rule_pos.fname in
-  let filename =
-    if String.starts_with ~prefix:"file:///" filename then
-      let n = String.length "file://" in
-      String.sub filename n (String.length filename - n)
-    else filename
-  in
-  let path = Library.path_of_file Parsing.LpLexer.escape filename in
-  let rule_name = (path, Common.Pos.to_string ~print_fname:false rule_pos) in
-  index_term_and_subterms ~is_spine:false lhs (fun where ->
-      ((rule_name, Some rule_pos), [ Xhs (get_relation where, Lhs) ]));
-  index_term_and_subterms ~is_spine:false rhs (fun where ->
-      ((rule_name, Some rule_pos), [ Xhs (get_relation where, Rhs) ]))
+    | Some pos -> pos in
+ let lhs = Core.Term.add_args (Core.Term.mk_Symb sym) lhsargs in
+ let rhs = rule.rhs in
+ let get_relation = function | DB.Conclusion r -> r | _ -> assert false in
+ let filename = Option.get rule_pos.fname in
+ let filename =
+   if String.starts_with ~prefix:"file:///" filename then
+    let n = String.length "file://" in
+    String.sub filename n (String.length filename - n)
+   else
+    filename in
+ let path = Library.path_of_file Parsing.LpLexer.escape filename in
+ let rule_name = (path,Common.Pos.to_string ~print_fname:false rule_pos) in
+ index_term_and_subterms ~is_spine:false lhs
+  (fun where -> ((rule_name,Some rule_pos),[Xhs(get_relation where,Lhs)])) ;
+ index_term_and_subterms ~is_spine:false rhs
+  (fun where -> ((rule_name,Some rule_pos),[Xhs(get_relation where,Rhs)]))
 
 let _ =
-  Stdlib.(
-    Core.Sign.add_rules_callback :=
-      fun sym rules -> List.iter (index_rule sym) rules)
+ Stdlib.(Core.Sign.add_rules_callback :=
+   fun sym rules -> List.iter (index_rule sym) rules)
 
 let index_sym sym =
-  let qname = name_of_sym sym in
-  (* Name *)
-  if
-    List.exists
-      (fun ((sn, _), _) -> sn = qname)
-      (DB.ItemSet.bindings (DB.locate_name (snd qname)))
+ let qname = name_of_sym sym in
+ (* Name *)
+ if List.exists (fun ((sn,_),_) -> sn=qname)
+     (DB.ItemSet.bindings (DB.locate_name (snd qname)))
   then
-    raise
-      (Common.Error.Fatal
-         (None, string_of_sym_name qname ^ " already indexed", ""));
-  DB.insert_name (snd qname) ((qname, sym.sym_decl_pos), [ Name ]);
-  (* Type + InType *)
-  let typ = Timed.(!(sym.Core.Term.sym_type)) in
-  index_term_and_subterms ~is_spine:true typ (fun where ->
-      ((qname, sym.sym_decl_pos), [ Type where ]));
-  (* InBody??? sym.sym_def : term option ref
+   raise
+    (Common.Error.Fatal
+      (None,string_of_sym_name qname ^ " already indexed", ""));
+ DB.insert_name (snd qname) ((qname,sym.sym_decl_pos),[Name]) ;
+ (* Type + InType *)
+ let typ = Timed.(!(sym.Core.Term.sym_type)) in
+ index_term_and_subterms ~is_spine:true typ
+  (fun where -> ((qname,sym.sym_decl_pos),[Type where])) ;
+ (* InBody??? sym.sym_def : term option ref
     but all the subterms are too much; collect only the constants? *)
-  (* Rules *)
-  List.iter (index_rule sym) Timed.(!(sym.Core.Term.sym_rules))
+ (* Rules *)
+ List.iter (index_rule sym) Timed.(!(sym.Core.Term.sym_rules))
 
 let _ = Stdlib.(Core.Sign.add_symbol_callback := index_sym)
-let load_rewriting_rules rwrules = Stdlib.(DB.rwpaths := rwrules)
+
+let load_rewriting_rules rwrules =
+ Stdlib.(DB.rwpaths := rwrules)
 
 let index_sign sign =
-  (*Console.set_flag "print_domains" true ;
+ (*Console.set_flag "print_domains" true ;
  Console.set_flag "print_implicits" true ;
  Common.Logger.set_debug true "e" ;*)
-  let syms = Timed.(!(sign.Core.Sign.sign_symbols)) in
-  let deps = Timed.(!(sign.Core.Sign.sign_deps)) in
-  Lplib.Extra.StrMap.iter (fun _ sym -> index_sym sym) syms;
-  Common.Path.Map.iter
-    (fun path d ->
-      Lplib.Extra.StrMap.iter
-        (fun name sd ->
-          let sym = Core.Sign.find_qualified path name in
-          List.iter (index_rule sym) sd.Sign.rules)
-        d.Sign.dep_symbols)
-    deps
+ let syms = Timed.(!(sign.Core.Sign.sign_symbols)) in
+ let deps = Timed.(!(sign.Core.Sign.sign_deps)) in
+ Lplib.Extra.StrMap.iter (fun _ sym -> index_sym sym) syms ;
+ Common.Path.Map.iter
+  (fun path d ->
+    Lplib.Extra.StrMap.iter
+     (fun name sd ->
+       let sym = Core.Sign.find_qualified path name in
+       List.iter (index_rule sym) sd.Sign.rules)
+     d.Sign.dep_symbols)
+  deps
 
 let deindex_path path = DB.remove path
 
@@ -802,129 +805,130 @@ let deindex_path path = DB.remove path
 include DB
 
 module QueryLanguage = struct
-  open Parsing.Syntax
 
-  let match_opt p x = match (p, x) with None, _ -> true | Some x', x -> x = x'
+ open Parsing.Syntax
 
-  let match_where p x =
-    match p with
-    | None -> true
-    | Some p -> (
-      match (p, x) with
+ let match_opt p x =
+  match p,x with
+  | None, _ -> true
+  | Some x', x -> x=x'
+
+ let match_where p x =
+  match p with
+  | None -> true
+  | Some p ->
+     match p,x with
       | Spine insp, Spine ins
       | Conclusion insp, Conclusion ins
-      | Hypothesis insp, Hypothesis ins ->
-        match_opt insp ins
-      | _, _ -> false)
+      | Hypothesis insp, Hypothesis ins -> match_opt insp ins
+      | _, _ -> false
 
-  let filter_constr constr _ positions =
-    Option.map
-      (fun x -> [ x ])
-      (match constr with
-      | QType wherep ->
-        List.find_opt
-          (function _, _, Type where -> match_where wherep where | _ -> false)
-          positions
-      | QXhs (insp, sidep) ->
-        List.find_opt
-          (function
-            | _, _, Xhs (ins, side) ->
-              match_opt insp ins && match_opt sidep side
-            | _ -> false)
-          positions)
+ let filter_constr constr _ positions =
+  Option.map (fun x -> [x])
+   (match constr with
+    | QType wherep ->
+       List.find_opt
+        (function
+          | _,_,Type where -> match_where wherep where
+          | _ -> false) positions
+    | QXhs (insp,sidep) ->
+       List.find_opt
+        (function
+          | _,_,Xhs (ins,side) -> match_opt insp ins && match_opt sidep side
+          | _ -> false) positions)
 
-  let answer_base_query ~mok ss env = function
-    | QName s -> locate_name s
-    | QSearch (patt, generalize, constr) -> (
+ let answer_base_query ~mok ss env =
+  function
+   | QName s -> locate_name s
+   | QSearch (patt,generalize,constr) ->
       let res = search_pterm ~generalize ~mok ss env patt in
-      match constr with
-      | None -> res
-      | Some constr -> ItemSet.filter_map (filter_constr constr) res)
+      (match constr with
+        | None -> res
+        | Some constr -> ItemSet.filter_map (filter_constr constr) res)
 
-  let perform_op = function
-    | Intersect ->
-      ItemSet.merge (fun _ positions1 positions2 ->
-          match (positions1, positions2) with
-          | Some l1, Some l2 -> Some (l1 @ l2)
-          | _, _ -> None)
-    | Union ->
-      ItemSet.union (fun _ positions1 positions2 ->
-          Some (positions1 @ positions2))
+ let perform_op =
+  function
+   | Intersect ->
+       ItemSet.merge
+        (fun _ positions1 positions2 ->
+          match positions1, positions2 with
+           | Some l1, Some l2 -> Some (l1@l2)
+           | _,_ -> None)
+   | Union ->
+       ItemSet.union
+        (fun _ positions1 positions2 -> Some (positions1 @ positions2))
 
-  let filter set f =
-    let g (((p', _) as name), _) _ =
-      match f with
-      | Path p -> is_path_prefix p p'
-      | RegExp s ->
-        let re = Str.regexp s in
-        re_matches_sym_name re name
-    in
-    ItemSet.filter g set
+ let filter set f =
+  let g ((p',_ as name),_) _ =
+   match f with
+    | Path p -> is_path_prefix p p'
+    | RegExp s -> let re = Str.regexp s in re_matches_sym_name re name in
+  ItemSet.filter g set
 
-  let answer_query ~mok ss env =
-    let rec aux = function
-      | QBase bq -> answer_base_query ~mok ss env bq
-      | QOp (q1, op, q2) -> perform_op op (aux q1) (aux q2)
-      | QFilter (q, f) -> filter (aux q) f
-    in
-    aux
+ let answer_query ~mok ss env =
+  let rec aux =
+   function
+    | QBase bq -> answer_base_query ~mok ss env bq
+    | QOp (q1,op,q2) -> perform_op op (aux q1) (aux q2)
+    | QFilter (q,f) -> filter (aux q) f
+  in
+   aux
+
 end
 
 (* let's flatten the interface *)
 include QueryLanguage
 
 module UserLevelQueries = struct
-  let search_cmd_gen ss ~from ~how_many
-      ~(fail : Pos.popt option -> ?err_desc:string -> string -> string)
-      ~pp_results ~tag:(hb, he) fmt q =
-    try
-      let mok _ = None in
-      (* Let's do the parsing here to capture the exceptions here *)
-      let q = Lazy.force q in
-      let items = ItemSet.bindings (answer_query ~mok ss [] q) in
-      let resultsno = List.length items in
-      let _, items = Lplib.List.cut items from in
-      let items, _ = Lplib.List.cut items how_many in
-      Lplib.Base.out fmt "%sNumber of results: %d%s@.%a@." hb resultsno he
-        pp_results items
-    with
-    | Stream.Failure ->
+
+ let search_cmd_gen ss ~from ~how_many
+  ~(fail:Pos.popt option -> ?err_desc:string -> string -> string)
+  ~pp_results ~tag:(hb,he) fmt q =
+  try
+   let mok _ = None in
+  (* Let's do the parsing here to capture the exceptions here *)
+   let q = Lazy.force q in
+   let items = ItemSet.bindings (answer_query ~mok ss [] q) in
+   let resultsno = List.length items in
+   let _,items = Lplib.List.cut items from in
+   let items,_ = Lplib.List.cut items how_many in
+   Lplib.Base.out fmt "%sNumber of results: %d%s@.%a@."
+    hb resultsno he pp_results items
+  with
+   | Stream.Failure ->
       Lplib.Base.out fmt "%s"
-        (fail None (Format.asprintf "Syntax error: a query was expected@."))
-    | Common.Error.Fatal (pos, msg, _) ->
+       (fail None (Format.asprintf "Syntax error: a query was expected@."))
+   | Common.Error.Fatal (pos, msg, _) ->
       Lplib.Base.out fmt "%s" (fail pos (Format.asprintf "Error: %s@." msg))
-    | Overloaded (name, res) ->
+   | Overloaded(name,res) ->
+      Lplib.Base.out fmt "%s" (fail None (Format.asprintf
+       "Overloaded symbol %s. Please rewrite the query replacing %s \
+        with a fully qualified identifier among the following:@."
+        name name)
+        ~err_desc:(Format.asprintf "%a@." pp_results (ItemSet.bindings res))
+        )
+   | Stack_overflow ->
+      Lplib.Base.out fmt "%s" (fail None
+       (Format.asprintf
+         "Error: too many results. Please refine your query.@." ))
+   | exn ->
       Lplib.Base.out fmt "%s"
-        (fail None
-           (Format.asprintf
-              "Overloaded symbol %s. Please rewrite the query replacing %s \
-               with a fully qualified identifier among the following:@."
-              name name)
-           ~err_desc:(Format.asprintf "%a@." pp_results
-            (ItemSet.bindings res)))
-    | Stack_overflow ->
-      Lplib.Base.out fmt "%s"
-        (fail None
-           (Format.asprintf
-              "Error: too many results. Please refine your query.@."))
-    | exn ->
-      Lplib.Base.out fmt "%s"
-        (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
+       (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
 
   let search_cmd_txt_query ss ~dbpath fmt q =
-    Stdlib.(the_dbpath := dbpath);
-    search_cmd_gen ss ~from:0 ~how_many:999999
-      ~fail:(fun pos ?err_desc x ->
-        Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-      ~pp_results:pp_results_list ~tag:("", "") fmt (lazy q)
+  Stdlib.(the_dbpath := dbpath);
+  search_cmd_gen ss ~from:0 ~how_many:999999
+   ~fail:(fun pos ?err_desc x ->
+          Common.Error.fatal_optional_position pos ?err_desc "%s" x)
+   ~pp_results:pp_results_list ~tag:("", "") fmt (lazy q)
 
   let search_cmd_gen_string ss ~from ~how_many ~fail ~pp_results ~tag fmt s =
-   search_cmd_gen ss ~from ~how_many ~fail ~pp_results ~tag fmt
-    (* Let's do the parsing later to capture the exceptions later *)
-    (lazy (Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s))
+    search_cmd_gen ss ~from ~how_many ~fail ~pp_results ~tag fmt
+     (* Let's do the parsing later to capture the exceptions later *)
+     (lazy (Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s))
 
-  (** [transform_ascii_to_unicode s] replaces all the occurences of ["->"] and
-      ["forall"] with ["→"] and ["Π"] in the search query [s] *)
+ (** [transform_ascii_to_unicode s] replaces all the occurences of ["->"] and
+     ["forall"] with ["→"] and ["Π"] in the search query [s] *)
   let transform_ascii_to_unicode : string -> string =
     let arrow = Str.regexp_string " -> "
     and forall = Str.regexp "\\bforall\\b" in
@@ -938,19 +942,20 @@ module UserLevelQueries = struct
     assert (transform_ascii_to_unicode "forall.x, y" = "Π.x, y");
     assert (transform_ascii_to_unicode "((forall x, y" = "((Π x, y")
 
-  let search_cmd_html ss ~from ~how_many ~dbpath fmt s =
-    Stdlib.(the_dbpath := dbpath);
+ let search_cmd_html ss ~from ~how_many ~dbpath fmt s =
+  Stdlib.(the_dbpath := dbpath);
     search_cmd_gen_string ss ~from ~how_many
-      ~fail:(fun pos ?err_desc x ->
-        "<font color=\"red\">" ^ x ^ "</font>"
-        ^ (match pos with None -> "" | Some p -> popt_to_string p)
-        ^ Option.value err_desc ~default:"")
+      ~fail:(fun pos ?err_desc x -> "<font color=\"red\">" ^ x ^ "</font>"
+          ^ (match pos with None -> "" | Some p -> popt_to_string p)
+          ^ Option.value err_desc ~default:"")
       ~pp_results:(html_of_results_list from)
-      ~tag:("<h1>", "</h1") fmt s
+      ~tag:("<h1>","</h1")
+      fmt
+      s
 
-  let search_cmd_txt ss ~dbpath fmt s =
+ let search_cmd_txt ss ~dbpath (fmt:Format.formatter) s =
     let s = transform_ascii_to_unicode s in
-    Stdlib.(the_dbpath := dbpath);
+  Stdlib.(the_dbpath := dbpath);
     search_cmd_gen_string ss ~from:0 ~how_many:999999
       ~fail:(fun pos ?err_desc x ->
           Common.Error.fatal_optional_position pos ?err_desc "%s" x)

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -869,6 +869,8 @@ module UserLevelQueries = struct
       ~pp_results ~tag:(hb, he) fmt q =
     try
       let mok _ = None in
+      (* Let's do the parsing here to capture the exceptions here *)
+      let q = Lazy.force q in
       let items = ItemSet.bindings (answer_query ~mok ss [] q) in
       let resultsno = List.length items in
       let _, items = Lplib.List.cut items from in
@@ -898,16 +900,17 @@ module UserLevelQueries = struct
       Lplib.Base.out fmt "%s"
         (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
 
-  let search_cmd_txt_query ss ~dbpath q =
+  let search_cmd_txt_query ss ~dbpath fmt q =
     Stdlib.(the_dbpath := dbpath);
     search_cmd_gen ss ~from:0 ~how_many:999999
       ~fail:(fun pos ?err_desc x ->
         Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-      ~pp_results:pp_results_list ~tag:("", "") q
+      ~pp_results:pp_results_list ~tag:("", "") fmt (lazy q)
 
   let search_cmd_gen_string ss ~from ~how_many ~fail ~pp_results ~tag fmt s =
    search_cmd_gen ss ~from ~how_many ~fail ~pp_results ~tag fmt
-    (Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s)
+    (* Let's do the parsing later to capture the exceptions later *)
+    (lazy (Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s))
 
   (** [transform_ascii_to_unicode s] replaces all the occurences of ["->"] and
       ["forall"] with ["→"] and ["Π"] in the search query [s] *)

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -903,15 +903,6 @@ module UserLevelQueries = struct
       Lplib.Base.out fmt "%s"
         (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
 
-  let search_cmd_txt_string ss ~dbpath s =
-    Stdlib.(the_dbpath := dbpath);
-    Format.asprintf "%a"
-      (search_cmd_gen ss ~from:0 ~how_many:999999
-         ~fail:(fun pos ?err_desc x ->
-           Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-         ~pp_results:pp_results_list ~tag:("", "") None)
-      s
-
   let search_cmd_txt_query ss ~dbpath q =
     Stdlib.(the_dbpath := dbpath);
     Format.asprintf "%a"
@@ -948,10 +939,13 @@ module UserLevelQueries = struct
          ~tag:("<h1>", "</h1") None)
       s
 
-  let search_cmd_txt ss ~dbpath (fmt : Format.formatter) s =
+  let search_cmd_txt ss ~dbpath fmt s =
+    let s = transform_ascii_to_unicode s in
     Stdlib.(the_dbpath := dbpath);
-    Lplib.Base.string fmt
-      (search_cmd_txt_string ss ~dbpath (transform_ascii_to_unicode s))
+    search_cmd_gen ss ~from:0 ~how_many:999999
+      ~fail:(fun pos ?err_desc x -> Common.Error.fatal_optional_position pos ?err_desc "%s" x)
+      ~pp_results:pp_results_list ~tag:("", "") None fmt s
+
 end
 
 (* let's flatten the interface *)

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -880,7 +880,7 @@ include QueryLanguage
 module UserLevelQueries = struct
 
  let search_cmd_gen ss ~from ~how_many
-  ~(fail:?err_desc:string -> string -> string)
+  ~(fail:Pos.popt option -> ?err_desc:string -> string -> string)
   ~pp_results ~tag:(hb,he) q fmt s =
   try
    let mok _ = None in
@@ -896,34 +896,36 @@ module UserLevelQueries = struct
   with
    | Stream.Failure ->
       Lplib.Base.out fmt "%s"
-       (fail (Format.asprintf "Syntax error: a query was expected@."))
-   | Common.Error.Fatal(_,msg, _) ->
-      Lplib.Base.out fmt "%s" (fail (Format.asprintf "Error: %s@." msg))
+       (fail None (Format.asprintf "Syntax error: a query was expected@."))
+   | Common.Error.Fatal(pos,msg, _) ->
+      Lplib.Base.out fmt "%s" (fail pos (Format.asprintf "Error: %s@." msg))
    | Overloaded(name,res) ->
-      Lplib.Base.out fmt "%s" (fail (Format.asprintf
+      Lplib.Base.out fmt "%s" (fail None (Format.asprintf
        "Overloaded symbol %s. Please rewrite the query replacing %s \
         with a fully qualified identifier among the following:@."
         name name)
         ~err_desc:(Format.asprintf "%a@." pp_results (ItemSet.bindings res))
         )
    | Stack_overflow ->
-      Lplib.Base.out fmt "%s" (fail
+      Lplib.Base.out fmt "%s" (fail None
        (Format.asprintf
          "Error: too many results. Please refine your query.@." ))
    | exn ->
       Lplib.Base.out fmt "%s"
-       (fail (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
+       (fail None (Format.asprintf "Error: %s@." (Printexc.to_string exn)))
 
   let search_cmd_txt_string ss ~dbpath s =
   Stdlib.(the_dbpath := dbpath);
   Format.asprintf "%a" (search_cmd_gen ss ~from:0 ~how_many:999999
-   ~fail:(fun ?err_desc x -> Common.Error.fatal_no_pos ?err_desc "%s" x)
+   ~fail:(fun pos ?err_desc x ->
+    Common.Error.fatal_optional_position pos ?err_desc "%s" x)
    ~pp_results:pp_results_list ~tag:("","") None) s
 
   let search_cmd_txt_query ss ~dbpath q =
   Stdlib.(the_dbpath := dbpath);
   Format.asprintf "%a" (search_cmd_gen ss ~from:0 ~how_many:999999
-   ~fail:(fun ?err_desc x -> Common.Error.fatal_no_pos ?err_desc "%s" x)
+   ~fail:(fun pos ?err_desc x ->
+    Common.Error.fatal_optional_position pos ?err_desc "%s" x)
    ~pp_results:pp_results_list ~tag:("","") (Some q)) ""
 
 
@@ -946,7 +948,8 @@ module UserLevelQueries = struct
   Stdlib.(the_dbpath := dbpath);
     Format.asprintf "%a"
     (search_cmd_gen ss ~from ~how_many
-      ~fail:(fun ?err_desc x -> "<font color=\"red\">" ^ x ^ "</font>"
+      ~fail:(fun pos ?err_desc x -> "<font color=\"red\">" ^ x ^ "</font>"
+          ^ (match pos with | None ->"" | Some p -> popt_to_string p)
           ^ (Option.value err_desc ~default:"")
    )
       ~pp_results:(html_of_results_list from)

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -866,14 +866,9 @@ include QueryLanguage
 module UserLevelQueries = struct
   let search_cmd_gen ss ~from ~how_many
       ~(fail : Pos.popt option -> ?err_desc:string -> string -> string)
-      ~pp_results ~tag:(hb, he) q fmt s =
+      ~pp_results ~tag:(hb, he) fmt q =
     try
       let mok _ = None in
-      let q =
-        match q with
-        | None -> Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s
-        | Some q -> q
-      in
       let items = ItemSet.bindings (answer_query ~mok ss [] q) in
       let resultsno = List.length items in
       let _, items = Lplib.List.cut items from in
@@ -905,12 +900,14 @@ module UserLevelQueries = struct
 
   let search_cmd_txt_query ss ~dbpath q =
     Stdlib.(the_dbpath := dbpath);
-    Format.asprintf "%a"
-      (search_cmd_gen ss ~from:0 ~how_many:999999
-         ~fail:(fun pos ?err_desc x ->
-           Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-         ~pp_results:pp_results_list ~tag:("", "") (Some q))
-      ""
+    search_cmd_gen ss ~from:0 ~how_many:999999
+      ~fail:(fun pos ?err_desc x ->
+        Common.Error.fatal_optional_position pos ?err_desc "%s" x)
+      ~pp_results:pp_results_list ~tag:("", "") q
+
+  let search_cmd_gen_string ss ~from ~how_many ~fail ~pp_results ~tag fmt s =
+   search_cmd_gen ss ~from ~how_many ~fail ~pp_results ~tag fmt
+    (Parsing.Parser.Rocq.parse_search_string (lexing_opt None) s)
 
   (** [transform_ascii_to_unicode s] replaces all the occurences of ["->"] and
       ["forall"] with ["→"] and ["Π"] in the search query [s] *)
@@ -927,24 +924,22 @@ module UserLevelQueries = struct
     assert (transform_ascii_to_unicode "forall.x, y" = "Π.x, y");
     assert (transform_ascii_to_unicode "((forall x, y" = "((Π x, y")
 
-  let search_cmd_html ss ~from ~how_many s ~dbpath =
+  let search_cmd_html ss ~from ~how_many ~dbpath fmt s =
     Stdlib.(the_dbpath := dbpath);
-    Format.asprintf "%a"
-      (search_cmd_gen ss ~from ~how_many
-         ~fail:(fun pos ?err_desc x ->
-           "<font color=\"red\">" ^ x ^ "</font>"
-           ^ (match pos with None -> "" | Some p -> popt_to_string p)
-           ^ Option.value err_desc ~default:"")
-         ~pp_results:(html_of_results_list from)
-         ~tag:("<h1>", "</h1") None)
-      s
+    search_cmd_gen_string ss ~from ~how_many
+      ~fail:(fun pos ?err_desc x ->
+        "<font color=\"red\">" ^ x ^ "</font>"
+        ^ (match pos with None -> "" | Some p -> popt_to_string p)
+        ^ Option.value err_desc ~default:"")
+      ~pp_results:(html_of_results_list from)
+      ~tag:("<h1>", "</h1") fmt s
 
   let search_cmd_txt ss ~dbpath fmt s =
     let s = transform_ascii_to_unicode s in
     Stdlib.(the_dbpath := dbpath);
-    search_cmd_gen ss ~from:0 ~how_many:999999
+    search_cmd_gen_string ss ~from:0 ~how_many:999999
       ~fail:(fun pos ?err_desc x -> Common.Error.fatal_optional_position pos ?err_desc "%s" x)
-      ~pp_results:pp_results_list ~tag:("", "") None fmt s
+      ~pp_results:pp_results_list ~tag:("", "") fmt s
 
 end
 

--- a/src/tool/indexing.mli
+++ b/src/tool/indexing.mli
@@ -19,6 +19,7 @@ val lsp_input : ((*uri*)string * (*text*)string) ref
 val search_cmd_txt_query: sig_state -> dbpath:string -> search Lplib.Base.pp
 
 (* search command used by websearch *)
-val search_cmd_html: sig_state -> from:int -> how_many:int -> dbpath:string -> string Lplib.Base.pp
+val search_cmd_html: sig_state -> from:int -> how_many:int -> dbpath:string
+    -> string Lplib.Base.pp
 
 val search_cmd_txt: sig_state -> dbpath:string -> string Lplib.Base.pp

--- a/src/tool/indexing.mli
+++ b/src/tool/indexing.mli
@@ -16,10 +16,9 @@ val preserving_index : ('a -> 'b) -> 'a -> 'b
 val lsp_input : ((*uri*)string * (*text*)string) ref
 
 (* search command used by cli *)
-val search_cmd_txt_query: sig_state -> dbpath:string -> search -> string
+val search_cmd_txt_query: sig_state -> dbpath:string -> search Lplib.Base.pp
 
 (* search command used by websearch *)
-val search_cmd_html:
-sig_state -> from:int -> how_many:int -> string -> dbpath:string -> string
+val search_cmd_html: sig_state -> from:int -> how_many:int -> dbpath:string -> string Lplib.Base.pp
 
 val search_cmd_txt: sig_state -> dbpath:string -> string Lplib.Base.pp

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -124,7 +124,9 @@ let start ~header ss ~port ~dbpath ~path_in_url () =
           if Timed.(!Common.Console.verbose) >= 2 then
             Dream.log "Received request = %s" message;
           let output =
-            Format.asprintf "%a" (Indexing.search_cmd_html ss ~from ~how_many:100 ~dbpath) message in
+            Format.asprintf "%a"
+            (Indexing.search_cmd_html ss ~from ~how_many:100 ~dbpath) message
+          in
           if Timed.(!Common.Console.verbose) >= 3 then
             Dream.log "sending response: %s" output;
           let header = match hideDescritionSection with

--- a/src/tool/websearch.eml.ml
+++ b/src/tool/websearch.eml.ml
@@ -124,8 +124,7 @@ let start ~header ss ~port ~dbpath ~path_in_url () =
           if Timed.(!Common.Console.verbose) >= 2 then
             Dream.log "Received request = %s" message;
           let output =
-            Indexing.search_cmd_html ss ~from ~how_many:100
-            message ~dbpath in
+            Format.asprintf "%a" (Indexing.search_cmd_html ss ~from ~how_many:100 ~dbpath) message in
           if Timed.(!Common.Console.verbose) >= 3 then
             Dream.log "sending response: %s" output;
           let header = match hideDescritionSection with


### PR DESCRIPTION
Summary:
- Fix parsing to preserve trailing characters after query
- Restore notation support by correcting required file requiring in `cli/lambdapi.ml`
- Add position info to query command error messages
- Prevent websearch server from crashing in case of syntax errors
- Restore the feature of streaming the search results in command line
- Use uniform types for query formatting functions and remove dual syntax-tree/string acceptance

Details:
- This branch implements several minor fixes after #1290 , focused on search indexing and query handling. It ensures query parsing is handled in the right phase, improves CLI error reporting, and prevents incorrect search results when syntax errors occur.