### PR TITLE
Fix error location reporting for required files in LP console

### DIFF
--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -133,6 +133,7 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
   | Cmd_Error(err_loc, err_msg) ->
     let nodes = { cmd; exec = false; goals = [] } :: nodes in
     let loc, diag_msg, log_msg = match cmd_loc, err_loc with
+    | _, Some None -> cmd_loc, err_msg, err_msg
     | Some l, Some Some l' ->
         if l.fname = l'.fname then
           (* if the error is in the same file as the command,
@@ -155,8 +156,9 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
           cmd_loc,
           Pos.popt_to_string (Some l') ^ "\n" ^ err_msg,
           Pos.popt_to_string (Some l') ^ "\n" ^ err_msg
-    | _, Some l' -> cmd_loc, err_msg, Pos.popt_to_string (l') ^ "\n" ^ err_msg
-    | _, None -> cmd_loc, err_msg, err_msg in
+    | None, _ -> assert false
+    | _, None -> assert false
+    in
     nodes, st, (loc, 1, diag_msg, None) :: dg, ((1, log_msg), loc) :: logs
 
 let new_doc ~uri ~version ~text =

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -132,20 +132,20 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
 
   | Cmd_Error(loc, msg) ->
     let nodes = { cmd; exec = false; goals = [] } :: nodes in
-    let cmd_loc, loc, diag, log = match cmd_loc, loc with
+    let cmd_loc, diag, log = match cmd_loc, loc with
     | Some l, Some Some l' ->
         if l.fname = l'.fname then
           (* if error in the same file, use the precise location *)
-          Some l', Some l', msg, Pos.popt_to_string (Some l') ^ msg
+          Some l', msg, Pos.popt_to_string (Some l') ^ msg
         else
           (* else, use the location of the command *)
-          cmd_loc, Some l', Pos.popt_to_string (Some l') ^ "\n" ^ msg
+          cmd_loc, Pos.popt_to_string (Some l') ^ "\n" ^ msg
             , Pos.popt_to_string (Some l') ^ "\n" ^ msg
     (* Otherwise,
       cmd_loc doesn't change and loc is : option_default loc cmd_loc *)
-    | _, Some l' -> cmd_loc, l', msg, Pos.popt_to_string (l') ^ "\n" ^ msg
-    | _, None -> cmd_loc, cmd_loc, msg, msg in
-    nodes, st, (cmd_loc, 1, diag, None) :: dg, ((1, log), loc) :: logs
+    | _, Some l' -> cmd_loc, msg, Pos.popt_to_string (l') ^ "\n" ^ msg
+    | _, None -> cmd_loc, msg, msg in
+    nodes, st, (cmd_loc, 1, diag, None) :: dg, ((1, log), cmd_loc) :: logs
 
 let new_doc ~uri ~version ~text =
   let root, logs =

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -212,7 +212,13 @@ let check_text ~doc =
     match error with
     | None -> logs, diags
     | Some(pos,msg) ->
-      logs @ [((1, (Pos.popt_to_string (Some pos) ^ ": " ^ msg)), Some pos)],
+      logs @ [
+        ((1,
+        (Pos.popt_to_string
+          ~print_dirname:false
+          ~print_fname:false
+          (Some pos) ^ ": " ^ msg)),
+        Some pos)],
       diags @ [pos,1,msg,None]
   in
   let map = Pure.rangemap cmds in

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -130,33 +130,34 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
     in
     nodes, st, dg_proof @ dg, logs
 
-  | Cmd_Error(loc, msg) ->
+  | Cmd_Error(err_loc, err_msg) ->
     let nodes = { cmd; exec = false; goals = [] } :: nodes in
-    let cmd_loc, diag, log = match cmd_loc, loc with
+    let loc, diag_msg, log_msg = match cmd_loc, err_loc with
     | Some l, Some Some l' ->
         if l.fname = l'.fname then
-          (* if error in the same file, use the precise location *)
+          (* if the error is in the same file as the command,
+            we set the diag/log position to the error position
+            and add the error position in the log message *)
           let log_msg =
             let form = Format.formatter_of_buffer lp_logger in
             Color.update_with_color form;
             Format.fprintf (form) (Color.red "[%s] %s") (Pos.popt_to_string
               ~print_dirname:false
               ~print_fname:false
-              (Some l')) msg;
+              (Some l')) err_msg;
             Format.pp_print_flush form ();
             buf_get_and_clear lp_logger
           in
-          Some l', msg, log_msg
+          Some l', err_msg, log_msg
         else
-          (* else, use the location of the command *)
+          (* otherwise we set the diag/log position to the command position
+            and add the error position to both the diag and log messages *)
           cmd_loc,
-          Pos.popt_to_string (Some l') ^ "\n" ^ msg,
-          Pos.popt_to_string (Some l') ^ "\n" ^ msg
-    (* Otherwise,
-      cmd_loc doesn't change and loc is : option_default loc cmd_loc *)
-    | _, Some l' -> cmd_loc, msg, Pos.popt_to_string (l') ^ "\n" ^ msg
-    | _, None -> cmd_loc, msg, msg in
-    nodes, st, (cmd_loc, 1, diag, None) :: dg, ((1, log), cmd_loc) :: logs
+          Pos.popt_to_string (Some l') ^ "\n" ^ err_msg,
+          Pos.popt_to_string (Some l') ^ "\n" ^ err_msg
+    | _, Some l' -> cmd_loc, err_msg, Pos.popt_to_string (l') ^ "\n" ^ err_msg
+    | _, None -> cmd_loc, err_msg, err_msg in
+    nodes, st, (loc, 1, diag_msg, None) :: dg, ((1, log_msg), loc) :: logs
 
 let new_doc ~uri ~version ~text =
   let root, logs =

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -136,11 +136,17 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
     | Some l, Some Some l' ->
         if l.fname = l'.fname then
           (* if error in the same file, use the precise location *)
-          Some l', msg, Pos.popt_to_string (Some l') ^ msg
+          Some l',
+          msg,
+          Pos.popt_to_string
+            ~print_dirname:false
+            ~print_fname:false
+            (Some l') ^ " " ^ msg
         else
           (* else, use the location of the command *)
-          cmd_loc, Pos.popt_to_string (Some l') ^ "\n" ^ msg
-            , Pos.popt_to_string (Some l') ^ "\n" ^ msg
+          cmd_loc,
+          Pos.popt_to_string (Some l') ^ "\n" ^ msg,
+          Pos.popt_to_string (Some l') ^ "\n" ^ msg
     (* Otherwise,
       cmd_loc doesn't change and loc is : option_default loc cmd_loc *)
     | _, Some l' -> cmd_loc, msg, Pos.popt_to_string (l') ^ "\n" ^ msg

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -136,12 +136,17 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
     | Some l, Some Some l' ->
         if l.fname = l'.fname then
           (* if error in the same file, use the precise location *)
-          Some l',
-          msg,
-          Pos.popt_to_string
-            ~print_dirname:false
-            ~print_fname:false
-            (Some l') ^ " " ^ msg
+          let log_msg =
+            let form = Format.formatter_of_buffer lp_logger in
+            Color.update_with_color form;
+            Format.fprintf (form) (Color.red "[%s] %s") (Pos.popt_to_string
+              ~print_dirname:false
+              ~print_fname:false
+              (Some l')) msg;
+            Format.pp_print_flush form ();
+            buf_get_and_clear lp_logger
+          in
+          Some l', msg, log_msg
         else
           (* else, use the location of the command *)
           cmd_loc,
@@ -212,14 +217,18 @@ let check_text ~doc =
     match error with
     | None -> logs, diags
     | Some(pos,msg) ->
-      logs @ [
-        ((1,
+      let log_msg =
+        let form = Format.formatter_of_buffer lp_logger in
+        Color.update_with_color form;
+        Format.fprintf (form) (Color.red "[%s] %s")
         (Pos.popt_to_string
           ~print_dirname:false
           ~print_fname:false
-          (Some pos) ^ ": " ^ msg)),
-        Some pos)],
-      diags @ [pos,1,msg,None]
+          (Some pos)) msg;
+        Format.pp_print_flush form ();
+        buf_get_and_clear lp_logger
+      in
+      logs @ [((1, log_msg),Some pos)], diags @ [pos,1,msg,None]
   in
   let map = Pure.rangemap cmds in
   let doc = { doc with nodes; final=Some(final); map; logs } in

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -205,7 +205,9 @@ let check_text ~doc =
   let logs, diags =
     match error with
     | None -> logs, diags
-    | Some(pos,msg) -> logs @ [((1, msg), Some pos)], diags @ [pos,1,msg,None]
+    | Some(pos,msg) ->
+      logs @ [((1, (Pos.popt_to_string (Some pos) ^ ": " ^ msg)), Some pos)],
+      diags @ [pos,1,msg,None]
   in
   let map = Pure.rangemap cmds in
   let doc = { doc with nodes; final=Some(final); map; logs } in

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -54,6 +54,18 @@ let buf_get_and_clear buf =
   let res = Buffer.contents buf in
   Buffer.clear buf; res
 
+(* Format an error message with its position for logging. *)
+let format_error_msg error_msg error_pos =
+  let form = Format.formatter_of_buffer lp_logger in
+  Color.update_with_color form;
+  Format.fprintf (form) (Color.red "[%s] %s")
+    (Pos.popt_to_string
+      ~print_dirname:false
+      ~print_fname:false
+      (Some error_pos)) error_msg;
+  Format.pp_print_flush form ();
+  buf_get_and_clear lp_logger
+
 let process_pstep (pstate,diags,logs) tac nb_subproofs =
   let open Pure in
   let tac_loc = Tactic.get_pos tac in
@@ -142,16 +154,7 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
           (* if the error is in the same file as the command,
             we set the diag/log position to the error position
             and add the error position in the log message *)
-          let log_msg =
-            let form = Format.formatter_of_buffer lp_logger in
-            Color.update_with_color form;
-            Format.fprintf (form) (Color.red "[%s] %s") (Pos.popt_to_string
-              ~print_dirname:false
-              ~print_fname:false
-              (Some l')) err_msg;
-            Format.pp_print_flush form ();
-            buf_get_and_clear lp_logger
-          in
+          let log_msg = format_error_msg err_msg l' in
           Some l', err_msg, log_msg
         else
           (* otherwise we set the diag/log position to the command position
@@ -221,17 +224,7 @@ let check_text ~doc =
     match error with
     | None -> logs, diags
     | Some(error_pos,error_msg) ->
-      let log_msg =
-        let form = Format.formatter_of_buffer lp_logger in
-        Color.update_with_color form;
-        Format.fprintf (form) (Color.red "[%s] %s")
-        (Pos.popt_to_string
-          ~print_dirname:false
-          ~print_fname:false
-          (Some error_pos)) error_msg;
-        Format.pp_print_flush form ();
-        buf_get_and_clear lp_logger
-      in
+      let log_msg = format_error_msg error_msg error_pos in
       logs @ [((1, log_msg),Some error_pos)],
       diags @ [error_pos,1,error_msg,None]
   in

--- a/src/lsp/lp_doc.ml
+++ b/src/lsp/lp_doc.ml
@@ -133,6 +133,9 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
   | Cmd_Error(err_loc, err_msg) ->
     let nodes = { cmd; exec = false; goals = [] } :: nodes in
     let loc, diag_msg, log_msg = match cmd_loc, err_loc with
+    | None, _ -> assert false
+    | _, None -> assert false
+    (* in case there is no error position, we use the command position. *)
     | _, Some None -> cmd_loc, err_msg, err_msg
     | Some l, Some Some l' ->
         if l.fname = l'.fname then
@@ -156,8 +159,6 @@ let process_cmd _file (nodes,st,dg,logs) cmd =
           cmd_loc,
           Pos.popt_to_string (Some l') ^ "\n" ^ err_msg,
           Pos.popt_to_string (Some l') ^ "\n" ^ err_msg
-    | None, _ -> assert false
-    | _, None -> assert false
     in
     nodes, st, (loc, 1, diag_msg, None) :: dg, ((1, log_msg), loc) :: logs
 
@@ -219,7 +220,7 @@ let check_text ~doc =
   let logs, diags =
     match error with
     | None -> logs, diags
-    | Some(pos,msg) ->
+    | Some(error_pos,error_msg) ->
       let log_msg =
         let form = Format.formatter_of_buffer lp_logger in
         Color.update_with_color form;
@@ -227,11 +228,12 @@ let check_text ~doc =
         (Pos.popt_to_string
           ~print_dirname:false
           ~print_fname:false
-          (Some pos)) msg;
+          (Some error_pos)) error_msg;
         Format.pp_print_flush form ();
         buf_get_and_clear lp_logger
       in
-      logs @ [((1, log_msg),Some pos)], diags @ [pos,1,msg,None]
+      logs @ [((1, log_msg),Some error_pos)],
+      diags @ [error_pos,1,error_msg,None]
   in
   let map = Pure.rangemap cmds in
   let doc = { doc with nodes; final=Some(final); map; logs } in

--- a/src/pure/pure.ml
+++ b/src/pure/pure.ml
@@ -124,6 +124,10 @@ let current_goals : proof_state -> Goal.info list =
   Print.sig_state := st;
   List.map Goal.to_info ps.proof_goals
 
+(** As  explained  in [src/common/error.ml], optional optional source position
+    is used with [Cmd_Error] to distinguish errors that  are  independent from
+    source code position from those where posiotion is expected but is missing
+    *)
 type command_result =
   | Cmd_OK    of state * string option
   | Cmd_Proof of proof_state * ProofTree.t * Pos.popt * Pos.popt


### PR DESCRIPTION
## Summary
This PR fixes :
-1 The location is displayed in the LP console when a syntax error occurs (issue #1456)
-2 Errors are displayed in Red color and location is put between bracket (issue #1405)
-3 When an LP file requires another file and the error originates in the required file, the location of the `require open` command is used so that when the "requiring" file is executed the error is displayed in the terminal when the user reaches the require command (issue    #1498)

## Changes
- keep the precise  from the originating error when an error is reported from a required module
- prefer the real error location when it points to a different file than the current command
- add a space separator between the file location and the message in the console output
- ensure logs include the position in a readable format for debugging and traceability
