### PR TITLE
fix conversion from term to p_term

### DIFF
--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -274,7 +274,14 @@ let p_term (ss:Sig_state.t) (pos:popt): int StrMap.t -> term -> p_term =
     match unfold t with
     | Type -> P_Type
     | Symb s ->
-      let mp = if StrMap.mem s.sym_name ss.in_scope then [] else s.sym_path in
+      let mp =
+        match StrMap.find_opt s.sym_name ss.in_scope with
+        | Some s' when s' == s -> []
+        | _ ->
+          match Path.Map.find_opt s.sym_path ss.path_alias with
+          | Some a -> [a]
+          | _ -> s.sym_path
+      in
       let expl = s.sym_impl <> [] in
       let t = P_Iden(Pos.make pos (mp,s.sym_name),expl) in
       if !(s.sym_nota) = NoNotation then t else P_Wrap (Pos.make pos t)
@@ -784,7 +791,8 @@ let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
         if List.length new_ps.proof_goals < List.length ps.proof_goals
         then new_ps
         else handle new_ps tac
-        with Fatal _ -> ps
+        with Fatal(_,s,_) ->
+          if Logger.log_enabled() then log "repeat stopped with: %s" s; ps
       end
   | P_tac_and(t1,t2) -> handle (handle ps t1) t2
   | P_tac_eval pt ->

--- a/src/parsing/scope.ml
+++ b/src/parsing/scope.ml
@@ -196,8 +196,8 @@ and scope_parsed : ?find_sym:find_sym ->
 
 (** [add_impl ~find_sym k md ss env loc h impl args] scopes [args] and returns
     the application of [h] to the scoped arguments. [impl] is a boolean list
-    described the implicit arguments. Implicit arguments are added as
-    underscores before scoping. *)
+    describing what are the implicit arguments. Implicit arguments are added
+    as underscores before scoping. *)
 and add_impl : ?find_sym:find_sym -> int -> mode -> sig_state ->
                Env.t -> popt -> term -> bool list -> p_term list -> term =
   fun ?find_sym k md ss env loc h impl args ->

--- a/tests/OK/1493.lp
+++ b/tests/OK/1493.lp
@@ -1,0 +1,40 @@
+require open tests.OK.FOL tests.OK.HOL tests.OK.Eq tests.OK.FunExt
+  tests.OK.Impred tests.OK.Tactic;
+
+symbol eps : τ ((ι ⤳ o) ⤳ ι);
+symbol if : τ (o ⤳ ι ⤳ ι ⤳ ι);
+symbol a : τ ι;
+symbol b : τ ι;
+
+symbol if_def :
+  π (if =
+     (λ (p : τ o), λ (x : τ ι), λ (y : τ ι),
+        eps (λ (z : τ ι), (p ∧ z = x) ∨ (¬ p ∧ z = y))));
+
+opaque symbol direct_eval_rewrite_ok :
+  π ((¬ (if ⊤ a b = a)) ⇒
+     (¬ (eps (λ (z : τ ι), (⊤ ∧ z = a) ∨ (¬ ⊤ ∧ z = b)) = a))) ≔
+begin
+  eval (#rewrite "" "" if_def);
+  assume h;
+  refine h
+end;
+
+opaque symbol parser_repeat_rewrite_ok :
+  π ((¬ (if ⊤ a b = a)) ⇒
+     (¬ (eps (λ (z : τ ι), (⊤ ∧ z = a) ∨ (¬ ⊤ ∧ z = b)) = a))) ≔
+begin
+  repeat rewrite if_def;
+  assume h;
+  refine h
+end;
+
+opaque symbol repro :
+
+  π ((¬ (if ⊤ a b = a)) ⇒
+     (¬ (eps (λ (z : τ ι), (⊤ ∧ z = a) ∨ (¬ ⊤ ∧ z = b)) = a))) ≔
+begin
+  eval (#repeat (#rewrite "" "" if_def));
+  assume h;
+  refine h
+end;

--- a/tests/export_dk.sh
+++ b/tests/export_dk.sh
@@ -45,11 +45,9 @@ do
         # require escaped module name
         π/utf_path|escape_path|'a b/escape file'|require_nondkmident|262_pair_ex_2|require_symbol);;
         # use builtin strings
-        Tactic|1374);;
-        # use Tactic
-        first_hyp|all_hyps);;
-        # requires an excluded file
-        assume|first_hyp);;
+        Tactic);;
+        # requires Tactic
+        1374|assume|first_hyp|all_hyps|1493);;
         # default case
         *) translate $f.lp;;
     esac

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -60,7 +60,7 @@ do
         # proofs
         why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit|change|assumption|focus|assume|first_hyp|all_hyps|1435_part2|1435);;
         # "open"
-        triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|1374|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod|Conj|Disj|ExtraRules|Univ);;
+        triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|1374|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod|Conj|Disj|ExtraRules|Univ|1493);;
         # "inductive"
         strictly_positive_*|inductive|989|904|830|341|1392|1407);;
         # underscore in query


### PR DESCRIPTION
The conversion from term to p_term was incorrectly translating a symbol s whose base name n is in scope to the unqualified ident n. Indeed, it may happen that the symbol s' corresponding to n is different from s.

fix #1493 