### PR TITLE
fix axiom counting

### DIFF
--- a/src/core/eval.ml
+++ b/src/core/eval.ml
@@ -549,7 +549,7 @@ let whnf_opt = time_reducer None whnf_opt
     AC-canonical form. Otherwise, it returns [t] itself. *)
 let partial_ac_nf (t:term): term =
   match get_args t with
-  | Symb s, _ when is_ac s.sym_prop -> cleanup t
+  | Symb s, _ when is_modulo s -> cleanup t
   | _ -> unfold t
 
 (** [whnf ?tags c t] returns a whnf of [t] that is in AC-canonical form. *)

--- a/src/core/print.ml
+++ b/src/core/print.ml
@@ -91,8 +91,6 @@ let notation : 'a pp -> 'a notation pp = fun elt ->
 
 let uid : string pp = string
 
-let path : Path.t pp = Path.pp
-
 let prop : prop pp = fun ppf p ->
   match p with
   | AC true -> out ppf "left associative commutative "
@@ -133,7 +131,7 @@ let sym : sym pp = fun ppf s ->
     | None ->
         (* Do not print path of temporary symbols introduced in sr.ml. *)
         if n <> "" && n.[0] = LibTerm.sym_meta_prefix then uid ppf n
-        else out ppf "%a.%a" path p uid n
+        else qsym ppf s
     | Some alias -> out ppf "%a.%a" uid alias uid n
 
 let var : var pp = fun ppf x -> uid ppf (base_name x)

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -247,7 +247,11 @@ let add_symbol : t -> expo -> prop -> match_strat -> bool -> strloc ->
     create_sym sign.sign_path sym_expo sym_prop sym_mstrat sym_opaq name pos
       (cleanup typ) (minimize_impl impl)
   in
-  sign.sign_symbols := StrMap.add name.elt sym !(sign.sign_symbols);
+  let f = function
+    | None -> Some sym
+    | Some _ -> fatal_no_pos "Bug: symbol %a already declared." Term.qsym sym
+  in
+  sign.sign_symbols := StrMap.update name.elt f !(sign.sign_symbols);
   if Stdlib.(!Common.Console.lsp_mod) then
     Stdlib.(!add_symbol_callback ~path:sign.sign_path sym) ;
   sym

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -354,8 +354,7 @@ let mk_right_comb : sym -> term list -> term -> term = fun s ->
 (** Printing functions for debug. *)
 let var : var pp = fun ppf (i,n) -> out ppf "%s%d" n i
 let sym : sym pp = fun ppf s -> string ppf s.sym_name
-let path = Path.pp
-let qsym : sym pp = fun ppf s -> out ppf "%a.%s" path s.sym_path s.sym_name
+let qsym : sym pp = fun ppf s -> out ppf "%a.%s" Path.pp s.sym_path s.sym_name
 let rec term : term pp = fun ppf t ->
   match unfold t with
   | Bvar (InSub k) -> out ppf "`%d" k
@@ -990,7 +989,6 @@ let new_problem : unit -> problem = fun () ->
 module Raw = struct
   let var = var let _ = var
   let sym = sym let _ = sym
-  let qsym = qsym let _ = qsym
   let term = term let _ = term
   let ctxt = ctxt let _ = ctxt
 end

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -38,8 +38,6 @@ type prop =
   | Assoc of bool (** Associative left if [true], right if [false]. *)
   | AC of bool (** Associative and commutative. *)
 
-let is_ac = function Commu | Assoc _ | AC _ -> true | _ -> false
-
 (** Data of a binder. *)
 type binder_info = {binder_name : string; binder_bound : bool}
 type mbinder_info = {mbinder_name : string array; mbinder_bound : bool array}
@@ -354,6 +352,10 @@ let mk_right_comb : sym -> term list -> term -> term = fun s ->
   List.fold_right (mk_bin s)
 
 (** Printing functions for debug. *)
+let var : var pp = fun ppf (i,n) -> out ppf "%s%d" n i
+let sym : sym pp = fun ppf s -> string ppf s.sym_name
+let path = Path.pp
+let qsym : sym pp = fun ppf s -> out ppf "%a.%s" path s.sym_path s.sym_name
 let rec term : term pp = fun ppf t ->
   match unfold t with
   | Bvar (InSub k) -> out ppf "`%d" k
@@ -375,8 +377,6 @@ let rec term : term pp = fun ppf t ->
   | LLet(a,t,(n,b,e)) ->
       out ppf "let %s:%a ≔ %a in %a#(%a)"
         n.binder_name term a term t terms e term b
-and var : var pp = fun ppf (i,n) -> out ppf "%s%d" n i
-and sym : sym pp = fun ppf s -> string ppf s.sym_name
 and terms : term array pp = fun ppf -> out ppf "[%a]" (Array.pp term ",")
 
 (** [unfold t] repeatedly unfolds the definition of the surface constructor
@@ -990,6 +990,7 @@ let new_problem : unit -> problem = fun () ->
 module Raw = struct
   let var = var let _ = var
   let sym = sym let _ = sym
+  let qsym = qsym let _ = qsym
   let term = term let _ = term
   let ctxt = ctxt let _ = ctxt
 end

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -36,8 +36,6 @@ type prop =
   | Assoc of bool (** Associative left if [true], right if [false]. *)
   | AC of bool (** Associative and commutative. *)
 
-val is_ac: prop -> bool
-
 (** Type for free variables. *)
 type var
 
@@ -462,9 +460,12 @@ val lhs : sym_rule -> term
 val rhs : sym_rule -> term
 
 (** Basic printing function (for debug). *)
+val qsym : sym pp
+
 module Raw : sig
   val var : var pp
   val sym : sym pp
+  val qsym : sym pp
   val term : term pp
   val ctxt : ctxt pp
 end

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -465,7 +465,6 @@ val qsym : sym pp
 module Raw : sig
   val var : var pp
   val sym : sym pp
-  val qsym : sym pp
   val term : term pp
   val ctxt : ctxt pp
 end

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -74,12 +74,12 @@ let handle_open : bool -> sig_state -> p_path -> sig_state =
   (* Check that [p] is not an alias. *)
   match p with
   | [a] when StrMap.mem a ss.alias_path ->
-      fatal pos "Module aliases cannot be open."
+    fatal pos "Module aliases cannot be open."
   | _ ->
-      (* Check that [p] has been required. *)
-      match Path.Map.find_opt p !loaded with
-      | None -> fatal pos "Module \"%a\" needs to be required first." path p
-      | Some _ -> rec_open (not prv) ss p
+    (* Check that [p] has been required. *)
+    match Path.Map.find_opt p !loaded with
+    | None -> fatal pos "Module \"%a\" needs to be required first." Path.pp p
+    | Some _ -> rec_open (not prv) ss p
 
 (** [rec_require compile ss p] handles the command [require p] with [ss] as
     signature state and [compile] as compilation function (passed as argument

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -55,10 +55,11 @@ let rec compile : Command.compiler = fun ss mp ->
       (*let open Base in sout "loaded:";
         Path.Map.iter (fun p _ -> sout " %a" Path.pp p) !loaded;
         sout "\n%!";*)
-      Tactic.reset_admitted();
+      let a = Tactic.reset_admitted() in
       let ss = Stdlib.ref (Sig_state.of_sign sign) in
       let consume cmd = Stdlib.(ss := Command.handle compile !ss cmd) in
       Debug.stream_iter consume (Parser.parse_file src);
+      Tactic.restore_admitted a;
       Console.out 1 (Color.blu "End checking \"%s\"") src;
       Sign.strip_private sign;
       if Stdlib.(!gen_obj) then begin

--- a/src/handle/query.ml
+++ b/src/handle/query.ml
@@ -152,10 +152,9 @@ let handle : Sig_state.t -> proof_state option -> p_query -> result =
         | Some ps -> return Proof.goals ps
       end
   | P_query_print Builtin ->
-    let sym ppf s = out ppf "%a.%a" path s.sym_path uid s.sym_name in
     let def ppf n =
       match Extra.StrMap.find_opt n ss.builtins with
-      | Some s -> out ppf " ≔ %a" sym s
+      | Some s -> out ppf " ≔ %a" qsym s
       | None -> ()
     in
     let f n _ acc = Format.asprintf "builtin \"%s\"%a;" n def n :: acc in

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -17,7 +17,9 @@ let log = log.pp
     new compiled module. *)
 let admitted_initial_value = min_int
 let admitted : int Stdlib.ref = Stdlib.ref admitted_initial_value
-let reset_admitted() = Stdlib.(admitted := admitted_initial_value)
+let reset_admitted() =
+  Stdlib.(let a = !admitted in admitted := admitted_initial_value; a)
+let restore_admitted (a:int) = Stdlib.(admitted := a)
 
 (** [add_axiom ss sym_pos m] adds in signature state [ss] a new axiom symbol
     of type [!(m.meta_type)] and instantiate [m] with it. WARNING: It does not

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -478,7 +478,7 @@ module DB = struct
       ^^
       (colorizer "%s")
       ^^ "%s@%s%s%a%s%s%s%a%s%s%a%s%s%a%s%s%s%s@.")
-      lisb (escaper.run Core.Print.path) p boldb n bolde
+      lisb (escaper.run Path.pp) p boldb n bolde
       (popt_to_string ~print_dirname:false pos)
       separator (generic_pp_of_position_list ~escaper ~sep) positions
       separator preb codeb
@@ -719,7 +719,7 @@ let index_term_and_subterms ~is_spine t item =
  let tn = normalize t in
  (*
  let pp_item ppf (((p,n),_ ), _) =
-   Lplib.Base.out ppf "%a.%s" Core.Print.path p n in
+   Lplib.Base.out ppf "%a.%s" Path.pp p n in
  Format.printf "%a :(%a) REWRITTEN TO (%a)@."
   pp_item (item (DB.Conclusion DB.Exact))
   Core.Print.term t Core.Print.term tn ;


### PR DESCRIPTION
A.lp:
```
symbol A:TYPE;
```
B.lp:
```
symbol B:TYPE;
```
bug.lp
```
require open Stdlib.A;
symbol a:A ≔ begin admit end;
require open Stdlib.B;
symbol b:B ≔ begin admit end;
```
was generating 2 axioms with the same name (namely _ax0) because each require reset the axiom counter.
This PR:
- fixes that bug (in compile.ml and tactic.ml)
- make Sign.add_symbol check that the signature does not already have a symbol with the same name
- add Term.qsym
- remove Print.path (= Path.pp)
- replace Term.is_ac by Term.is_modulo