### PR TITLE
new apply tactic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Tactic `all_hyps t` calls parameterized tactic term t on all hypotheses ignoring failing calls.
 - Extend `print` query to the following arguments: `verbose`, `debug`, `flag`, `builtin`, `prover`, `prover_timeout`.
 - add a version number to the header of the index db file to prevent crash of LP when the structure of db changes.
-
+- tactic `#abstract e P t` abstracts e from P and calls tactic `t` with the abstraction as parameter
 ### Changed
 
 - Tactic `simplify` now fails if the goal cannot be simplified.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Extend `print` query to the following arguments: `verbose`, `debug`, `flag`, `builtin`, `prover`, `prover_timeout`.
 - add a version number to the header of the index db file to prevent crash of LP when the structure of db changes.
 - tactic `#abstract e P t` abstracts e from P and calls tactic `t` with the abstraction as parameter
+
 ### Changed
 
 - Tactic `simplify` now fails if the goal cannot be simplified.

--- a/doc/tacticals.rst
+++ b/doc/tacticals.rst
@@ -25,9 +25,8 @@ The BNF grammar of tactics is in `lambdapi.bnf <https://raw.githubusercontent.co
    builtin "Type" ≔ … // : Π [l:L], U l → TYPE, written η below
    builtin "Tactic" ≔ …; // : TYPE, written T below
    builtin "admit" ≔ …; // : T
-   builtin "abstract" ≔ … // : Π [l:L] [a:U l] (e: η a) (P:Prop), 
-                   (Π (Q:η a → Prop), (π P → π (Q e)) → Tactic) → Tactic;
-
+   builtin "abstract" ≔ … // : Π [l l':L] [a:U l] (e: η a) (P:U l'), 
+                   (Π Q:η a → U l', (η P → η (Q e)) → Tactic) → Tactic;
    builtin "all_hyps" ≔ …; // : (Π [l] [a:U l], η a → T) → T
    builtin "apply" ≔ …; // : Π [l] [a:U l], η a → T
    builtin "assume" ≔ …; // : String → Π [l] [a:U l], (η a → T) → T

--- a/doc/tacticals.rst
+++ b/doc/tacticals.rst
@@ -25,6 +25,9 @@ The BNF grammar of tactics is in `lambdapi.bnf <https://raw.githubusercontent.co
    builtin "Type" ≔ … // : Π [l:L], U l → TYPE, written η below
    builtin "Tactic" ≔ …; // : TYPE, written T below
    builtin "admit" ≔ …; // : T
+   builtin "abstract" ≔ … // : Π [l:L] [a:U l] (e: η a) (P:Prop), 
+                   (Π (Q:η a → Prop), (π P → π (Q e)) → Tactic) → Tactic;
+
    builtin "all_hyps" ≔ …; // : (Π [l] [a:U l], η a → T) → T
    builtin "apply" ≔ …; // : Π [l] [a:U l], η a → T
    builtin "assume" ≔ …; // : String → Π [l] [a:U l], (η a → T) → T

--- a/src/core/builtin.ml
+++ b/src/core/builtin.ml
@@ -215,6 +215,20 @@ let _ =
             arr (arr (eps (var l) (var a)) tac) tac))
   in
   register_typ "admit" tac;
+  (*
+    Π [l:L] [a:U l] (e: η a) (P:Prop),
+    (Π (Q:η a → Prop), π (P ⇒ Q e) → Tactic) → Tactic;
+   *)
+  register_typ "abstract"
+    (prod lvl (fun l ->
+         prod (univ (var l)) (fun a ->
+             prod (eps (var l) (var a)) (fun e ->
+                 prod prop (fun p ->
+                     arr (prod (arr (eps (var l) (var a)) prop)
+                            (fun q -> arr (arr (app prf (var p))
+                                             (app prf (app (var q) (var e))))
+                                        tac))
+                       tac)))));
   register_typ "all_hyps" (arr t1 tac);
   register_typ "apply" t1;
   register_typ "assume" (arr str t2);

--- a/src/core/builtin.ml
+++ b/src/core/builtin.ml
@@ -216,19 +216,21 @@ let _ =
   in
   register_typ "admit" tac;
   (*
-    Π [l:L] [a:U l] (e: η a) (P:Prop),
-    (Π (Q:η a → Prop), π (P ⇒ Q e) → Tactic) → Tactic;
+    Π [l l':L] [a:U l] (e: η a) (P: U l'),
+    (Π Q:η a → U l', (η P -> η (Q e)) → Tactic) → Tactic;
    *)
   register_typ "abstract"
     (prod lvl (fun l ->
+      prod lvl (fun l' ->
          prod (univ (var l)) (fun a ->
              prod (eps (var l) (var a)) (fun e ->
-                 prod prop (fun p ->
-                     arr (prod (arr (eps (var l) (var a)) prop)
-                            (fun q -> arr (arr (app prf (var p))
-                                             (app prf (app (var q) (var e))))
-                                        tac))
-                       tac)))));
+                 prod (univ (var l')) (fun p ->
+                     arr (prod (arr (eps (var l) (var a)) (univ (var l')))
+                           (fun q -> arr (arr (eps (var l') (var p))
+                                              (eps (var l')
+                                                   (app (var q) (var e))))
+                                         tac))
+                       tac))))));
   register_typ "all_hyps" (arr t1 tac);
   register_typ "apply" t1;
   register_typ "assume" (arr str t2);

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -199,6 +199,7 @@ let get_prod_ids env =
 
 (** Builtin tactic names. *)
 type tactic =
+  | T_abstract
   | T_admit
   | T_all_hyps
   | T_apply
@@ -236,6 +237,7 @@ let get_config (ss:Sig_state.t) (pos:Pos.popt) : config =
     let s = Builtin.get ss pos [] n in
     Hashtbl.add t s.sym_name v
   in
+  add "abstract" T_abstract;
   add "admit" T_admit;
   add "all_hyps" T_all_hyps;
   add "apply" T_apply;
@@ -399,6 +401,30 @@ let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
             (*FIXME: compute config only once in a proof*)
             let c = get_config ss pos in
             match Hashtbl.find c s.sym_name, ts with
+            | T_abstract, [_; _; e; t; Abst (u, bi)] -> begin
+               match Eval.whnf ctx u with
+                 Prod(tte,_) -> begin
+                   let p = Rewrite.bind_pattern e t in
+                   let bi = subst bi (mk_Abst (tte,p)) in
+                   let ctx = Env.to_ctxt env in
+                   let bi = match Eval.whnf ctx bi with
+                       Abst (ty, bi) ->
+                         begin match Eval.whnf ctx ty with
+                           Prod(te, _) ->
+                             let v = new_var "x" in
+                             subst bi (mk_Abst (te, bind_var v (mk_Vari v)))
+                         | _ ->
+                             fatal pos "ABSTRACT fails on type: %a\n" term ty
+                         end
+                     | bi ->
+                         fatal pos "ABSTRACT fails on term: %a\n" term bi
+                   in
+                   if Logger.log_enabled() then log "ABSTRACT %a\n" term bi;
+                   ps, mk(P_tac_eval(p_term bi))
+                 end
+               | _ -> assert false
+              end
+            | T_abstract, _ -> assert false
             | T_admit, _ -> ps, mk P_tac_admit
             | T_all_hyps, [t] -> ps, mk(P_tac_all_hyps(p_term t))
             | T_all_hyps, _ -> assert false
@@ -571,6 +597,7 @@ let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
             let ids = Ctxt.names c in let term = term_in ids in
             fatal pos "(%a) is not typable." term t
         | Some (_, a) -> LibTerm.count_products Eval.whnf c a
+                         - LibTerm.count_products Eval.whnf c gt.goal_type
       in
       let t = scope (P.appl_wild pt n) in
       tac_refine pos ps gt gs (new_problem()) t

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -597,7 +597,6 @@ let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
             let ids = Ctxt.names c in let term = term_in ids in
             fatal pos "(%a) is not typable." term t
         | Some (_, a) -> LibTerm.count_products Eval.whnf c a
-                         - LibTerm.count_products Eval.whnf c gt.goal_type
       in
       let t = scope (P.appl_wild pt n) in
       tac_refine pos ps gt gs (new_problem()) t

--- a/src/handle/tactic.ml
+++ b/src/handle/tactic.ml
@@ -401,16 +401,16 @@ let handle (ss:Sig_state.t) (sym_pos:popt) (priv:bool)
             (*FIXME: compute config only once in a proof*)
             let c = get_config ss pos in
             match Hashtbl.find c s.sym_name, ts with
-            | T_abstract, [_; _; e; t; Abst (u, bi)] -> begin
+            | T_abstract, [_; _; _; e; t; Abst (u, bi)] -> begin
                match Eval.whnf ctx u with
                  Prod(tte,_) -> begin
                    let p = Rewrite.bind_pattern e t in
                    let bi = subst bi (mk_Abst (tte,p)) in
                    let ctx = Env.to_ctxt env in
                    let bi = match Eval.whnf ctx bi with
-                       Abst (ty, bi) ->
+                     | Abst (ty, bi) ->
                          begin match Eval.whnf ctx ty with
-                           Prod(te, _) ->
+                         | Prod(te, _) ->
                              let v = new_var "x" in
                              subst bi (mk_Abst (te, bind_var v (mk_Vari v)))
                          | _ ->

--- a/tests/OK/Tactic.lp
+++ b/tests/OK/Tactic.lp
@@ -7,6 +7,10 @@ require open tests.OK.String tests.OK.Univ;
 constant symbol Tactic : TYPE;
 builtin "Tactic" ≔ Tactic;
 
+symbol #abstract : Π [l:L] [a:U l] (e: η a) (P:Prop), 
+                   (Π (Q:η a → Prop), (π P → π (Q e)) → Tactic) → Tactic;
+builtin "abstract" ≔ #abstract;
+
 constant symbol #admit : Tactic;
 builtin "admit" ≔ #admit;
 

--- a/tests/OK/Tactic.lp
+++ b/tests/OK/Tactic.lp
@@ -7,8 +7,8 @@ require open tests.OK.String tests.OK.Univ;
 constant symbol Tactic : TYPE;
 builtin "Tactic" ≔ Tactic;
 
-symbol #abstract : Π [l:L] [a:U l] (e: η a) (P:Prop), 
-                   (Π (Q:η a → Prop), (π P → π (Q e)) → Tactic) → Tactic;
+symbol #abstract : Π [l l':L] [a:U l] (e: η a) (P:U l'),
+                   (Π Q:η a → U l', (η P → η (Q e)) → Tactic) → Tactic;
 builtin "abstract" ≔ #abstract;
 
 constant symbol #admit : Tactic;

--- a/tests/OK/abstract.lp
+++ b/tests/OK/abstract.lp
@@ -1,0 +1,15 @@
+require open tests.OK.Set tests.OK.Prop tests.OK.Eq;
+require open tests.OK.String tests.OK.Tactic;
+
+constant symbol T:Set;
+constant symbol f: τ T → τ T;
+
+symbol test (a b: τ T) (h: π (a = b)): π (f a = f b) ≔
+begin
+  assume a b h;
+  // f a = f b is seen as p a where p x = (f x = f b)
+  eval (#abstract a (f a = f b) (λ p _, #apply (ind_eq [T] [a] [b] h p)));
+  reflexivity
+end;
+
+

--- a/tests/export_dk.sh
+++ b/tests/export_dk.sh
@@ -45,7 +45,7 @@ do
         # use builtin strings
         Tactic);;
         # requires Tactic
-        1374|assume|first_hyp|all_hyps|1493);;
+        1374|assume|first_hyp|all_hyps|abstract|1493);;
         # default case
         *) translate $f.lp;;
     esac

--- a/tests/export_raw_dk.sh
+++ b/tests/export_raw_dk.sh
@@ -57,7 +57,7 @@ do
         # module alias
         alias);;
         # proofs
-        why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit|change|assumption|focus|assume|first_hyp|all_hyps|1435_part2|1435);;
+        why3*|tutorial|try|tautologies|rewrite*|remove|natproofs|have|generalize|foo|comment_in_qid|apply|anonymous|admit|change|assumption|focus|assume|first_hyp|all_hyps|abstract|1435_part2|1435);;
         # "open"
         triangular|power-fact|postfix|perf_rw_*|not-eager|nonLeftLinear2|natural|Nat|lpparse2|logic|List|FOL|Eq|doc|Bool|arity_var|arity_diff|922|262_pair_ex_2|215|1141|Tactic|1374|Option|String|HOL|Impred|PropExt|Classic|Comp|Pos|Z|1217|1151|B1|B2|C1|C2|C3|Epsilon|1313|FunExt|Prod|Conj|Disj|ExtraRules|Univ|1493);;
         # "inductive"


### PR DESCRIPTION
This PR introduces the new tactic `#napply` inside `eval`. It takes as first parameter a string containing the number of arguments to  add. `#apply` is now defined as `#napply ""`.
`Tactic.lp` now contains the following declarations:

```
constant symbol #napply: String → Π [l] [a:U l], η a → Tactic;
builtin "apply" ≔ #napply;
symbol #apply [l] [a:U l]: η a → Tactic ≔ @#napply "" l a;
```
The `apply` tactic remains unchanged.

lambdapi-stdlib should be updated accordingly.

