### PR TITLE
make Eval.whnf t return an AC-canonical form

### DIFF
--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -80,7 +80,7 @@ let snf : (term -> term) -> (term -> term) = fun whnf ->
     | TRef _ -> assert false
   in snf
 
-type rw_tag = [ `NoBeta | `NoRw | `NoExpand ]
+type rw_tag = NoBeta | NoRw | NoExpand
 
 (** Configuration of the reduction engine. *)
 module Config = struct
@@ -98,9 +98,9 @@ module Config = struct
       By default, beta reduction and rewriting is enabled for all symbols. *)
   let make : ?dtree:(sym -> dtree) -> ?tags:rw_tag list -> ctxt -> t =
   fun ?(dtree=fun sym -> Timed.(!(sym.sym_dtree))) ?(tags=[]) context ->
-    let beta = not @@ List.mem `NoBeta tags in
-    let expand_defs = not @@ List.mem `NoExpand tags in
-    let rewrite = not @@ List.mem `NoRw tags in
+    let beta = not @@ List.mem NoBeta tags in
+    let expand_defs = not @@ List.mem NoExpand tags in
+    let rewrite = not @@ List.mem NoRw tags in
     {varmap = Ctxt.to_map context; rewrite; expand_defs; beta; dtree}
 
   (** [unfold cfg a] unfolds [a] if it's a variable defined in the
@@ -510,7 +510,7 @@ let snf : ?dtree:(sym -> dtree) -> term reducer = fun ?dtree ?tags c t ->
 
 let snf ?dtree = time_reducer mk_Kind (snf ?dtree)
 
-let snf_beta t = snf ~tags:[`NoRw; `NoExpand] [] t
+let snf_beta t = snf ~tags:[NoRw;NoExpand] [] t
 
 (** [hnf c t] computes a hnf of [t], unfolding the variables defined in the
     context [c], and using user-defined rewrite rules. *)
@@ -545,10 +545,18 @@ let whnf_opt : term option reducer = fun ?tags c t ->
 
 let whnf_opt = time_reducer None whnf_opt
 
+(** If [t] is headed by an AC symbol, then [partial_ac_nf t] returns its
+    AC-canonical form. Otherwise, it returns [t] itself. *)
+let partial_ac_nf (t:term): term =
+  match get_args t with
+  | Symb s, _ when is_ac s.sym_prop -> cleanup t
+  | _ -> unfold t
+
+(** [whnf ?tags c t] returns a whnf of [t] that is in AC-canonical form. *)
 let whnf : term reducer = fun ?tags c t ->
   Stdlib.(steps := 0);
   let u = whnf (Config.make ?tags c) t in
-  if Stdlib.(!steps = 0) then unfold t else u
+  if Stdlib.(!steps = 0) then partial_ac_nf t else u
 
 let whnf = time_reducer mk_Kind whnf
 

--- a/src/core/eval.mli
+++ b/src/core/eval.mli
@@ -23,9 +23,9 @@ val eta_equality : bool Timed.ref
 
 (** Tags for rewriting configuration. *)
 type rw_tag =
-  [ `NoBeta (** If true, no beta-reduction is performed. *)
-  | `NoRw (** If true, no user-defined rewrite rule is used. *)
-  | `NoExpand (** If true, definitions are not expanded. *) ]
+  | NoBeta (** If true, no beta-reduction is performed. *)
+  | NoRw (** If true, no user-defined rewrite rule is used. *)
+  | NoExpand (** If true, definitions are not expanded. *)
 
 (** Functions that use the rewriting engine and accept an optional argument
     [tags] of type [rw_tag list] have the following behaviour.

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -38,6 +38,8 @@ type prop =
   | Assoc of bool (** Associative left if [true], right if [false]. *)
   | AC of bool (** Associative and commutative. *)
 
+let is_ac = function Commu | Assoc _ | AC _ -> true | _ -> false
+
 (** Data of a binder. *)
 type binder_info = {binder_name : string; binder_bound : bool}
 type mbinder_info = {mbinder_name : string array; mbinder_bound : bool array}
@@ -428,8 +430,8 @@ and msubst : mbinder -> term array -> term = fun (bi,tm,env) vs ->
     if Array.for_all ((=) false) bi.mbinder_bound && Array.length env = 0
     then tm
     else msubst tm in
-  if Logger.log_enabled() then
-    log "msubst %a#%a %a = %a" terms env term tm terms vs term r;
+  (*if Logger.log_enabled() then
+    log "msubst %a#%a %a = %a" terms env term tm terms vs term r;*)
   r
 
 (** Total order on terms. *)
@@ -523,16 +525,16 @@ and right_aliens : sym -> term -> term list = fun s ->
           | _ -> aliens (u :: acc) us
         else aliens (u :: acc) us
   in fun t -> let r = aliens [] [t] in
-  if Logger.log_enabled () then
-    log "right_aliens %a %a = %a" sym s term t (D.list term) r;
+  (*if Logger.log_enabled () then
+    log "right_aliens %a %a = %a" sym s term t (D.list term) r;*)
   r
 
 (** [mk_Appl t u] puts the application of [t] to [u] in canonical form wrt C
    or AC symbols. *)
 and mk_Appl : term * term -> term = fun (t, u) ->
-  (* if Logger.log_enabled () then
-    log "mk_Appl(%a, %a)" term t term u;
-  let r = *)
+  (*if Logger.log_enabled () then
+    log "mk_Appl(%a, %a)" term t term u;*)
+  let r =
   match get_args t with
   | Symb s, [t1] ->
       begin
@@ -552,10 +554,10 @@ and mk_Appl : term * term -> term = fun (t, u) ->
         | _ -> Appl (t, u)
       end
   | _ -> Appl (t, u)
-  (* in
-  if Logger.log_enabled () then
-    log "mk_Appl(%a, %a) = %a" term t term u term r;
-  r *)
+  in
+  (*if Logger.log_enabled () then
+    log "mk_Appl(%a, %a) = %a" term t term u term r;*)
+  r
 
 (* unit test *)
 let _ =
@@ -683,8 +685,8 @@ let subst : binder -> term -> term = fun (bi,tm,env) v ->
   let r =
     if bi.binder_bound = false &&  Array.length env = 0 then tm
     else subst tm in
-  if Logger.log_enabled() then
-    log "subst %a#%a [%a] = %a" terms env term tm term v term r;
+  (*if Logger.log_enabled() then
+    log "subst %a#%a [%a] = %a" terms env term tm term v term r;*)
   r
 
 (** [unbind b] substitutes the binder [b] by a fresh variable of name [name]

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -36,6 +36,8 @@ type prop =
   | Assoc of bool (** Associative left if [true], right if [false]. *)
   | AC of bool (** Associative and commutative. *)
 
+val is_ac: prop -> bool
+
 (** Type for free variables. *)
 type var
 

--- a/src/core/unif.ml
+++ b/src/core/unif.ml
@@ -372,7 +372,7 @@ let solve : problem -> unit = fun p ->
   p := {!p with to_solve};
 
   (* We first try without normalizing wrt user-defined rules. *)
-  let tags = [`NoRw; `NoExpand] in
+  let tags = Eval.[NoRw;NoExpand] in
   let t1 = Eval.whnf ~tags c t1 and t2 = Eval.whnf ~tags c t2 in
   if Logger.log_enabled () then log "solve %a" constr (c,t1,t2);
   if Eval.pure_eq_modulo ~tags c t1 t2 then

--- a/src/handle/rewrite.ml
+++ b/src/handle/rewrite.ml
@@ -50,7 +50,7 @@ let get_eq_data :
         let v,t = unbind ~name:("$"^binder_name t) t in get_eq (v::vs) t true
     | p, [u] when is_symb cfg.symb_P p ->
       begin
-        let u = Eval.whnf ~tags:[`NoRw;`NoExpand] [] u in
+        let u = Eval.whnf ~tags:[NoRw;NoExpand] [] u in
         try return vs (get_eq_args u)
         with Not_eq _ ->
           (try return vs (get_eq_args (Eval.whnf [] u))

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -489,7 +489,7 @@ let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
       end
   | P_tac_simpl SimpBetaOnly ->
       begin
-        match Goal.simpl_opt (Eval.snf_opt ~tags:[`NoRw; `NoExpand]) g with
+        match Goal.simpl_opt (Eval.snf_opt ~tags:[NoRw;NoExpand]) g with
         | Some g -> {ps with proof_goals = g :: gs}
         | None -> fatal pos "Could not simplify the goal."
       end

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -623,7 +623,7 @@ let normalize typ =
  let dtree sym =
   try QNameMap.find (name_of_sym sym) (Lazy.force meta_rules)
   with Not_found -> Core.Tree_type.empty_dtree in
- Core.Eval.snf ~dtree ~tags:[`NoExpand] [] typ
+ Core.Eval.snf ~dtree ~tags:[NoExpand] [] typ
 
 let _ = normalize_fun := normalize
 

--- a/src/tool/sr.ml
+++ b/src/tool/sr.ml
@@ -121,7 +121,7 @@ let check_rule : Pos.popt -> sym_rule -> sym_rule =
   | Some (lhs_with_metas, ty_lhs) ->
   if not (Unif.solve_noexn ~type_check:false p) then
     fatal pos "The LHS is not typable.";
-  (* Try to simplify constraints. *)
+  (* Normalize constraints. *)
   let norm_constr (c,t,u) = (c, Eval.snf [] t, Eval.snf [] u) in
   let lhs_constrs = List.map norm_constr !p.unsolved in
   if Logger.log_enabled () then
@@ -129,10 +129,8 @@ let check_rule : Pos.popt -> sym_rule -> sym_rule =
       term ty_lhs constrs lhs_constrs
       term lhs_with_metas term rhs_with_metas;
   (* Instantiate all uninstantiated metavariables by fresh symbols. *)
-  (* Map each uninstantiated meta to a fresh symbol. *)
-  let m2s = Stdlib.ref MetaMap.empty
-  (* Map each new symbol to Some pattern index if any, and None otherwise. *)
-  and s2p = Stdlib.ref SymMap.empty in
+  let m2s = Stdlib.ref MetaMap.empty (* meta -> symbol *)
+  and s2p = Stdlib.ref SymMap.empty in (* symbol -> pattern index option *)
   let sym_of_meta m =
     let name = Printf.sprintf "%c%d" LibTerm.sym_meta_prefix m.meta_key in
     Term.create_sym (Sign.current_path())
@@ -194,7 +192,7 @@ let check_rule : Pos.popt -> sym_rule -> sym_rule =
   if Logger.log_enabled () then
     log_subj "replace LHS metavariables by function symbols:@ %a ↪ %a"
       term lhs_with_metas term rhs_with_metas;
-  (* TODO complete the constraints into a set of rewriting rules on
+  (* TODO: complete the constraints into a set of rewriting rules on
      the function symbols of [symbols]. *)
   (* Compute the constraints for the RHS to have the same type as the LHS. *)
   let p = new_problem() in

--- a/tests/OK/1407.lp
+++ b/tests/OK/1407.lp
@@ -1,0 +1,24 @@
+symbol Prop : TYPE;
+injective symbol π: Prop → TYPE;
+builtin "Prop" ≔ Prop;
+builtin "Prf" ≔ π;
+
+symbol context: TYPE;
+symbol □ : context;
+associative commutative symbol ∙ : context → context → context;
+notation ∙ infix right 1;
+
+symbol γ: context → context;
+rule □ ∙  $H ↪ $H;
+
+inductive valid1: context → TYPE ≔
+| R1 H1 H2 : valid1 (H1 ∙ H2) → valid1 H2;
+
+inductive valid2: context → TYPE ≔
+| R2 H1 H2 : valid2 (H1 ∙ H2) → valid2 H1;
+
+inductive valid3: context → TYPE ≔
+| R3 P H : valid3 (H ∙ γ P) → valid3 H;
+
+inductive valid4: context → TYPE ≔
+| R4 P H : valid4 (γ P ∙ H) → valid4 H;

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -63,7 +63,7 @@ do
         # "open"
         triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|1374|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod|Conj|Disj|ExtraRules|Univ);;
         # "inductive"
-        strictly_positive_*|inductive|989|904|830|341|1392);;
+        strictly_positive_*|inductive|989|904|830|341|1392|1407);;
         # underscore in query
         unif_hint|patterns|let|767);;
         # abstracted variable type in rule LHS


### PR DESCRIPTION
if the whnf of t is headed by an AC symbol (fix #1407)

other modifications:
- change rw_tag type to non-polymorphic variant (remove backquotes)