### PR TITLE
fix parsing of bare open: do not load modules as require open does

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,9 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- A bare `open` (not preceded by `require`) was parsed as `require open`
-  since the parser rework, silently loading not yet required modules
-  instead of failing.
 - Convertibility test of non-linear higher-order pattern variables in rule LHS.
 - Syntactical errors in Dedukti export.
 - Weak head normal form test.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A bare `open` (not preceded by `require`) was parsed as `require open`
+  since the parser rework, silently loading not yet required modules
+  instead of failing.
 - Convertibility test of non-linear higher-order pattern variables in rule LHS.
 - Syntactical errors in Dedukti export.
 - Weak head normal form test.

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -433,11 +433,15 @@ let term_id (lb:'token lexbuf): p_term =
 
 (* commands *)
 
-let open_ (priv:bool) (lb:'token lexbuf) : p_command_aux =
+(* [req] tells whether the command starts with the [require] keyword:
+   [require [private] open] loads the modules and opens them
+   ([P_require]), while a bare [[private] open] only opens modules
+   that are already loaded ([P_open]). *)
+let open_ (req:bool) (priv:bool) (lb:'token lexbuf) : p_command_aux =
  if log_enabled() then log "%s" __FUNCTION__;
  consume OPEN lb;
  let ps = nelist path_tks path lb in
- P_require(Some priv,ps)
+ if req then P_require(Some priv,ps) else P_open(priv,ps)
 
 let rec symbol (p_sym_mod:p_modifier list) (lb:'token lexbuf): p_command_aux =
  if log_enabled() then log "%s" __FUNCTION__;
@@ -520,7 +524,7 @@ and command (lb:'token lexbuf) : p_command =
     end
  | [{elt=P_expo Term.Privat;_}] ->
     begin match current_token lb with
-    | OPEN -> extend_pos lb (*__FUNCTION__*) pos1 (open_ true lb)
+    | OPEN -> extend_pos lb (*__FUNCTION__*) pos1 (open_ false true lb)
     | SYMBOL ->
         extend_pos lb (*__FUNCTION__*) pos1 (symbol p_sym_mod lb)
     | L_PAREN
@@ -546,10 +550,10 @@ and command (lb:'token lexbuf) : p_command =
         begin
           match current_token lb with
           | OPEN ->
-              extend_pos lb (*__FUNCTION__*) pos1 (open_ false lb)
+              extend_pos lb (*__FUNCTION__*) pos1 (open_ true false lb)
           | PRIVATE ->
               consume_token lb;
-              extend_pos lb (*__FUNCTION__*) pos1 (open_ true lb)
+              extend_pos lb (*__FUNCTION__*) pos1 (open_ true true lb)
           | QID _ ->
               let ps = nelist path_tks path lb in
               begin
@@ -570,7 +574,7 @@ and command (lb:'token lexbuf) : p_command =
           | _ -> expected lb "" [OPEN;PRIVATE;QID[]]
         end
     | OPEN ->
-        extend_pos lb (*__FUNCTION__*) pos1 (open_ false lb)
+        extend_pos lb (*__FUNCTION__*) pos1 (open_ false false lb)
     | SYMBOL ->
         extend_pos lb (*__FUNCTION__*) pos1 (symbol p_sym_mod lb)
     | L_PAREN

--- a/tests/KO/open_not_required.lp
+++ b/tests/KO/open_not_required.lp
@@ -1,0 +1,3 @@
+// A bare [open] does not load modules: the module must have been
+// required first (with [require] or [require open]).
+open tests.OK.boolean;


### PR DESCRIPTION
Since the LL(1) parser rework (#1441, 078dba47), a bare `[private] open M;` is parsed as `P_require(Some private?, ...)` — the same AST as `require [private] open M;`. Consequently:

- `open M;` silently requires `M` when it is not yet loaded, instead of failing with `Module "M" needs to be required first.` — `Handle.Command.handle_open` became unreachable, since no parser constructed `P_open` anymore;
- the lp export prints `open M;` back as `require open M;`.

This PR restores `P_open` for the bare forms (`open`, `private open`), keeps `P_require` for the `require` forms, and adds a KO test (`open` of a module that was not required). No change to the grammar itself.
