### PR TITLE
give better error message on forbidden identifiers

### DIFF
--- a/src/export/rawdk.ml
+++ b/src/export/rawdk.ml
@@ -198,6 +198,7 @@ let command : p_command pp = fun ppf ({elt; pos} as c) ->
   | P_query q -> query ppf q
   | P_require(None,ps) ->
       List.iter (fun {elt;_} -> out ppf "#REQUIRE %a@." Dk.mident elt) ps
+  | P_symbol{p_sym_prf=Some(_,{elt=P_proof_abort;_}); _} -> ()
   | P_symbol{p_sym_mod; p_sym_kw=_; p_sym_nam=n; p_sym_arg; p_sym_typ;
              p_sym_trm; p_sym_prf=None; p_sym_def=_;} ->
       let ms = partition_modifiers p_sym_mod in
@@ -231,11 +232,11 @@ let command : p_command pp = fun ppf ({elt; pos} as c) ->
   | P_builtin _
   | P_unif_rule _
   | P_coercion _
-    -> () (*FIXME?*)
-  | P_inductive _
+    -> ()
+  | P_inductive _ (*FIXME*)
   | P_open _
   | P_require_as _
-  | P_notation _ (* FIXME: accept quantifier notations *)
+  | P_notation _
   | P_opaque _
   | P_require(Some _,_)
   | P_symbol{p_sym_prf=Some _; _}

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -344,6 +344,7 @@ let rec token ~allow_rocq_syntax lb =
   | '@', id -> UID_EXPL(remove_first lb)
   | '?', nat -> UID_META(int_of_string(remove_first lb))
   | '?', '0', nat -> fail lb "Forbidden metavariable name."
+  | '?', id -> fail lb "Forbidden metavariable name."
   | '$', nat -> fail lb "Forbidden pattern variable name."
   | '$', '0', nat -> fail lb "Forbidden pattern variable name."
   | '$', id -> UID_PATT(remove_first lb)

--- a/src/parsing/lpLexer.ml
+++ b/src/parsing/lpLexer.ml
@@ -28,7 +28,7 @@ let fail : lexbuf -> string -> 'a = fun lb msg ->
 
 (* raises an unrecoverable lexing error; do not use in the parser *)
 let invalid_character : lexbuf -> 'a = fun lb ->
-  fail lb "Invalid character"
+  fail lb "Invalid character."
 
 (** Tokens. *)
 type token =
@@ -156,7 +156,6 @@ let float = [%sedlex.regexp? int, '.', nat]
 let oneline_comment = [%sedlex.regexp? "//", Star (Compl ('\n' | '\r'))]
 let string = [%sedlex.regexp? '"', Star (Compl '"'), '"']
 let positive_digit = [%sedlex.regexp? '1' .. '9']
-let strict_nat = [%sedlex.regexp? '0' | positive_digit, Star digit]
 
 (** Identifiers.
 
@@ -344,7 +343,9 @@ let rec token ~allow_rocq_syntax lb =
   | id -> UID(Utf8.lexeme lb)
   | '@', id -> UID_EXPL(remove_first lb)
   | '?', nat -> UID_META(int_of_string(remove_first lb))
-  | '$', nat -> fail lb "Forbidden pattern variable name"
+  | '?', '0', nat -> fail lb "Forbidden metavariable name."
+  | '$', nat -> fail lb "Forbidden pattern variable name."
+  | '$', '0', nat -> fail lb "Forbidden pattern variable name."
   | '$', id -> UID_PATT(remove_first lb)
 
   | id, '.' -> qid false [remove_last lb] lb
@@ -359,9 +360,9 @@ let token :
    lexbuf -> token * Lexing.position * Lexing.position =
   fun ~allow_rocq_syntax lb ->
     try Sedlexing.with_tokenizer (token ~allow_rocq_syntax) lb () with
-    | MalFormed -> fail lb "Not Utf8 encoded file"
+    | MalFormed -> fail lb "Not Utf8 encoded file."
     | InvalidCodepoint k ->
-       fail lb ("Invalid Utf8 code point " ^ string_of_int k)
+       fail lb ("Invalid Utf8 code point \""^string_of_int k^"\".")
 
 let dummy_token = (EOF, Lexing.dummy_pos, Lexing.dummy_pos)
 

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -12,112 +12,119 @@ let log = log.pp
 
 (* token management *)
 
-let string_of_token = function
+let tokens = function
+  | [] -> ""
+  | s::l -> List.fold_left (fun acc s -> acc^", "^String.add_quotes s) s l
+
+let string_of_token =
+  let q = String.add_quotes in
+  let (||) a b = a^", "^b in
+  function
   | EOF -> "end of file"
-  | ABORT -> "abort"
-  | ADMIT -> "admit"
-  | ADMITTED -> "admitted"
-  | ALL_HYPS -> "all_hyps"
-  | APPLY -> "apply"
-  | ARROW -> "→"
-  | AS -> "as"
-  | ASSERT _ -> "assert or assertnot"
-  | ASSIGN -> "≔"
-  | ASSOCIATIVE -> "associative"
-  | ASSUME -> "assume"
-  | ASSUMPTION -> "assumption"
-  | BACKQUOTE -> "`"
-  | BEGIN -> "begin"
-  | BUILTIN -> "builtin"
-  | CHANGE -> "change"
-  | COERCE_RULE -> "coerce_rule"
-  | COLON -> ":"
-  | COMMA -> ","
-  | COMMUTATIVE -> "commutative"
-  | COMPUTE -> "compute"
-  | CONSTANT -> "constant"
-  | DEBUG -> "debug"
+  | ABORT -> q"abort"
+  | ADMIT -> q"admit"
+  | ADMITTED -> q"admitted"
+  | ALL_HYPS -> q"all_hyps"
+  | APPLY -> q"apply"
+  | ARROW -> q"→"
+  | AS -> q"as"
+  | ASSERT _ -> q"assert" || q"assertnot"
+  | ASSIGN -> q"≔"
+  | ASSOCIATIVE -> q"associative"
+  | ASSUME -> q"assume"
+  | ASSUMPTION -> q"assumption"
+  | BACKQUOTE -> q"`"
+  | BEGIN -> q"begin"
+  | BUILTIN -> q"builtin"
+  | CHANGE -> q"change"
+  | COERCE_RULE -> q"coerce_rule"
+  | COLON -> q":"
+  | COMMA -> q","
+  | COMMUTATIVE -> q"commutative"
+  | COMPUTE -> q"compute"
+  | CONSTANT -> q"constant"
+  | DEBUG -> q"debug"
   | DEBUG_FLAGS _ -> "debug flags"
-  | DOT -> "."
-  | END -> "end"
-  | EQUIV -> "≡"
-  | EVAL -> "eval"
-  | EXISTS -> "exists" (* only in Rocq *)
-  | FAIL -> "fail"
-  | FIRST_HYP -> "first_hyp"
-  | FLAG -> "flag"
-  | FLOAT _ -> "float"
-  | FOCUS -> "focus"
-  | FORALL -> "forall" (* only in Rocq *)
-  | FUN -> "fun"       (* only in Rocq *)
-  | GENERALIZE -> "generalize"
-  | HAVE -> "have"
-  | HOOK_ARROW -> "↪"
-  | IN -> "in"
-  | INDUCTION -> "induction"
-  | INDUCTIVE -> "inductive"
-  | INFIX -> "infix"
-  | INJECTIVE -> "injective"
-  | INT _ -> "integer"
-  | LAMBDA -> "λ"
-  | LET -> "let"
-  | L_CU_BRACKET -> "{"
-  | L_PAREN -> "("
-  | L_SQ_BRACKET -> "["
-  | NOTATION -> "notation"
-  | OPAQUE -> "opaque"
-  | OPEN -> "open"
-  | ORELSE -> "orelse"
-  | PI -> "Π"
-  | POSTFIX -> "postfix"
-  | PREFIX -> "prefix"
-  | PRINT -> "print"
-  | PRIVATE -> "private"
-  | PROOFTERM -> "proofterm"
-  | PROTECTED -> "protected"
-  | PROVER -> "prover"
-  | PROVER_TIMEOUT -> "prover_timeout"
+  | DOT -> q"."
+  | END -> q"end"
+  | EQUIV -> q"≡"
+  | EVAL -> q"eval"
+  | EXISTS -> q"exists" (* only in Rocq *)
+  | FAIL -> q"fail"
+  | FIRST_HYP -> q"first_hyp"
+  | FLAG -> q"flag"
+  | FLOAT _ -> q"float"
+  | FOCUS -> q"focus"
+  | FORALL -> q"forall" (* only in Rocq *)
+  | FUN -> q"fun"       (* only in Rocq *)
+  | GENERALIZE -> q"generalize"
+  | HAVE -> q"have"
+  | HOOK_ARROW -> q"↪"
+  | IN -> q"in"
+  | INDUCTION -> q"induction"
+  | INDUCTIVE -> q"inductive"
+  | INFIX -> q"infix"
+  | INJECTIVE -> q"injective"
+  | INT _ -> q"integer"
+  | LAMBDA -> q"λ"
+  | LET -> q"let"
+  | L_CU_BRACKET -> q"{"
+  | L_PAREN -> q"("
+  | L_SQ_BRACKET -> q"["
+  | NOTATION -> q"notation"
+  | OPAQUE -> q"opaque"
+  | OPEN -> q"open"
+  | ORELSE -> q"orelse"
+  | PI -> q"Π"
+  | POSTFIX -> q"postfix"
+  | PREFIX -> q"prefix"
+  | PRINT -> q"print"
+  | PRIVATE -> q"private"
+  | PROOFTERM -> q"proofterm"
+  | PROTECTED -> q"protected"
+  | PROVER -> q"prover"
+  | PROVER_TIMEOUT -> q"prover_timeout"
   | QID _ -> "qualified identifier"
   | QID_EXPL _ -> "@-prefixed qualified identifier"
   | QINT _ -> "qualified integer"
-  | QUANTIFIER -> "quantifier"
-  | REFINE -> "refine"
-  | REFLEXIVITY -> "reflexivity"
-  | REMOVE -> "remove"
-  | REPEAT -> "repeat"
-  | REQUIRE -> "require"
-  | REWRITE -> "rewrite"
-  | RULE -> "rule"
-  | R_CU_BRACKET -> "}"
-  | R_PAREN -> ")"
-  | R_SQ_BRACKET -> "]"
-  | SEARCH -> "search"
-  | SEQUENTIAL -> "sequential"
-  | SEMICOLON -> ";"
-  | SET -> "set"
-  | SIDE _ -> "left or right"
-  | SIMPLIFY -> "simplify"
-  | SOLVE -> "solve"
+  | QUANTIFIER -> q"quantifier"
+  | REFINE -> q"refine"
+  | REFLEXIVITY -> q"reflexivity"
+  | REMOVE -> q"remove"
+  | REPEAT -> q"repeat"
+  | REQUIRE -> q"require"
+  | REWRITE -> q"rewrite"
+  | RULE -> q"rule"
+  | R_CU_BRACKET -> q"}"
+  | R_PAREN -> q")"
+  | R_SQ_BRACKET -> q"]"
+  | SEARCH -> q"search"
+  | SEQUENTIAL -> q"sequential"
+  | SEMICOLON -> q";"
+  | SET -> q"set"
+  | SIDE _ -> q"left" || q"right"
+  | SIMPLIFY -> q"simplify"
+  | SOLVE -> q"solve"
   | STRINGLIT _ -> "string literal"
-  | SWITCH false -> "off"
-  | SWITCH true -> "on or off"
-  | SYMBOL -> "symbol"
-  | SYMMETRY -> "symmetry"
-  | THICKARROW -> "=>" (* only in Rocq *)
-  | TRY -> "try"
-  | TURNSTILE -> "⊢"
-  | TYPE_QUERY -> "type"
-  | TYPE_TERM -> "TYPE"
+  | SWITCH false -> q"off"
+  | SWITCH true -> q"on" || q"off"
+  | SYMBOL -> q"symbol"
+  | SYMMETRY -> q"symmetry"
+  | THICKARROW -> q"=>" (* only in Rocq *)
+  | TRY -> q"try"
+  | TURNSTILE -> q"⊢"
+  | TYPE_QUERY -> q"type"
+  | TYPE_TERM -> q"TYPE"
   | UID _ -> "non-qualified identifier"
   | UID_EXPL _ -> "@-prefixed non-qualified identifier"
   | UID_META _ -> "?-prefixed metavariable number"
   | UID_PATT _ -> "$-prefixed non-qualified identifier"
-  | UNDERSCORE -> "_"
-  | UNIF_RULE -> "unif_rule"
-  | VBAR -> "|"
-  | VERBOSE -> "verbose"
-  | WHY3 -> "why3"
-  | WITH -> "with"
+  | UNDERSCORE -> q"_"
+  | UNIF_RULE -> q"unif_rule"
+  | VBAR -> q"|"
+  | VERBOSE -> q"verbose"
+  | WHY3 -> q"why3"
+  | WITH -> q"with"
 
 let pp_token ppf t = Base.string ppf (string_of_token t)
 
@@ -149,10 +156,9 @@ let expected lb (msg:string) (tokens:token list) : 'a =
     match tokens with
     | [] -> assert false
     | t::ts ->
-      let ts = ts @ get_expected_tokens lb in
-      let soft t = String.add_quotes (string_of_token t) in
       syntax_error (current_pos lb)
-        (List.fold_left (fun s t -> s^", "^soft t) ("Expected: "^soft t) ts
+        (List.fold_left (fun s t -> s^", "^string_of_token t)
+           ("Expected: "^string_of_token t) (ts @ get_expected_tokens lb)
         ^".")
 
 (* building positions and terms *)
@@ -385,7 +391,7 @@ let float_or_int (lb:'token lexbuf): string =
       consume_token lb;
       s
   | _ ->
-      expected lb "" [INT"";FLOAT""]
+      expected lb "" [FLOAT"";INT""]
 
 let path_tks = [QID[]]
 let path (lb:'token lexbuf): string list loc =
@@ -1622,7 +1628,7 @@ and relation (lb:'token lexbuf): relation option =
   | UID "=" -> consume_token lb; Some Exact
   | UID ">" -> consume_token lb; Some Inside
   | UID ("≥"|">=") -> consume_token lb; None
-  | _ -> expected lb "\">\", \"=\", \"≥\",\">=\"" []
+  | _ -> expected lb (tokens[">";"=";"≥";">="]) []
 
 and where (lb:'token lexbuf): bool * relation option =
   if log_enabled() then log "%s" __FUNCTION__;
@@ -1646,7 +1652,7 @@ and asearch (lb:'token lexbuf): search =
             let g = generalize lb in
             let t = term lb in
             QBase(QSearch(t,g,Some(QType None)))
-        | _ -> expected lb "\"≥\",\">=\"" []
+        | _ -> expected lb (tokens["≥";">="]) []
       end
   | UID "anywhere" ->
       begin
@@ -1657,7 +1663,7 @@ and asearch (lb:'token lexbuf): search =
             let g = generalize lb in
             let t = term lb in
             QBase(QSearch(t,g,None))
-        | _ -> expected lb "\"≥\",\">=\"" []
+        | _ -> expected lb (tokens["≥";">="]) []
       end
   | RULE ->
       consume_token lb;
@@ -1701,7 +1707,8 @@ and asearch (lb:'token lexbuf): search =
       consume R_PAREN lb;
       q
   | _ ->
-      expected lb "name, anywhere, rule, lhs, rhs, type, concl, hyp, spine" []
+    expected lb (tokens["name";"anywhere";"rule";"lhs";"rhs";"type";"concl";
+                        "hyp";"spine"]) []
 
 and csearch (lb:'token lexbuf): search =
   if log_enabled() then log "%s" __FUNCTION__;

--- a/src/parsing/lpParser.ml
+++ b/src/parsing/lpParser.ml
@@ -332,7 +332,6 @@ let qid_expl (lb:'token lexbuf): (string list * string) loc =
   | _ ->
       expected lb "" [UID_EXPL"";QID_EXPL[]]
 
-let uid_tks = [UID""]
 let uid (lb:'token lexbuf): string loc =
   if log_enabled() then log "%s" __FUNCTION__;
   match current_token lb with
@@ -341,7 +340,19 @@ let uid (lb:'token lexbuf): string loc =
       consume_token lb;
       make_pos pos1 s
   | _ ->
-      expected lb "" uid_tks
+      expected lb "" [UID""]
+
+let sym_name (lb:'token lexbuf): string loc =
+  if log_enabled() then log "%s" __FUNCTION__;
+  match current_token lb with
+  | INT s ->
+      syntax_error (current_pos lb) "Forbidden symbol name."
+  | UID s ->
+      let pos1 = current_pos lb in
+      consume_token lb;
+      make_pos pos1 s
+  | _ ->
+      expected lb "" [UID""]
 
 let param_tks = [UID"";UNDERSCORE]
 let param (lb:'token lexbuf): string loc option =
@@ -451,7 +462,7 @@ let rec symbol (p_sym_mod:p_modifier list) (lb:'token lexbuf): p_command_aux =
  if log_enabled() then log "%s" __FUNCTION__;
  let p_sym_kw = Some(locate (current_pos lb)) in
  consume SYMBOL lb;
- let p_sym_nam = uid lb in
+ let p_sym_nam = sym_name lb in
  let p_sym_arg = list params_tks params lb in
  begin
    match current_token lb with
@@ -640,7 +651,7 @@ and command (lb:'token lexbuf) : p_command =
         let q = query lb in
         extend_pos lb (*__FUNCTION__*) pos1 (P_query(q))
     | _ ->
-        expected lb ""
+        expected lb "command"
          [ SIDE Pratter.Left ; ASSOCIATIVE ; COMMUTATIVE ; CONSTANT ;
            INJECTIVE ; SEQUENTIAL ; PRIVATE ; OPAQUE ; PROTECTED ; REQUIRE ;
            OPEN ; SYMBOL ; L_PAREN ; L_SQ_BRACKET ; INDUCTIVE ; RULE ;
@@ -1110,7 +1121,7 @@ and tactic (lb:'token lexbuf): p_tactic =
   | REMOVE ->
       let pos1 = current_pos lb in
       consume_token lb;
-      let xs = nelist uid_tks uid lb in
+      let xs = nelist [UID""] uid lb in
       extend_pos lb (*__FUNCTION__*) pos1 (P_tac_remove xs)
   | REPEAT ->
       let pos1 = current_pos lb in
@@ -1510,7 +1521,7 @@ and aterm (lb:'token lexbuf): p_term =
         consume_token lb;
         make_pos pos1 (P_SLit s)
     | _ ->
-      expected lb "TYPE, identifier, integer or string literal, \"_\", \
+      expected lb "TYPE, identifier, integer or string literal, \"_\" \
                    or term between parentheses or square brackets" []
 
 and env (lb:'token lexbuf): p_term list =

--- a/tests/KO/invalid_pattvar_name.lp
+++ b/tests/KO/invalid_pattvar_name.lp
@@ -1,0 +1,3 @@
+symbol A:TYPE;
+symbol f:A → A;
+rule f $0 ↪ $0;

--- a/tests/KO/invalid_sym_name.lp
+++ b/tests/KO/invalid_sym_name.lp
@@ -1,0 +1,1 @@
+symbol 0:TYPE;

--- a/tests/OK/print.lp
+++ b/tests/OK/print.lp
@@ -1,0 +1,5 @@
+symbol A:TYPE;
+symbol a:A ≔
+begin
+  print;
+abort;


### PR DESCRIPTION
- lpLexer: fail if ? is followed by an id or a number with a leading 0, fail if $ is followed by a number
- lpParser: fail if a symbol name is a number, put expected keywords between double quotes
- add OK and KO tests
- rawdk.ml: accept aborted proofs