### PR TITLE
Check version of the indexing DB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Export to Lean.
 - Tactic `all_hyps t` calls parameterized tactic term t on all hypotheses ignoring failing calls.
 - Extend `print` query to the following arguments: `verbose`, `debug`, `flag`, `builtin`, `prover`, `prover_timeout`.
+- add a version number to the header of the index db file to prevent crash of LP when the structure of db changes.
 
 ### Changed
 

--- a/src/tool/indexing.ml
+++ b/src/tool/indexing.ml
@@ -2,6 +2,8 @@ open Core open Term
 open Common open Pos
 open Timed
 
+let index_version = "v.1.0.0"
+
 let lsp_input = Stdlib.ref ("","")
 
 type sym_name = Common.Path.t * string
@@ -24,11 +26,20 @@ let name_of_sym s = (s.sym_path, s.sym_name)
 
 let dump_to ~filename i =
  let ch = open_out_bin filename in
+ output_string ch index_version;
  Marshal.to_channel ch i [] ;
  close_out ch
 
 let restore_from ~filename =
   let ch = open_in_bin filename in
+
+  let buffer = Bytes.create (String.length index_version) in
+  really_input ch buffer 0 (String.length index_version);
+  if Bytes.unsafe_to_string buffer <> index_version then
+    Error.fatal_no_pos "Wrong search index version!
+      Please (re)move or regenerate the index DB
+      (default is ~/.LPSearch.db)";
+
   let i = Marshal.from_channel ch in
   close_in ch ;
   i
@@ -318,7 +329,9 @@ module DB = struct
       Type \"lambdapi index --help\" to learn how to create the index." msg ;
      Sym_nameMap.empty, Index.empty
 
- (* The persistent database *)
+ (* The persistent database.
+ Please increment the value of [index_version] in the header of this file
+ whenever the structure of db changes to prevent SIGSEGV to occur *)
  let db :
   ((string * string * int * int) Sym_nameMap.t *
    (item * position list) Index.db) Lazy.t ref =


### PR DESCRIPTION
This PR adds a version number at the beginning of the search index file. It also verifies this version and fails with a clear error if the existing search index structure does not match the current one (instead of crashing consequently to a segmentation error)

Fixes: #1479, Fixes #1458, Fixes #1437