### PR TITLE
do not take into account extra rules when checking a dependency

### DIFF
--- a/src/core/sig_state.ml
+++ b/src/core/sig_state.ml
@@ -152,3 +152,19 @@ let find_sym : find_sym = fun ~prt ~prv ss {elt=(mp,s); pos} ->
       fatal pos "Protected symbol not allowed here."
   | (_    , false, Privat) -> fatal pos "Private symbol not allowed here."
   | _                      -> s
+
+(** [update_ext_sym_dtrees b ss] updates the decision trees of external
+    symbols by adding (resp. removing) extra rules if [b] is true
+    (resp. false). *)
+let update_ext_sym_dtrees (b:bool) (ss:sig_state): unit =
+  Path.Map.iter (fun p dd ->
+      let sign = try Path.Map.find p !loaded with Not_found -> assert false in
+      StrMap.iter (fun n sd ->
+          let s = try Sign.find sign n with Not_found -> assert false in
+          if sd.rules <> [] then
+            if b then Tree.update s
+            else let neq r1 r2 = not (eq_lhs r1 r2) in
+              let is_not_extra r = List.for_all (neq r) sd.rules in
+              Tree.set_dtree s (List.filter is_not_extra !(s.sym_rules))
+        ) dd.dep_symbols
+    ) !(ss.signature.sign_deps)

--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -144,7 +144,7 @@ let link : t -> unit = fun sign ->
     s.sym_type := link_term !(s.sym_type);
     s.sym_def := Option.map link_term !(s.sym_def);
     s.sym_rules := List.map link_rule !(s.sym_rules);
-    Tree.update_dtree s []
+    Tree.update s
   in
   StrMap.iter f !(sign.sign_symbols);
   let f mp {dep_symbols=sm; _} =
@@ -155,7 +155,7 @@ let link : t -> unit = fun sign ->
         let s = try find sign n with Not_found -> assert false in
         s.sym_rules := !(s.sym_rules) @ List.map link_rule sd.rules;
         Option.iter (fun n -> s.sym_nota := n) sd.nota;
-        Tree.update_dtree s []
+        Tree.update s
       in
       StrMap.iter g sm
   in

--- a/src/core/term.ml
+++ b/src/core/term.ml
@@ -464,6 +464,11 @@ and cmp_binder : binder cmp =
   fun (_,u,e) (_,u',e') ->
   lex cmp (Array.cmp cmp) (u,e) (u',e')
 
+and eq : term eq = fun t u -> cmp t u = 0
+
+and eq_lhs r1 r2 =
+  try List.for_all2 eq r1.lhs r2.lhs with Invalid_argument _ -> false
+
 (** [get_args t] decomposes the {!type:term} [t] into a pair [(h,args)], where
     [h] is the head term of [t] and [args] is the list of arguments applied to
     [h] in [t]. The returned [h] cannot be an [Appl] node. *)
@@ -941,6 +946,9 @@ type sym_rule = sym * rule
 let lhs : sym_rule -> term = fun (s, r) -> add_args (mk_Symb s) r.lhs
 let rhs : sym_rule -> term = fun (_, r) -> r.rhs
 
+let sym_rule : sym_rule pp = fun ppf (s,r) ->
+  out ppf "%a%a ↪ %a" sym s (List.pp (prefix " " term) "") r.lhs term r.rhs
+
 (** Positions in terms in reverse order. The i-th argument of a constructor
    has position i-1. *)
 type subterm_pos = int list
@@ -990,5 +998,6 @@ module Raw = struct
   let var = var let _ = var
   let sym = sym let _ = sym
   let term = term let _ = term
+  let sym_rule = sym_rule let _ = sym_rule
   let ctxt = ctxt let _ = ctxt
 end

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -327,8 +327,12 @@ val get_args : term -> term * term list
     of the list of arguments. *)
 val get_args_len : term -> term * term list * int
 
-(** Total orders terms. *)
+(** Total order on terms (modulo alpha-equivalence). *)
 val cmp : term cmp
+
+(** Equality on terms (modulo alpha-equivalence) and rules. *)
+val eq : term eq
+val eq_lhs : rule eq
 
 (** Construction functions of the private type term. They ensure some
    invariants:
@@ -466,5 +470,6 @@ module Raw : sig
   val var : var pp
   val sym : sym pp
   val term : term pp
+  val sym_rule : sym_rule pp
   val ctxt : ctxt pp
 end

--- a/src/core/tree.ml
+++ b/src/core/tree.ml
@@ -770,11 +770,14 @@ let compile : match_strat -> CM.t -> tree = fun mstrat m ->
   in
   compile VarMap.empty m
 
-(** [update_dtree s rs] updates the decision tree of the symbol [s] by adding
-   rules [rs]. *)
-let update_dtree : sym -> rule list -> unit = fun symb rs ->
-  let rs = if rs = [] then !(symb.sym_rules) else !(symb.sym_rules) @ rs in
+(** [set_dtree s rs] resets [s.sym_dtree] with the rules [rs]. *)
+let set_dtree : sym -> rule list -> unit = fun s rs ->
   let cm = lazy (CM.of_rules rs) in
-  let tree = lazy (compile symb.sym_mstrat (Lazy.force cm)) in
+  let tree = lazy (compile s.sym_mstrat (Lazy.force cm)) in
   let cap = lazy (Tree_type.tree_capacity (Lazy.force tree)) in
-  symb.sym_dtree := (cap, tree)
+  s.sym_dtree := (cap, tree)
+
+(** [update s] resets [s.sym_dtree] with [s.sym_rules]. *)
+let update (s:sym): unit = set_dtree s !(s.sym_rules)
+
+let add_and_update s rs = set_dtree s (!(s.sym_rules) @ rs)

--- a/src/handle/command.ml
+++ b/src/handle/command.ml
@@ -270,7 +270,7 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
       let srs, map = List.fold_right handle_rule rs ([], SymMap.empty) in
       (* /!\ Update decision trees without adding the rules themselves. It is
          important for local confluence checking. *)
-      SymMap.iter Tree.update_dtree map;
+      SymMap.iter Tree.add_and_update map;
       let sign = ss.signature in
       (* Local confluence checking. *)
       Tool.Lcr.check_cps pos sign srs map;
@@ -334,14 +334,14 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
       let lhs = match r1.lhs with [x;y] -> [y;x] | _ -> assert false in
       let r2 = {r1 with lhs} in
       Sign.add_rules ss.signature s [r1;r2];
-      Tree.update_dtree Unif_rule.equiv [];
+      Tree.update Unif_rule.equiv;
       Console.out 2 (Color.gre "unif_rule %a") sym_rule x;
       Console.out 2 (Color.gre "unif_rule %a") sym_rule (s,r2);
       (ss, None, None)
   | P_coercion c ->
       let r = scope_rule false ss c in
       Sign.add_rule ss.signature r;
-      Tree.update_dtree Coercion.coerce [];
+      Tree.update Coercion.coerce;
       Console.out 2 (Color.gre "coercion %a") sym_rule r;
       (ss, None, None)
 
@@ -433,7 +433,7 @@ let get_proof_data : compiler -> sig_state -> p_command -> cmd_output =
         Console.out 2 (Color.gre "rule %a") sym_rule r
       in
       no_wrn (Inductive.iter_rec_rules pos ind_list vs ind_pred_map) add_rule;
-      List.iter (fun s -> Tree.update_dtree s []) rec_sym_list;
+      List.iter Tree.update rec_sym_list;
       (* Store the inductive structure in the signature *)
       let ind_nb_types = List.length ind_list in
       List.iter2

--- a/src/handle/compile.ml
+++ b/src/handle/compile.ml
@@ -56,9 +56,13 @@ let rec compile : Command.compiler = fun ss mp ->
         Path.Map.iter (fun p _ -> sout " %a" Path.pp p) !loaded;
         sout "\n%!";*)
       let a = Tactic.reset_admitted() in
-      let ss = Stdlib.ref (Sig_state.of_sign sign) in
-      let consume cmd = Stdlib.(ss := Command.handle compile !ss cmd) in
+      Sig_state.update_ext_sym_dtrees false ss;
+      let consume =
+        let new_ss = Stdlib.ref (Sig_state.of_sign sign) in
+        fun cmd -> Stdlib.(new_ss := Command.handle compile !new_ss cmd)
+      in
       Debug.stream_iter consume (Parser.parse_file src);
+      Sig_state.update_ext_sym_dtrees true ss;
       Tactic.restore_admitted a;
       Console.out 1 (Color.blu "End checking \"%s\"") src;
       Sign.strip_private sign;
@@ -88,7 +92,7 @@ let rec compile : Command.compiler = fun ss mp ->
           match Extra.StrMap.find_opt "String" !(sign.sign_builtins) with
           | Some sym_String -> s.sym_type := Term.mk_Symb sym_String
           | None -> assert false
-        else Tree.update_dtree s []
+        else Tree.update s
       in
       Ghost.iter update;
       if Stdlib.(!Common.Console.lsp_mod) then Tool.Indexing.index_sign sign;

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -609,7 +609,7 @@ let load_meta_rules () =
    let h = function Some rs -> Some(r::rs) | None -> Some[r] in
    SymMap.update s h map in
  let map = List.fold_left handle_rule SymMap.empty rules in
- SymMap.iter Tree.update_dtree map;
+ SymMap.iter Tree.set_dtree map;
  SymMap.fold
   (fun sym _rs map' ->
     QNameMap.add (name_of_sym sym) (Timed.(!(sym.sym_dtree))) map')

--- a/tests/OK/1435.lp
+++ b/tests/OK/1435.lp
@@ -1,0 +1,5 @@
+require open tests.OK.Nat;
+
+rule + $x 0 ↪ $x;
+
+require tests.OK.1435_part2;

--- a/tests/OK/1435_part2.lp
+++ b/tests/OK/1435_part2.lp
@@ -1,0 +1,8 @@
+require open tests.OK.Nat;
+
+opaque symbol plus_z_r (x:ℕ) : π (x + 0 = x) ≔
+begin
+  induction
+  { reflexivity }
+  { assume x' h; simplify; rewrite h; reflexivity }
+end;

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -59,7 +59,7 @@ do
         # module alias
         alias);;
         # proofs
-        why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit|change|assumption|focus|assume|first_hyp|all_hyps);;
+        why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit|change|assumption|focus|assume|first_hyp|all_hyps|1435_part2|1435);;
         # "open"
         triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|1374|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod|Conj|Disj|ExtraRules|Univ);;
         # "inductive"

--- a/tests/rewriting.ml
+++ b/tests/rewriting.ml
@@ -35,7 +35,7 @@ let arrow_matching () =
   (* Matching on a product. *)
   let (c, _) as rule = parse_rule "rule C (A → A) ↪ Ok;" in
   Sign.add_rule sig_state.signature rule;
-  Tree.update_dtree c [];
+  Tree.update c;
   let lhs = parse_term "C (A → A)" |> scope_term sig_state in
   Alcotest.(check bool)
     "C (A → A) matches C (A → A)"
@@ -48,7 +48,7 @@ let arrow_matching = Timed.pure_apply arrow_matching
 let prod_matching () =
   let (c,_) as rule = parse_rule "rule C (Π _: _, A) ↪ Ok;" in
   Sign.add_rule sig_state.signature rule;
-  Tree.update_dtree c [];
+  Tree.update c;
   let lhs = parse_term "C (A → A)" |> scope_term sig_state in
   Alcotest.(check bool)
     "C (A → A) matches C (Π _: _, A)"
@@ -61,7 +61,7 @@ let arrow_default () =
   (* Assert that a product can be considered as a default case. *)
   let (c,_) as rule = parse_rule "rule C _ ↪ Ok;" in
   Sign.add_rule sig_state.signature rule;
-  Tree.update_dtree c [];
+  Tree.update c;
   let lhs = parse_term "C (A → A)" |> scope_term sig_state in
   Alcotest.(check bool)
     "C (A → A) matches C _"
@@ -74,7 +74,7 @@ let arrow_default = Timed.pure_apply arrow_default
 let type_matching () =
   let rule = parse_rule "rule C TYPE ↪ Ok;" in
   Sign.add_rule sig_state.signature rule;
-  Tree.update_dtree c [];
+  Tree.update c;
   let lhs = parse_term "C TYPE" |> scope_term sig_state in
   Alcotest.(check bool)
     "C TYPE matches C TYPE"
@@ -86,7 +86,7 @@ let type_matching = Timed.pure_apply type_matching
 let type_default () =
   let rule = parse_rule "rule C _ ↪ Ok;" in
   Sign.add_rule sig_state.signature rule;
-  Tree.update_dtree c [];
+  Tree.update c;
   let lhs = parse_term "C TYPE" |> scope_term sig_state in
   Alcotest.(check bool)
     "C TYPE matches C _"


### PR DESCRIPTION
A require M command can fail, even though lambdapi check M succeeds, if in previous commands (including previous requires), some rules are added on symbols defined or used in M (issue #1435). This PR fixes this problem by updating the decision trees of external symbols before and after requires (using the fact that, for a symbol s, s.sym_dtree does not need to be in sync with s.sym_rules). 
- Sig_state: add update_ext_sym_dtrees
- Tree: rename update_dtree into add_and_update, and add update and add set_dtree
- Term: add eq, eq_lhs and Raw.sym_rule