### PR TITLE
allow -v 0 instead of -v0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Type of `#assume` in order to generate a new symbol and use it inside a tactic term.
 - Errors occurring while a proof is in progress now report the proof state: the goals a failing tactic was applied to, the goals before and after the tactic for a subproof-count mismatch, and the remaining goals when a proof is unfinished at `end`. The state is printed after the error message, which stays unchanged. The LSP server does not attach the proof state to tactic failures since editors display it themselves.
 - Lambdapi does not use Cmdliner anymore.
-- Lambdapi does not accept as option '-v $n' anymore. Use '-v$n' instead.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ test_why3: lambdapi
 .PHONY: test_libs
 test_libs: lambdapi
 	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-stdlib.git
-	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-zenon.git
 	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-logics.git
 
 #### Library tests ###########################################################

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,9 @@ test_why3: lambdapi
 
 .PHONY: test_libs
 test_libs: lambdapi
-	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-logics.git
 	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-stdlib.git
+	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-zenon.git
+	@tests/test_lib.sh https://github.com/Deducteam/lambdapi-logics.git
 
 #### Library tests ###########################################################
 

--- a/src/cli/main.ml
+++ b/src/cli/main.ml
@@ -154,10 +154,10 @@ let opt_debug =
   Stdlib.String.concat "" (List.map f (Common.Logger.log_summary())) }
 
 let opt_verbose =
-  { opt_name = "--verbose="
+  { opt_name = "--verbose"
   ; opt_short = Some "-v"
   ; opt_handle =
-      Suffix("INT",
+      Next("INT",
              fun v -> Common.Console.set_default_verbose (nat_of_string v))
   ; opt_desc =
 {|Set the verbosity level to INT. A value smaller or equal to 0 will disable

--- a/tests/dtrees.sh
+++ b/tests/dtrees.sh
@@ -16,7 +16,7 @@ ok() {
 }
 
 lambdapi='_build/install/default/bin/lambdapi'
-cmd='decision-tree -v0 -w --map-dir=tests:tests'
+cmd='decision-tree -v 0 -w --map-dir=tests:tests'
 
 out="$($lambdapi $cmd tests.OK.natural.+)"
 if [ -z "$out" ]; then

--- a/tests/export_dk.sh
+++ b/tests/export_dk.sh
@@ -20,7 +20,7 @@ reset_outdir
 translate() {
     out=$outdir/${1%.lp}.dk
     echo "$1 --> $out ..."
-    $lambdapi export -w -v0 -o dk $1 > $out
+    $lambdapi export -w -v 0 -o dk $1 > $out
     if test $? -ne 0; then echo KO; exit 1; fi
 }
 

--- a/tests/export_lp.sh
+++ b/tests/export_lp.sh
@@ -22,7 +22,7 @@ translate() {
             tests/OK/why3*.lp|tests/OK/search.lp);; #FIXME
             *) out=/tmp/$f
                echo "$f --> $out ..."
-               $lambdapi export -o lp -w -v0 "$f" > "$out"
+               $lambdapi export -o lp -w -v 0 "$f" > "$out"
                if test $? -ne 0; then echo KO; exit 1; fi
         esac
     done
@@ -38,7 +38,7 @@ check() {
             /tmp/tests/OK/why3*.lp);; # FIXME
             /tmp/tests/OK/perf_rw_engine.lp);; # takes too much time
             *) echo "lambdapi check $f ..."
-               $lambdapi check -w -v0 "$f"
+               $lambdapi check -w -v 0 "$f"
                if test $? -ne 0; then echo KO; exit 1; fi
         esac
     done

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -20,7 +20,7 @@ reset_outdir
 translate() {
     out=$outdir/${1%.lp}.dk
     echo "$1 --> $out ..."
-    $lambdapi export -w -v0 -o raw_dk $1 > $out
+    $lambdapi export -w -v 0 -o raw_dk $1 > $out
     if test $? -ne 0; then echo KO; exit 1; fi
 }
 

--- a/tests/test_load.sh
+++ b/tests/test_load.sh
@@ -23,7 +23,7 @@ FILES := $FILES
 default: \$(FILES:%.lp=%.lpo)
 %.lpo: %.lp
 	@echo lambdapi check \$(OPTION) \$<
-	@$lambdapi check -w -v0 \$(OPTION) \$<
+	@$lambdapi check -w -v 0 \$(OPTION) \$<
 __END__
 for f in $FILES
 do


### PR DESCRIPTION
revert change introduced in #1333 : keep allowing "-v 0" instead of enforcing "-v0"