### PR TITLE
fix: longest-prefix selection in path_of_file library mappings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Stack_overflow exception due large number of search results.
 - Parser fix: the (ne)list combinator did not backtrack the stream in case of
   failure in the middle of the parsing of a list item
+- Selection of the library mapping with the longest matching prefix in
+  `path_of_file`: with nested mappings, the computed module path could get a
+  duplicated directory component.
 
 ## 3.0.0 (2025-07-16)
 

--- a/src/common/library.ml
+++ b/src/common/library.ml
@@ -212,7 +212,7 @@ let path_of_file : (string -> string) -> string -> Path.t =
       match !mapping with
       | None       -> mapping := Some(mp, fp)
       | Some(_, p) ->
-          if String.(length p < length fp) then mapping := Some(mp, p)
+          if String.(length p < length fp) then mapping := Some(mp, fp)
   in
   LibMap.iter f !lib_mappings;
   (* Fail if there is none. *)


### PR DESCRIPTION
`path_of_file` selects the library mapping whose filesystem prefix is the longest match for the file, but when a longer match replaced a previous candidate it paired the new module path `mp` with the previous candidate's *shorter* prefix `p`:

```ocaml
| Some(_, p) ->
    if String.(length p < length fp) then mapping := Some(mp, p)  (* should be fp *)
```

The remainder of the file path is then computed against the wrong prefix, so with nested mappings the module path gets a duplicated directory component.

**Reproduction:** checking an installed Stdlib file nests two mappings (`[] ↦ …/lib_root` and `Stdlib ↦ …/lib_root/Stdlib`) automatically.
```
$ lambdapi check $OPAM_SWITCH_PREFIX/lib/lambdapi/lib_root/Stdlib/Set.lp
File ".../lib_root/Stdlib/Stdlib/Set.lp" (or .dk) not found.   # path_of_file = Stdlib.Stdlib.Set
```

**Fix**: store the winning mapping with its own prefix, `Some(mp, fp)`. The command above then computes `Stdlib.Set` and succeeds.